### PR TITLE
Release 1.0.2

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */; };
 		05FAED3D483F3C16AEFFB7A5 /* TranscriptSectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */; };
+		0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */; };
 		0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
@@ -41,6 +43,7 @@
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
+		821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */; };
 		8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */; };
 		88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */; };
 		8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67770387C5BA986EEB40382E /* SessionLibraryTests.swift */; };
@@ -117,6 +120,8 @@
 		820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabelView.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
+		9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
 		9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsService.swift; sourceTree = "<group>"; };
 		9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStore.swift; sourceTree = "<group>"; };
 		A663ED1B160E290FCFAC3AED /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
@@ -136,6 +141,7 @@
 		DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProviderTests.swift; sourceTree = "<group>"; };
 		DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorApp.swift; sourceTree = "<group>"; };
 		E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
+		EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
 		F03E1852A3D56F888E98739E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClientTests.swift; sourceTree = "<group>"; };
 		F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProvider.swift; sourceTree = "<group>"; };
@@ -161,7 +167,9 @@
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
 				33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */,
 				DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */,
+				EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
+				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
 				67770387C5BA986EEB40382E /* SessionLibraryTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
@@ -260,6 +268,7 @@
 				C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */,
 				33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */,
 				4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */,
+				9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */,
 				CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */,
 			);
 			path = Utilities;
@@ -387,7 +396,9 @@
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
 				F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */,
 				57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */,
+				0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
+				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
 				8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
@@ -426,6 +437,7 @@
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
 				E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */,
+				821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */,
 				4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */,
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
@@ -467,7 +479,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -476,7 +488,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -489,7 +501,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -498,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+## 1.0.2 - 2026-03-14
+
+- Migrated screenshot capture from the deprecated CoreGraphics screenshot path to ScreenCaptureKit on macOS 14+, while preserving session associations, marker proximity, and screenshot-specific permission recovery.
+- Added direct recovery guidance and an `Open Microphone Settings` action when microphone permission is denied.
+- Updated the menu bar status card to wrap longer error text and expand for recovery messaging instead of truncating it.
+- Hardened post-transcription persistence so a completed transcript stays open as an unsaved session if local history storage fails after transcription.
+- Updated the session library to prefer the latest in-memory session snapshot when persistence falls behind, preventing stale issue edits and summaries from disappearing out of the detail view.
+- Prevented GitHub and Jira exports from running against deleted or stale sessions and added date-bucket regression coverage around midnight in local timezones.
+- Hardened the DMG packaging script to verify branded icon resources, DMG contents, and public-release validation steps before publishing.
+- Added regression coverage for deferred interactive secret loading and the menu bar status presentation rules behind the permission and error fixes.
+
 ## 1.0.1 - 2026-03-14
 
 - Fixed the app icon pipeline so BugNarrator ships with branded app icon assets instead of a generic fallback.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -22,6 +22,7 @@
 
 - BugNarrator does not include a built-in OpenAI API key.
 - OpenAI transcription and issue extraction use your own OpenAI account and may cost money.
-- The app asks for microphone permission on first record.
-- Screenshot capture may ask for Screen Recording permission on first use.
+- The app asks for microphone permission only when you start recording. If you deny it, BugNarrator gives you an `Open Microphone Settings` recovery button.
+- Screenshot capture may ask for Screen Recording permission on first use. If you deny it, recording can still continue without screenshots.
+- If OpenAI rejects your key, BugNarrator sends you back to `Settings` so you can replace it.
 - To build or package the app from source, see [docs/Distribution.md](docs/Distribution.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 BugNarrator is a macOS menu bar tool for narrated software testing sessions that automatically captures transcripts, markers, screenshots, and extracted issues.
 
-## Download
+## Download BugNarrator
 
 - [Download the latest macOS DMG](https://github.com/deffenda/bugnarrator/releases/latest/download/BugNarrator-macOS.dmg)
 - [View the latest release page](https://github.com/deffenda/bugnarrator/releases/latest)
@@ -17,6 +17,13 @@ If the direct DMG link is not live yet, use the release page and download the ne
 BugNarrator is free to use. If it helps your workflow, consider supporting development.
 
 - [Support BugNarrator on PayPal](https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8)
+
+## Help And Project Links
+
+- [Read the user guide](docs/UserGuide.md)
+- [Hosted documentation](https://github.com/deffenda/bugnarrator/blob/main/docs/UserGuide.md)
+- [Report a bug or request a feature](https://github.com/deffenda/bugnarrator/issues/new)
+- [View the changelog](CHANGELOG.md)
 
 ## What BugNarrator Does
 
@@ -54,9 +61,10 @@ Important:
 2. Open the DMG.
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
-5. If Gatekeeper warns about the app, use Finder and choose `Open` for the app you trust.
+5. If Gatekeeper warns about the app, open `Applications`, Control-click `BugNarrator.app`, choose `Open`, then confirm once.
 6. On first run, expect microphone permission and OpenAI API key setup.
 7. If you use screenshot capture, expect Screen Recording permission on first use.
+8. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
 
 ## Quick Start
 
@@ -83,7 +91,7 @@ Markers let you flag important moments during a session. Each marker stores a ti
 
 ### Screenshot Capture
 
-Screenshots are captured only when you request them. Each screenshot is attached to the current session and can appear alongside markers and extracted issues.
+Screenshots are captured only when you request them. On macOS 14 and later, BugNarrator uses ScreenCaptureKit to capture the current desktop layout and attach the saved image to the active session. Each screenshot is attached to the current session and can appear alongside markers and extracted issues.
 
 ### Review Summary
 
@@ -133,11 +141,11 @@ Configure your Jira Cloud URL, email, API token, project key, and issue type in 
 
 ### Microphone
 
-BugNarrator requests microphone permission the first time you start a recording.
+BugNarrator requests microphone permission the first time you start a recording. If access is denied, recording is blocked until you re-enable BugNarrator in `System Settings > Privacy & Security > Microphone`. The menu bar window includes an `Open Microphone Settings` recovery button.
 
 ### Screen Recording
 
-Screenshot capture may prompt for Screen Recording permission on first use.
+Screenshot capture may prompt for Screen Recording permission on first use. That permission is only needed for screenshots. If access is denied, the current recording can still continue without screenshots, and the menu bar window includes an `Open Screen Recording Settings` recovery button.
 
 ### Accessibility
 
@@ -169,6 +177,7 @@ BugNarrator does not continuously upload audio while you are still recording.
 - [Report a bug or request a feature](https://github.com/deffenda/bugnarrator/issues/new)
 - [Support development](https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8)
 - [Changelog](CHANGELOG.md)
+- [Post-1.0.0 bug log](docs/PostV1BugLog.md)
 
 ## Build From Source
 
@@ -196,8 +205,12 @@ The script builds a Release app, creates a DMG with `BugNarrator.app` plus an `A
 
 Full packaging details live in [docs/Distribution.md](docs/Distribution.md).
 
-For public distribution, prefer a signed and notarized build. The packaging script supports signed local builds when you provide your Apple team in the environment.
-For a true public macOS release, use a `Developer ID Application` certificate plus notarization so Gatekeeper accepts the download on other Macs.
+For public distribution, use a `Developer ID Application` certificate plus notarization so Gatekeeper accepts the download on other Macs. The packaging script supports:
+
+- unsigned local packaging for development
+- signed Release builds
+- notarization and stapling
+- validation that the DMG contains `BugNarrator.app`, an `Applications` shortcut, and the expected branded icon resources
 
 ## Documentation
 
@@ -207,6 +220,7 @@ For a true public macOS release, use a `Developer ID Application` certificate pl
 - [docs/QA_CHECKLIST.md](docs/QA_CHECKLIST.md)
 - [docs/TESTING_NOTES.md](docs/TESTING_NOTES.md)
 - [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md)
+- [docs/PostV1BugLog.md](docs/PostV1BugLog.md)
 - [SECURITY.md](SECURITY.md)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 
@@ -214,7 +228,7 @@ For a true public macOS release, use a `Developer ID Application` certificate pl
 
 - transcription and issue extraction require network access
 - BugNarrator does not yet support offline Whisper
-- screenshot capture still uses a deprecated CoreGraphics API and should move to ScreenCaptureKit
+- if you remove or invalidate the OpenAI API key while a recording is already in progress, BugNarrator cannot yet hold that finished audio for a later retry
 - GitHub and Jira export include screenshot references in issue bodies instead of uploading attachments automatically
 - session deletion is permanent today
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,15 @@
 
 BugNarrator is distributed as a local macOS app. Release builds and DMGs should be signed and notarized before public distribution whenever practical.
 
+## Permissions
+
+BugNarrator requests permission only when the related feature is used.
+
+- microphone access is requested when you start recording
+- Screen Recording access is requested when you capture a screenshot
+
+BugNarrator does not require Accessibility permission for its core workflow.
+
 ## Credentials
 
 BugNarrator uses a bring-your-own-credentials model.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,6 +5,7 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published private(set) var status: AppStatus = .idle()
+    @Published private(set) var currentError: AppError?
     @Published private(set) var elapsedDuration: TimeInterval = 0
     @Published var showDiscardConfirmation = false
     @Published var currentTranscript: TranscriptSession?
@@ -122,12 +123,12 @@ final class AppState: ObservableObject {
 
     var displayedTranscript: TranscriptSession? {
         if let selectedTranscriptID {
-            if let storedSession = transcriptStore.session(with: selectedTranscriptID) {
-                return storedSession
-            }
-
             if currentTranscript?.id == selectedTranscriptID {
                 return currentTranscript
+            }
+
+            if let storedSession = transcriptStore.session(with: selectedTranscriptID) {
+                return storedSession
             }
         }
 
@@ -143,7 +144,7 @@ final class AppState: ObservableObject {
             return false
         }
 
-        return transcriptStore.session(with: currentTranscript.id) != nil
+        return transcriptStore.session(with: currentTranscript.id) == currentTranscript
     }
 
     var needsAPIKeySetup: Bool {
@@ -161,6 +162,7 @@ final class AppState: ObservableObject {
     func canExportIssues(from session: TranscriptSession, to destination: ExportDestination) -> Bool {
         guard status.phase != .recording,
               status.phase != .transcribing,
+              let session = sessionSnapshot(with: session.id),
               let extraction = session.issueExtraction,
               !extraction.selectedIssues.isEmpty else {
             return false
@@ -208,7 +210,7 @@ final class AppState: ObservableObject {
                     sessionID: sessionID,
                     artifactsDirectoryURL: artifactsDirectoryURL
                 )
-                status = .recording("Recording in progress.")
+                setStatus(.recording("Recording in progress."))
                 beginActivity(reason: "Recording a spoken feedback session")
                 startTimer()
             } catch {
@@ -247,7 +249,7 @@ final class AppState: ObservableObject {
                 throw AppError.missingAPIKey
             }
 
-            status = .transcribing("Uploading audio to OpenAI and waiting for transcription...")
+            setStatus(.transcribing("Uploading audio to OpenAI and waiting for transcription..."))
             swapActivity(reason: "Uploading audio for transcription")
 
             let request = TranscriptionRequest(
@@ -283,14 +285,30 @@ final class AppState: ObservableObject {
                 artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
             )
 
+            do {
+                try persistCompletedTranscript(session)
+            } catch {
+                currentTranscript = session
+                selectedTranscriptID = session.id
+                activeRecordingSession = nil
+                if settingsStore.autoCopyTranscript {
+                    clipboardService.copy(session.transcript)
+                }
+                cleanupPendingRecordedAudioIfNeeded()
+                endActivity()
+                let appError = (error as? AppError) ?? .storageFailure(error.localizedDescription)
+                setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+                showTranscriptWindow?()
+                return
+            }
+
             currentTranscript = session
             activeRecordingSession = nil
-            try persistCompletedTranscript(session)
             showTranscriptWindow?()
 
             if settingsStore.autoExtractIssues {
                 issueExtractionSessionID = session.id
-                status = .transcribing("Extracting reviewable issues...")
+                setStatus(.transcribing("Extracting reviewable issues..."))
                 swapActivity(reason: "Extracting review issues")
 
                 do {
@@ -314,13 +332,13 @@ final class AppState: ObservableObject {
 
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
-            status = .success(
+            setStatus(.success(
                 settingsStore.autoExtractIssues
                     ? "Transcript and extracted issues are ready."
                     : (settingsStore.autoCopyTranscript
                         ? "Transcript copied to the clipboard."
                         : "Transcript ready.")
-            )
+            ))
         } catch {
             if !settingsStore.debugMode {
                 artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
@@ -355,7 +373,7 @@ final class AppState: ObservableObject {
             self.activeRecordingSession = nil
         }
         pendingRecordedAudio = nil
-        status = .idle("Session discarded.")
+        setStatus(.idle("Session discarded."))
     }
 
     func openTranscriptHistory() {
@@ -393,6 +411,34 @@ final class AppState: ObservableObject {
 
     func openSupportDonationPage() {
         openExternalURL(BugNarratorLinks.supportDevelopment, label: "PayPal donation page")
+    }
+
+    func openMicrophonePrivacySettings() {
+        let candidateURLs = [
+            BugNarratorLinks.microphonePrivacySettings,
+            BugNarratorLinks.securityPrivacySettings,
+            BugNarratorLinks.systemSettingsApp
+        ]
+
+        for url in candidateURLs where urlHandler.open(url) {
+            return
+        }
+
+        presentUtilityActionFailure("BugNarrator could not open Microphone settings automatically.")
+    }
+
+    func openScreenRecordingPrivacySettings() {
+        let candidateURLs = [
+            BugNarratorLinks.screenRecordingPrivacySettings,
+            BugNarratorLinks.securityPrivacySettings,
+            BugNarratorLinks.systemSettingsApp
+        ]
+
+        for url in candidateURLs where urlHandler.open(url) {
+            return
+        }
+
+        presentUtilityActionFailure("BugNarrator could not open Screen Recording settings automatically.")
     }
 
     func checkForUpdates() {
@@ -436,7 +482,7 @@ final class AppState: ObservableObject {
         }
 
         clipboardService.copy(transcript.transcript)
-        status = .success("Transcript copied to the clipboard.")
+        setStatus(.success("Transcript copied to the clipboard."))
     }
 
     func saveCurrentTranscriptToHistory() {
@@ -448,7 +494,7 @@ final class AppState: ObservableObject {
         do {
             try transcriptStore.add(currentTranscript)
             selectedTranscriptID = currentTranscript.id
-            status = .success("Transcript saved to session history.")
+            setStatus(.success("Transcript saved to session history."))
         } catch {
             presentError(error)
         }
@@ -493,7 +539,7 @@ final class AppState: ObservableObject {
 
             let deletedCount = removedSessions.count + (deletingUnsavedCurrentTranscript ? 1 : 0)
             if deletedCount > 0 {
-                status = .success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions.")
+                setStatus(.success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions."))
             }
         } catch {
             presentError(error)
@@ -506,7 +552,14 @@ final class AppState: ObservableObject {
         captureScreenshot: Bool = false
     ) async {
         guard status.phase == .recording, var recordingSession = activeRecordingSession else {
-            status = .error(AppError.noActiveSession("Start a feedback session before inserting a marker.").userMessage)
+            let error = AppError.noActiveSession("Start a feedback session before inserting a marker.")
+            setStatus(.error(error.userMessage), error: error)
+            return
+        }
+
+        if isCapturingScreenshot {
+            let error = AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+            setStatus(.recording(error.userMessage), error: error)
             return
         }
 
@@ -517,19 +570,32 @@ final class AppState: ObservableObject {
 
         var screenshot: SessionScreenshot?
         var statusMessage = "Inserted \(markerTitle)."
+        var warningError: AppError?
 
         if captureScreenshot {
             do {
-                screenshot = try performScreenshotCapture(
-                    into: &recordingSession,
+                screenshot = try await performScreenshotCapture(
+                    in: recordingSession,
                     prefix: "marker",
                     index: recordingSession.screenshots.count + 1,
                     elapsedTime: elapsedTime,
                     associatedMarkerID: markerID
                 )
+                guard status.phase == .recording,
+                      var latestRecordingSession = activeRecordingSession,
+                      latestRecordingSession.sessionID == recordingSession.sessionID else {
+                    return
+                }
+                latestRecordingSession.screenshots.append(screenshot!)
+                recordingSession = latestRecordingSession
                 statusMessage = "Inserted \(markerTitle) with a screenshot."
             } catch {
+                let appError = (error as? AppError) ?? .screenshotCaptureFailure(error.localizedDescription)
+                guard status.phase == .recording else {
+                    return
+                }
                 statusMessage = "\(markerTitle) was inserted, but the screenshot failed."
+                warningError = appError
             }
         }
 
@@ -545,40 +611,48 @@ final class AppState: ObservableObject {
         )
 
         activeRecordingSession = recordingSession
-        status = .recording(statusMessage)
+        setStatus(.recording(statusMessage), error: warningError)
     }
 
     func captureScreenshot() async {
-        guard status.phase == .recording, var recordingSession = activeRecordingSession else {
-            status = .error(AppError.noActiveSession("Start a feedback session before capturing a screenshot.").userMessage)
+        guard status.phase == .recording, let recordingSession = activeRecordingSession else {
+            let error = AppError.noActiveSession("Start a feedback session before capturing a screenshot.")
+            setStatus(.error(error.userMessage), error: error)
             return
         }
 
-        guard !isCapturingScreenshot else {
+        if isCapturingScreenshot {
+            let error = AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+            setStatus(.recording(error.userMessage), error: error)
             return
         }
-
-        isCapturingScreenshot = true
-        defer { isCapturingScreenshot = false }
 
         let screenshotIndex = recordingSession.screenshots.count + 1
         let elapsedTime = max(audioRecorder.currentDuration, elapsedDuration)
         let associatedMarkerID = nearestMarkerID(in: recordingSession, to: elapsedTime)
 
         do {
-            _ = try performScreenshotCapture(
-                into: &recordingSession,
+            let screenshot = try await performScreenshotCapture(
+                in: recordingSession,
                 prefix: "capture",
                 index: screenshotIndex,
                 elapsedTime: elapsedTime,
                 associatedMarkerID: associatedMarkerID
             )
-            activeRecordingSession = recordingSession
-            status = .recording("Captured Screenshot \(screenshotIndex).")
+            guard status.phase == .recording,
+                  var latestRecordingSession = activeRecordingSession,
+                  latestRecordingSession.sessionID == recordingSession.sessionID else {
+                return
+            }
+            latestRecordingSession.screenshots.append(screenshot)
+            activeRecordingSession = latestRecordingSession
+            setStatus(.recording("Captured Screenshot \(screenshotIndex)."))
         } catch {
-            activeRecordingSession = recordingSession
             let appError = (error as? AppError) ?? .screenshotCaptureFailure(error.localizedDescription)
-            status = .recording(appError.userMessage)
+            guard status.phase == .recording else {
+                return
+            }
+            setStatus(.recording(appError.userMessage), error: appError)
         }
     }
 
@@ -591,7 +665,7 @@ final class AppState: ObservableObject {
 
         guard let preflightError = preflightForIssueExtraction(transcriptSession) else {
             issueExtractionSessionID = transcriptSession.id
-            status = .transcribing("Extracting reviewable issues...")
+            setStatus(.transcribing("Extracting reviewable issues..."))
             beginActivity(reason: "Extracting review issues")
 
             do {
@@ -607,7 +681,7 @@ final class AppState: ObservableObject {
 
                 issueExtractionSessionID = nil
                 endActivity()
-                status = .success("Extracted \(extraction.issues.count) review issues.")
+                setStatus(.success("Extracted \(extraction.issues.count) review issues."))
                 showTranscriptWindow?()
             } catch {
                 issueExtractionSessionID = nil
@@ -675,7 +749,17 @@ final class AppState: ObservableObject {
     }
 
     func exportSelectedIssues(from session: TranscriptSession, to destination: ExportDestination) async {
-        guard let extraction = session.issueExtraction else {
+        guard status.phase != .recording, status.phase != .transcribing else {
+            presentError(AppError.exportFailure("Finish the current background work before exporting issues."))
+            return
+        }
+
+        guard let currentSession = sessionSnapshot(with: session.id) else {
+            presentError(AppError.exportFailure("This session is no longer available in the library."))
+            return
+        }
+
+        guard let extraction = currentSession.issueExtraction else {
             presentError(AppError.exportFailure("Run issue extraction before exporting."))
             return
         }
@@ -699,7 +783,7 @@ final class AppState: ObservableObject {
         }
 
         exportDestinationInProgress = destination
-        status = .transcribing("Exporting \(selectedIssues.count) issues to \(destination.rawValue)...")
+        setStatus(.transcribing("Exporting \(selectedIssues.count) issues to \(destination.rawValue)..."))
         beginActivity(reason: "Exporting extracted issues")
 
         do {
@@ -714,7 +798,7 @@ final class AppState: ObservableObject {
                 }
                 results = try await exportService.exportToGitHub(
                     issues: selectedIssues,
-                    session: session,
+                    session: currentSession,
                     configuration: configuration
                 )
             case .jira:
@@ -725,14 +809,14 @@ final class AppState: ObservableObject {
                 }
                 results = try await exportService.exportToJira(
                     issues: selectedIssues,
-                    session: session,
+                    session: currentSession,
                     configuration: configuration
                 )
             }
 
             exportDestinationInProgress = nil
             endActivity()
-            status = .success("Exported \(results.count) issues to \(destination.rawValue).")
+            setStatus(.success("Exported \(results.count) issues to \(destination.rawValue)."))
         } catch {
             exportDestinationInProgress = nil
             presentError(error)
@@ -784,11 +868,11 @@ final class AppState: ObservableObject {
     private func presentUtilityActionFailure(_ message: String) {
         switch status.phase {
         case .recording:
-            status = .recording("\(message) Recording is still active.")
+            setStatus(.recording("\(message) Recording is still active."))
         case .transcribing:
-            status = .transcribing("\(message) Background work is still in progress.")
+            setStatus(.transcribing("\(message) Background work is still in progress."))
         case .idle, .success, .error:
-            status = .error(message)
+            setStatus(.error(message))
         }
     }
 
@@ -833,6 +917,11 @@ final class AppState: ObservableObject {
         processActivity = nil
     }
 
+    private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {
+        status = newStatus
+        currentError = error
+    }
+
     private func presentError(_ error: Error) {
         stopTimer(resetElapsed: status.phase == .recording)
         endActivity()
@@ -841,7 +930,7 @@ final class AppState: ObservableObject {
         exportDestinationInProgress = nil
 
         let appError = (error as? AppError) ?? .transcriptionFailure(error.localizedDescription)
-        status = .error(appError.userMessage)
+        setStatus(.error(appError.userMessage), error: appError)
 
         switch appError {
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey, .exportConfigurationMissing:
@@ -853,7 +942,7 @@ final class AppState: ObservableObject {
 
     private func presentPostTranscriptionError(_ error: Error) {
         let appError = (error as? AppError) ?? .issueExtractionFailure(error.localizedDescription)
-        status = .error("Transcript ready, but \(appError.userMessage)")
+        setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
 
         switch appError {
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
@@ -892,9 +981,7 @@ final class AppState: ObservableObject {
         var session = session
         session.updatedAt = Date()
 
-        if currentTranscript?.id == session.id {
-            currentTranscript = session
-        }
+        currentTranscript = session
 
         if transcriptStore.session(with: session.id) != nil {
             try transcriptStore.add(session)
@@ -953,19 +1040,23 @@ final class AppState: ObservableObject {
     }
 
     private func editableSession(with sessionID: UUID) -> TranscriptSession? {
+        sessionSnapshot(with: sessionID)
+    }
+
+    private func preferredTranscriptSelection() -> UUID? {
+        if let currentTranscript, !currentTranscriptIsPersisted {
+            return currentTranscript.id
+        }
+
+        return transcriptStore.sessions.first?.id
+    }
+
+    private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {
         if currentTranscript?.id == sessionID {
             return currentTranscript
         }
 
         return transcriptStore.session(with: sessionID)
-    }
-
-    private func preferredTranscriptSelection() -> UUID? {
-        if let currentTranscript, transcriptStore.session(with: currentTranscript.id) == nil {
-            return currentTranscript.id
-        }
-
-        return transcriptStore.sessions.first?.id
     }
 
     private func cleanupArtifactsForDeletedSession(_ session: TranscriptSession) {
@@ -986,12 +1077,19 @@ final class AppState: ObservableObject {
     }
 
     private func performScreenshotCapture(
-        into recordingSession: inout RecordingSessionDraft,
+        in recordingSession: RecordingSessionDraft,
         prefix: String,
         index: Int,
         elapsedTime: TimeInterval,
         associatedMarkerID: UUID?
-    ) throws -> SessionScreenshot {
+    ) async throws -> SessionScreenshot {
+        guard !isCapturingScreenshot else {
+            throw AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+        }
+
+        isCapturingScreenshot = true
+        defer { isCapturingScreenshot = false }
+
         let screenshotURL = artifactsService.makeScreenshotURL(
             in: recordingSession.artifactsDirectoryURL,
             prefix: prefix,
@@ -999,15 +1097,24 @@ final class AppState: ObservableObject {
             elapsedTime: elapsedTime
         )
 
-        try screenshotCaptureService.captureScreenshot(to: screenshotURL)
+        do {
+            try await screenshotCaptureService.captureScreenshot(to: screenshotURL)
+        } catch {
+            try? FileManager.default.removeItem(at: screenshotURL)
+            throw error
+        }
 
-        let screenshot = SessionScreenshot(
+        guard status.phase == .recording,
+              activeRecordingSession?.sessionID == recordingSession.sessionID else {
+            try? FileManager.default.removeItem(at: screenshotURL)
+            throw AppError.screenshotCaptureFailure("The session ended before the screenshot finished saving.")
+        }
+
+        return SessionScreenshot(
             elapsedTime: elapsedTime,
             filePath: screenshotURL.path,
             associatedMarkerID: associatedMarkerID
         )
-        recordingSession.screenshots.append(screenshot)
-        return screenshot
     }
 
     private func normalizedMarkerTitle(_ title: String?, index: Int) -> String {

--- a/Sources/BugNarrator/Models/AppError.swift
+++ b/Sources/BugNarrator/Models/AppError.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-enum AppError: LocalizedError {
+enum AppError: LocalizedError, Equatable {
     case missingAPIKey
     case invalidAPIKey
     case revokedAPIKey
     case microphonePermissionDenied
+    case screenRecordingPermissionDenied
     case noActiveSession(String)
     case recordingFailure(String)
     case transcriptionFailure(String)
@@ -27,7 +28,9 @@ enum AppError: LocalizedError {
         case .revokedAPIKey:
             return "The OpenAI API key is no longer valid. Open Settings, remove it, and add a new key."
         case .microphonePermissionDenied:
-            return "Microphone permission was denied. Enable it in System Settings and try again."
+            return "Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again."
+        case .screenRecordingPermissionDenied:
+            return "Screenshot capture requires Screen Recording permission. Recording can continue without screenshots. Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again."
         case .noActiveSession(let message):
             return message
         case .recordingFailure(let message):
@@ -57,5 +60,14 @@ enum AppError: LocalizedError {
 
     var errorDescription: String? {
         userMessage
+    }
+
+    var suggestsOpenAISettings: Bool {
+        switch self {
+        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
+++ b/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
@@ -1,40 +1,253 @@
 import CoreGraphics
 import Foundation
 import ImageIO
+@preconcurrency import ScreenCaptureKit
 import UniformTypeIdentifiers
 
+struct ScreenCaptureDisplaySnapshot: Equatable {
+    let displayID: CGDirectDisplayID
+    let frame: CGRect
+    let pixelWidth: Int
+    let pixelHeight: Int
+}
+
+struct CapturedDisplayImage {
+    let display: ScreenCaptureDisplaySnapshot
+    let image: CGImage
+}
+
+protocol ScreenCapturePermissionChecking {
+    @MainActor
+    func preflightAccess() -> Bool
+    @MainActor
+    func requestAccess() -> Bool
+}
+
+struct SystemScreenCapturePermissionChecker: ScreenCapturePermissionChecking {
+    func preflightAccess() -> Bool {
+        CGPreflightScreenCaptureAccess()
+    }
+
+    func requestAccess() -> Bool {
+        CGRequestScreenCaptureAccess()
+    }
+}
+
+protocol ScreenCaptureImageProviding {
+    @MainActor
+    func availableDisplays() async throws -> [ScreenCaptureDisplaySnapshot]
+    @MainActor
+    func captureDisplayImage(for display: ScreenCaptureDisplaySnapshot) async throws -> CapturedDisplayImage
+}
+
+struct ScreenCaptureKitImageProvider: ScreenCaptureImageProviding {
+    func availableDisplays() async throws -> [ScreenCaptureDisplaySnapshot] {
+        let shareableContent: SCShareableContent
+        do {
+            shareableContent = try await SCShareableContent.current
+        } catch {
+            throw Self.mapCaptureError(error)
+        }
+
+        return shareableContent.displays
+            .map { display in
+                ScreenCaptureDisplaySnapshot(
+                    displayID: display.displayID,
+                    frame: display.frame.integral,
+                    pixelWidth: display.width,
+                    pixelHeight: display.height
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.frame.minY == rhs.frame.minY {
+                    return lhs.frame.minX < rhs.frame.minX
+                }
+
+                return lhs.frame.minY < rhs.frame.minY
+            }
+    }
+
+    func captureDisplayImage(for display: ScreenCaptureDisplaySnapshot) async throws -> CapturedDisplayImage {
+        let shareableContent: SCShareableContent
+        do {
+            shareableContent = try await SCShareableContent.current
+        } catch {
+            throw Self.mapCaptureError(error)
+        }
+
+        guard let shareableDisplay = shareableContent.displays.first(where: { $0.displayID == display.displayID }) else {
+            throw AppError.screenshotCaptureFailure("The selected display was no longer available for capture.")
+        }
+
+        let filter = SCContentFilter(display: shareableDisplay, excludingApplications: [], exceptingWindows: [])
+        if #available(macOS 14.2, *) {
+            filter.includeMenuBar = true
+        }
+
+        let configuration = SCStreamConfiguration()
+        configuration.width = size_t(max(1, display.pixelWidth))
+        configuration.height = size_t(max(1, display.pixelHeight))
+
+        let image: CGImage
+        do {
+            image = try await withCheckedThrowingContinuation { continuation in
+                SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration) { image, error in
+                    if let image {
+                        continuation.resume(returning: image)
+                    } else {
+                        continuation.resume(throwing: error ?? AppError.screenshotCaptureFailure("Screen capture failed."))
+                    }
+                }
+            }
+        } catch {
+            throw Self.mapCaptureError(error)
+        }
+
+        return CapturedDisplayImage(display: display, image: image)
+    }
+
+    private static func mapCaptureError(_ error: Error) -> AppError {
+        if let appError = error as? AppError {
+            return appError
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == SCStreamErrorDomain,
+           nsError.code == SCStreamError.userDeclined.rawValue {
+            return .screenRecordingPermissionDenied
+        }
+
+        return .screenshotCaptureFailure(nsError.localizedDescription)
+    }
+}
+
+protocol ScreenshotImageWriting {
+    @MainActor
+    func writePNG(_ image: CGImage, to url: URL) throws
+}
+
+struct PNGScreenshotImageWriter: ScreenshotImageWriting {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func writePNG(_ image: CGImage, to url: URL) throws {
+        let directoryURL = url.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let temporaryURL = directoryURL
+            .appendingPathComponent(".\(UUID().uuidString)")
+            .appendingPathExtension("png")
+
+        do {
+            guard let destination = CGImageDestinationCreateWithURL(
+                temporaryURL as CFURL,
+                UTType.png.identifier as CFString,
+                1,
+                nil
+            ) else {
+                throw AppError.screenshotCaptureFailure("The screenshot file could not be created.")
+            }
+
+            CGImageDestinationAddImage(destination, image, nil)
+
+            guard CGImageDestinationFinalize(destination) else {
+                throw AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
+            }
+
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
+
+            try fileManager.moveItem(at: temporaryURL, to: url)
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+    }
+}
+
 struct ScreenshotCaptureService: ScreenshotCapturing {
-    func captureScreenshot(to url: URL) throws {
-        if !CGPreflightScreenCaptureAccess() && !CGRequestScreenCaptureAccess() {
-            throw AppError.screenshotCaptureFailure(
-                "Screen Recording permission is required to capture review screenshots. Enable it in System Settings and try again."
-            )
+    private let permissionChecker: any ScreenCapturePermissionChecking
+    private let imageProvider: any ScreenCaptureImageProviding
+    private let imageWriter: any ScreenshotImageWriting
+
+    init(
+        permissionChecker: any ScreenCapturePermissionChecking = SystemScreenCapturePermissionChecker(),
+        imageProvider: any ScreenCaptureImageProviding = ScreenCaptureKitImageProvider(),
+        imageWriter: any ScreenshotImageWriting = PNGScreenshotImageWriter()
+    ) {
+        self.permissionChecker = permissionChecker
+        self.imageProvider = imageProvider
+        self.imageWriter = imageWriter
+    }
+
+    @MainActor
+    func captureScreenshot(to url: URL) async throws {
+        if !permissionChecker.preflightAccess() && !permissionChecker.requestAccess() {
+            throw AppError.screenRecordingPermissionDenied
         }
 
-        guard let image = CGWindowListCreateImage(
-            .infinite,
-            .optionOnScreenOnly,
-            kCGNullWindowID,
-            [.bestResolution]
+        let displays = try await imageProvider.availableDisplays()
+        guard !displays.isEmpty else {
+            throw AppError.screenshotCaptureFailure("No displays were available to capture.")
+        }
+
+        var capturedDisplays: [CapturedDisplayImage] = []
+        capturedDisplays.reserveCapacity(displays.count)
+        for display in displays {
+            capturedDisplays.append(try await imageProvider.captureDisplayImage(for: display))
+        }
+
+        let image = try makeCompositeImage(from: capturedDisplays)
+        try imageWriter.writePNG(image, to: url)
+    }
+
+    private func makeCompositeImage(from capturedDisplays: [CapturedDisplayImage]) throws -> CGImage {
+        let frames = capturedDisplays.map(\.display.frame)
+        let compositeBounds = frames.reduce(into: CGRect.null) { partialResult, frame in
+            partialResult = partialResult.union(frame)
+        }.integral
+
+        guard !compositeBounds.isNull, compositeBounds.width > 0, compositeBounds.height > 0 else {
+            throw AppError.screenshotCaptureFailure("No display content was available to capture.")
+        }
+
+        let width = Int(compositeBounds.width.rounded(.up))
+        let height = Int(compositeBounds.height.rounded(.up))
+        let colorSpace = capturedDisplays.first?.image.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ) else {
-            throw AppError.screenshotCaptureFailure(
-                "Screen capture failed. If the problem persists, check Screen Recording permission in System Settings."
+            throw AppError.screenshotCaptureFailure("BugNarrator could not prepare the screenshot image.")
+        }
+
+        context.interpolationQuality = .high
+
+        for capturedDisplay in capturedDisplays {
+            let frame = capturedDisplay.display.frame
+            let drawRect = CGRect(
+                x: frame.minX - compositeBounds.minX,
+                y: frame.minY - compositeBounds.minY,
+                width: frame.width,
+                height: frame.height
             )
+            context.draw(capturedDisplay.image, in: drawRect)
         }
 
-        guard let destination = CGImageDestinationCreateWithURL(
-            url as CFURL,
-            UTType.png.identifier as CFString,
-            1,
-            nil
-        ) else {
-            throw AppError.screenshotCaptureFailure("The screenshot file could not be created.")
+        guard let image = context.makeImage() else {
+            throw AppError.screenshotCaptureFailure("BugNarrator could not finish the screenshot image.")
         }
 
-        CGImageDestinationAddImage(destination, image, nil)
-
-        guard CGImageDestinationFinalize(destination) else {
-            throw AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
-        }
+        return image
     }
 }

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -28,7 +28,8 @@ protocol HotkeyManaging: AnyObject {
 }
 
 protocol ScreenshotCapturing {
-    func captureScreenshot(to url: URL) throws
+    @MainActor
+    func captureScreenshot(to url: URL) async throws
 }
 
 protocol IssueExtracting: Sendable {

--- a/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
@@ -6,4 +6,8 @@ enum BugNarratorLinks {
     static let issues = URL(string: "https://github.com/deffenda/bugnarrator/issues/new")!
     static let releases = URL(string: "https://github.com/deffenda/bugnarrator/releases")!
     static let supportDevelopment = URL(string: "https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8")!
+    static let microphonePrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
+    static let screenRecordingPrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+    static let securityPrivacySettings = URL(fileURLWithPath: "/System/Library/PreferencePanes/Security.prefPane")
+    static let systemSettingsApp = URL(fileURLWithPath: "/System/Applications/System Settings.app")
 }

--- a/Sources/BugNarrator/Utilities/MenuBarStatusPresentation.swift
+++ b/Sources/BugNarrator/Utilities/MenuBarStatusPresentation.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+
+enum MenuBarStatusRecoveryAction: Equatable {
+    case none
+    case microphone
+    case screenRecording
+    case openAI
+    case exportConfiguration
+    case storage
+}
+
+struct MenuBarStatusPresentation: Equatable {
+    let preferredWidth: CGFloat
+    let recoveryAction: MenuBarStatusRecoveryAction
+
+    init(status: AppStatus, currentError: AppError?) {
+        self.recoveryAction = Self.recoveryAction(for: currentError)
+        self.preferredWidth = Self.preferredWidth(for: status, currentError: currentError)
+    }
+
+    private static func recoveryAction(for currentError: AppError?) -> MenuBarStatusRecoveryAction {
+        switch currentError {
+        case .microphonePermissionDenied:
+            return .microphone
+        case .screenRecordingPermissionDenied:
+            return .screenRecording
+        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
+            return .openAI
+        case .exportConfigurationMissing:
+            return .exportConfiguration
+        case .storageFailure:
+            return .storage
+        default:
+            return .none
+        }
+    }
+
+    private static func preferredWidth(for status: AppStatus, currentError: AppError?) -> CGFloat {
+        if recoveryAction(for: currentError) != .none {
+            return 420
+        }
+
+        if let detail = status.detail, detail.count > 85 || status.phase == .transcribing {
+            return 390
+        }
+
+        return 340
+    }
+}

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -4,6 +4,10 @@ struct MenuBarView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var transcriptStore: TranscriptStore
 
+    private var statusPresentation: MenuBarStatusPresentation {
+        MenuBarStatusPresentation(status: appState.status, currentError: appState.currentError)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             statusCard
@@ -20,7 +24,7 @@ struct MenuBarView: View {
             footerSection
         }
         .padding(16)
-        .frame(width: 340)
+        .frame(width: preferredMenuWidth)
         .alert("Discard this recording?", isPresented: $appState.showDiscardConfirmation) {
             Button("Discard", role: .destructive) {
                 Task {
@@ -69,29 +73,151 @@ struct MenuBarView: View {
                     if let detail = appState.status.detail {
                         Text(detail)
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(appState.currentError == nil ? .secondary : .primary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
+
+                    statusRecoverySection
                 }
             } else if appState.status.phase == .transcribing {
-                HStack(spacing: 10) {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text(appState.status.detail ?? "Uploading audio and waiting for transcription...")
-                        .font(.subheadline)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(appState.status.detail ?? "Uploading audio and waiting for transcription...")
+                            .font(.subheadline)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    statusRecoverySection
                 }
             } else if let detail = appState.status.detail {
                 Text(detail)
                     .font(.subheadline)
                     .foregroundStyle(statusTint)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                statusRecoverySection
             } else {
                 Text("Ready for a spoken software review session.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
         .background(.quaternary.opacity(0.6), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var microphoneRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Open System Settings and enable BugNarrator in Privacy & Security > Microphone.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Open Microphone Settings") {
+                appState.openMicrophonePrivacySettings()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .accessibilityLabel("Open Microphone privacy settings")
+            .accessibilityHint("Opens the macOS privacy settings for microphone access")
+        }
+    }
+
+    @ViewBuilder
+    private var statusRecoverySection: some View {
+        switch statusPresentation.recoveryAction {
+        case .microphone:
+            microphoneRecoverySection
+        case .screenRecording:
+            screenRecordingRecoverySection
+        case .openAI:
+            openAIKeyRecoverySection
+        case .exportConfiguration:
+            exportConfigurationRecoverySection
+        case .storage:
+            storageRecoverySection
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private var screenRecordingRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recording can continue without screenshots. To capture them again, enable BugNarrator in Privacy & Security > Screen & System Audio Recording.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Open Screen Recording Settings") {
+                appState.openScreenRecordingPrivacySettings()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .accessibilityLabel("Open Screen Recording privacy settings")
+            .accessibilityHint("Opens the macOS privacy settings for screen recording access")
+        }
+    }
+
+    private var openAIKeyRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Open Settings to add or replace your own OpenAI API key. BugNarrator stores it in your macOS Keychain when available.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Open Settings") {
+                appState.openSettings()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+    }
+
+    private var exportConfigurationRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Open Settings and finish the GitHub or Jira export configuration before exporting issues.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Open Settings") {
+                appState.openSettings()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var storageRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("The transcript is still available in BugNarrator. After fixing local storage, open the transcript window and save it to history.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button("Open Transcript Window") {
+                appState.openTranscriptHistory()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var preferredMenuWidth: CGFloat {
+        statusPresentation.preferredWidth
     }
 
     private var apiKeyRequirementCard: some View {
@@ -116,7 +242,40 @@ struct MenuBarView: View {
         VStack(alignment: .leading, spacing: 10) {
             switch appState.status.phase {
             case .idle, .success, .error:
-                if appState.needsAPIKeySetup {
+                if appState.currentError == .microphonePermissionDenied {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Button("Open Microphone Settings") {
+                                appState.openMicrophonePrivacySettings()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.large)
+
+                            Button("Try Again") {
+                                Task {
+                                    await appState.startSession()
+                                }
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Text("After allowing access, return to BugNarrator and try starting the session again.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let currentError = appState.currentError, currentError.suggestsOpenAISettings {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Button("Open Settings") {
+                            appState.openSettings()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+
+                        Text("BugNarrator requires your own OpenAI API key and keeps it in Keychain when available.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if appState.needsAPIKeySetup {
                     Button("Add OpenAI API Key") {
                         appState.openSettings()
                     }

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -126,6 +126,20 @@ struct SettingsView: View {
                     }
                 }
 
+                GroupBox("Permissions") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("BugNarrator asks for microphone access only when you start recording.")
+                            .foregroundStyle(.secondary)
+
+                        Text("BugNarrator asks for Screen Recording access only when you capture a screenshot. Recording can continue without screenshots if you skip this permission.")
+                            .foregroundStyle(.secondary)
+
+                        Text("If you deny a permission, BugNarrator shows recovery buttons in the menu bar window so you can reopen the right System Settings pane.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 GroupBox("Global Hotkeys") {
                     VStack(alignment: .leading, spacing: 12) {
                         hotkeyRow(title: HotkeyAction.toggleRecording.title, shortcut: $settingsStore.recordingHotkeyShortcut)

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -319,10 +319,12 @@ struct TranscriptView: View {
     private var allSessions: [TranscriptSession] {
         var sessions = transcriptStore.sessions
 
-        if let currentTranscript = appState.currentTranscript,
-           !appState.currentTranscriptIsPersisted,
-           !sessions.contains(where: { $0.id == currentTranscript.id }) {
-            sessions.insert(currentTranscript, at: 0)
+        if let currentTranscript = appState.currentTranscript {
+            if let existingIndex = sessions.firstIndex(where: { $0.id == currentTranscript.id }) {
+                sessions[existingIndex] = currentTranscript
+            } else if !appState.currentTranscriptIsPersisted {
+                sessions.insert(currentTranscript, at: 0)
+            }
         }
 
         return sessions

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -41,7 +41,60 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertEqual(harness.appState.status.detail, AppError.microphonePermissionDenied.userMessage)
+        XCTAssertEqual(harness.appState.currentError, .microphonePermissionDenied)
         XCTAssertEqual(harness.audioRecorder.startCallCount, 0)
+    }
+
+    func testOpenMicrophoneSettingsUsesPrivacyDeepLinkFirst() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.appState.openMicrophonePrivacySettings()
+
+        XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.microphonePrivacySettings])
+    }
+
+    func testOpenMicrophoneSettingsFallsBackToSecuritySettings() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.urlHandler.openResults = [false, true]
+
+        harness.appState.openMicrophonePrivacySettings()
+
+        XCTAssertEqual(
+            harness.urlHandler.openedURLs,
+            [
+                BugNarratorLinks.microphonePrivacySettings,
+                BugNarratorLinks.securityPrivacySettings
+            ]
+        )
+    }
+
+    func testOpenScreenRecordingSettingsUsesPrivacyDeepLinkFirst() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.appState.openScreenRecordingPrivacySettings()
+
+        XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.screenRecordingPrivacySettings])
+    }
+
+    func testOpenScreenRecordingSettingsFallsBackToSecuritySettings() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.urlHandler.openResults = [false, true]
+
+        harness.appState.openScreenRecordingPrivacySettings()
+
+        XCTAssertEqual(
+            harness.urlHandler.openedURLs,
+            [
+                BugNarratorLinks.screenRecordingPrivacySettings,
+                BugNarratorLinks.securityPrivacySettings
+            ]
+        )
     }
 
     func testSuccessfulSessionSavesCopiesAndDeletesTemporaryAudioFile() async throws {
@@ -81,6 +134,47 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.transcriptStore.sessions.count, 0)
         XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
         XCTAssertNil(harness.appState.activeRecordingSession)
+    }
+
+    func testSuccessfulTranscriptionWithStorageFailureKeepsTranscriptAvailableForManualSave() async throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "storage-failure")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        await harness.transcriptionClient.enqueue(
+            .success(TranscriptionResult(text: "Transcript survived local save failure.", segments: []))
+        )
+
+        var didOpenTranscriptWindow = false
+        harness.appState.showTranscriptWindow = {
+            didOpenTranscriptWindow = true
+        }
+
+        await harness.appState.startSession()
+        await harness.appState.captureScreenshot()
+
+        let storageURL = harness.rootDirectoryURL.appendingPathComponent("sessions.json")
+        try? FileManager.default.removeItem(at: storageURL)
+        try FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true)
+
+        await harness.appState.stopSession()
+
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertTrue(
+            harness.appState.status.detail?.hasPrefix("Transcript ready, but Could not save local session history:") == true
+        )
+        XCTAssertEqual(harness.appState.currentTranscript?.transcript, "Transcript survived local save failure.")
+        XCTAssertFalse(harness.appState.currentTranscriptIsPersisted)
+        XCTAssertEqual(harness.transcriptStore.sessions.count, 0)
+        XCTAssertEqual(harness.clipboardService.copiedStrings.last, "Transcript survived local save failure.")
+        XCTAssertTrue(didOpenTranscriptWindow)
+        XCTAssertNil(harness.appState.activeRecordingSession)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+
+        let screenshotPath = try XCTUnwrap(harness.appState.currentTranscript?.screenshots.first?.filePath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: screenshotPath))
+        XCTAssertTrue(harness.artifactsService.removedDirectories.isEmpty)
     }
 
     func testStopSessionIgnoresDuplicateStopsWhileStopping() async throws {
@@ -392,7 +486,7 @@ final class AppStateTests: XCTestCase {
     func testCaptureScreenshotFailureKeepsRecordingAndShowsMessage() async {
         let harness = AppStateHarness(
             screenshotCaptureService: MockScreenshotCaptureService(
-                error: AppError.screenshotCaptureFailure("Permission denied.")
+                error: AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
             )
         )
         defer { harness.cleanup() }
@@ -403,9 +497,73 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.status.phase, .recording)
         XCTAssertEqual(
             harness.appState.status.detail,
-            AppError.screenshotCaptureFailure("Permission denied.").userMessage
+            AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.").userMessage
+        )
+        XCTAssertEqual(
+            harness.appState.currentError,
+            AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
         )
         XCTAssertEqual(harness.appState.activeRecordingSession?.screenshots.count, 0)
+    }
+
+    func testCaptureScreenshotWithDeniedScreenRecordingKeepsRecordingAndShowsRecoveryContext() async {
+        let harness = AppStateHarness(
+            screenshotCaptureService: MockScreenshotCaptureService(
+                error: AppError.screenRecordingPermissionDenied
+            )
+        )
+        defer { harness.cleanup() }
+
+        await harness.appState.startSession()
+        await harness.appState.captureScreenshot()
+
+        XCTAssertEqual(harness.appState.status.phase, .recording)
+        XCTAssertEqual(harness.appState.status.detail, AppError.screenRecordingPermissionDenied.userMessage)
+        XCTAssertEqual(harness.appState.currentError, .screenRecordingPermissionDenied)
+        XCTAssertEqual(harness.appState.activeRecordingSession?.screenshots.count, 0)
+    }
+
+    func testRapidRepeatedScreenshotRequestsOnlyPersistOneCaptureAtATime() async throws {
+        let firstCaptureStarted = expectation(description: "first screenshot capture started")
+        let screenshotService = MockScreenshotCaptureService(delayNanoseconds: 200_000_000)
+        screenshotService.onCaptureStart = {
+            firstCaptureStarted.fulfill()
+        }
+
+        let harness = AppStateHarness(screenshotCaptureService: screenshotService)
+        defer { harness.cleanup() }
+
+        await harness.appState.startSession()
+
+        async let firstCapture: Void = harness.appState.captureScreenshot()
+        await fulfillment(of: [firstCaptureStarted], timeout: 1.0)
+        async let secondCapture: Void = harness.appState.captureScreenshot()
+        _ = await (firstCapture, secondCapture)
+
+        let recordingSession = try XCTUnwrap(harness.appState.activeRecordingSession)
+        XCTAssertEqual(recordingSession.screenshots.count, 1)
+        XCTAssertEqual(harness.appState.status.phase, .recording)
+        XCTAssertEqual(harness.appState.status.detail, "Captured Screenshot 1.")
+        XCTAssertNil(harness.appState.currentError)
+    }
+
+    func testInsertMarkerWithScreenshotPermissionDeniedStillCreatesMarker() async {
+        let harness = AppStateHarness(
+            screenshotCaptureService: MockScreenshotCaptureService(
+                error: AppError.screenRecordingPermissionDenied
+            )
+        )
+        defer { harness.cleanup() }
+
+        await harness.appState.startSession()
+        harness.audioRecorder.currentDuration = 7
+
+        await harness.appState.insertMarker(title: "Checkout", captureScreenshot: true)
+
+        XCTAssertEqual(harness.appState.activeRecordingSession?.markers.count, 1)
+        XCTAssertEqual(harness.appState.activeRecordingSession?.screenshots.count, 0)
+        XCTAssertEqual(harness.appState.currentError, .screenRecordingPermissionDenied)
+        XCTAssertEqual(harness.appState.status.phase, .recording)
     }
 
     func testAutomaticIssueExtractionPersistsDraftIssuesAfterTranscription() async throws {
@@ -442,6 +600,34 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.status.phase, .success)
     }
 
+    func testExtractIssuesWithoutAPIKeyFailsAndOpensSettings() async throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil
+        )
+        try harness.transcriptStore.add(session)
+        harness.appState.selectedTranscriptID = session.id
+        harness.settingsStore.removeAPIKey()
+
+        var didOpenSettings = false
+        harness.appState.showSettingsWindow = {
+            didOpenSettings = true
+        }
+
+        await harness.appState.extractIssuesForDisplayedTranscript()
+
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertEqual(harness.appState.status.detail, AppError.missingAPIKey.userMessage)
+        XCTAssertTrue(didOpenSettings)
+    }
+
     func testCanExportIssuesRequiresConfiguredDestinationAndSelectedIssue() {
         let harness = AppStateHarness()
         defer { harness.cleanup() }
@@ -470,6 +656,8 @@ final class AppStateTests: XCTestCase {
         )
 
         XCTAssertFalse(harness.appState.canExportIssues(from: session, to: .github))
+        XCTAssertNoThrow(try harness.transcriptStore.add(session))
+        harness.appState.selectedTranscriptID = session.id
 
         harness.settingsStore.githubToken = "github-token"
         harness.settingsStore.githubRepositoryOwner = "acme"
@@ -504,6 +692,8 @@ final class AppStateTests: XCTestCase {
                 ]
             )
         )
+        XCTAssertNoThrow(try harness.transcriptStore.add(session))
+        harness.appState.selectedTranscriptID = session.id
 
         var didOpenSettings = false
         harness.appState.showSettingsWindow = {
@@ -514,6 +704,50 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertTrue(didOpenSettings)
+    }
+
+    func testExportSelectedIssuesFailsWhenSessionIsNoLongerAvailable() async {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.githubToken = "github-token"
+        harness.settingsStore.githubRepositoryOwner = "acme"
+        harness.settingsStore.githubRepositoryName = "bugnarrator"
+
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(
+                summary: "Summary",
+                issues: [
+                    ExtractedIssue(
+                        title: "Issue",
+                        category: .bug,
+                        summary: "Summary",
+                        evidenceExcerpt: "Evidence",
+                        timestamp: 2,
+                        requiresReview: true,
+                        isSelectedForExport: true
+                    )
+                ]
+            )
+        )
+
+        XCTAssertFalse(harness.appState.canExportIssues(from: session, to: .github))
+
+        await harness.appState.exportSelectedIssues(from: session, to: .github)
+
+        let callCount = await harness.exportService.gitHubCallCount
+        XCTAssertEqual(callCount, 0)
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertEqual(
+            harness.appState.status.detail,
+            AppError.exportFailure("This session is no longer available in the library.").userMessage
+        )
     }
 
     func testExportSelectedIssuesCallsGitHubProviderWhenConfigured() async {
@@ -550,12 +784,67 @@ final class AppStateTests: XCTestCase {
             prompt: nil,
             issueExtraction: IssueExtractionResult(summary: "Summary", issues: [sourceIssue])
         )
+        XCTAssertNoThrow(try harness.transcriptStore.add(session))
+        harness.appState.selectedTranscriptID = session.id
 
         await harness.appState.exportSelectedIssues(from: session, to: .github)
 
         let callCount = await harness.exportService.gitHubCallCount
         XCTAssertEqual(callCount, 1)
         XCTAssertEqual(harness.appState.status.phase, .success)
+    }
+
+    func testPersistUpdatedSessionFailureKeepsEditedIssueVisibleAsUnsavedOverlay() throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let originalIssue = ExtractedIssue(
+            title: "Original title",
+            category: .bug,
+            summary: "Summary",
+            evidenceExcerpt: "Evidence",
+            timestamp: 5,
+            requiresReview: true,
+            isSelectedForExport: true
+        )
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [originalIssue])
+        )
+        try harness.transcriptStore.add(session)
+        harness.appState.selectedTranscriptID = session.id
+
+        let storageURL = harness.rootDirectoryURL.appendingPathComponent("sessions.json")
+        try FileManager.default.removeItem(at: storageURL)
+        try FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true)
+
+        var updatedIssue = originalIssue
+        updatedIssue.title = "Updated visible title"
+
+        harness.appState.updateExtractedIssue(updatedIssue, in: session.id)
+
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertTrue(
+            harness.appState.status.detail?.hasPrefix("Could not save local session history:") == true
+        )
+        XCTAssertEqual(
+            harness.appState.currentTranscript?.issueExtraction?.issues.first?.title,
+            "Updated visible title"
+        )
+        XCTAssertEqual(
+            harness.appState.displayedTranscript?.issueExtraction?.issues.first?.title,
+            "Updated visible title"
+        )
+        XCTAssertFalse(harness.appState.currentTranscriptIsPersisted)
+        XCTAssertEqual(
+            harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.first?.title,
+            "Original title"
+        )
     }
 
     func testConsecutiveSessionsWorkBackToBackWithoutRestart() async throws {

--- a/Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
+++ b/Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import BugNarrator
+
+final class MenuBarStatusPresentationTests: XCTestCase {
+    func testMicrophoneErrorUsesRecoveryWidthAndAction() {
+        let presentation = MenuBarStatusPresentation(
+            status: .error(AppError.microphonePermissionDenied.userMessage),
+            currentError: .microphonePermissionDenied
+        )
+
+        XCTAssertEqual(presentation.recoveryAction, .microphone)
+        XCTAssertEqual(presentation.preferredWidth, 420)
+    }
+
+    func testScreenRecordingErrorUsesRecoveryWidthAndAction() {
+        let presentation = MenuBarStatusPresentation(
+            status: .recording(AppError.screenRecordingPermissionDenied.userMessage),
+            currentError: .screenRecordingPermissionDenied
+        )
+
+        XCTAssertEqual(presentation.recoveryAction, .screenRecording)
+        XCTAssertEqual(presentation.preferredWidth, 420)
+    }
+
+    func testOpenAIErrorUsesSettingsRecoveryAction() {
+        let presentation = MenuBarStatusPresentation(
+            status: .error(AppError.invalidAPIKey.userMessage),
+            currentError: .invalidAPIKey
+        )
+
+        XCTAssertEqual(presentation.recoveryAction, .openAI)
+        XCTAssertEqual(presentation.preferredWidth, 420)
+    }
+
+    func testTranscribingStateExpandsWidthForLongRunningStatus() {
+        let presentation = MenuBarStatusPresentation(
+            status: .transcribing("Uploading audio to OpenAI and waiting for transcription..."),
+            currentError: nil
+        )
+
+        XCTAssertEqual(presentation.recoveryAction, .none)
+        XCTAssertEqual(presentation.preferredWidth, 390)
+    }
+
+    func testDefaultIdleStateStaysCompact() {
+        let presentation = MenuBarStatusPresentation(
+            status: .idle(),
+            currentError: nil
+        )
+
+        XCTAssertEqual(presentation.recoveryAction, .none)
+        XCTAssertEqual(presentation.preferredWidth, 340)
+    }
+}

--- a/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
@@ -1,0 +1,158 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import XCTest
+@testable import BugNarrator
+
+final class ScreenshotCaptureServiceTests: XCTestCase {
+    func testCaptureScreenshotFailsFastWhenScreenRecordingPermissionIsDenied() async {
+        let service = ScreenshotCaptureService(
+            permissionChecker: MockScreenCapturePermissionChecker(preflightAccessValue: false, requestAccessValue: false),
+            imageProvider: MockScreenCaptureImageProvider(),
+            imageWriter: PNGScreenshotImageWriter()
+        )
+
+        do {
+            try await service.captureScreenshot(to: temporaryDirectoryURL().appendingPathComponent("capture.png"))
+            XCTFail("Expected permission denial.")
+        } catch {
+            XCTAssertEqual(error as? AppError, .screenRecordingPermissionDenied)
+        }
+    }
+
+    func testCaptureScreenshotCreatesParentDirectoryAndWritesCompositePNG() async throws {
+        let temporaryRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let displayA = ScreenCaptureDisplaySnapshot(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 50),
+            pixelWidth: 100,
+            pixelHeight: 50
+        )
+        let displayB = ScreenCaptureDisplaySnapshot(
+            displayID: 2,
+            frame: CGRect(x: 100, y: 0, width: 50, height: 50),
+            pixelWidth: 50,
+            pixelHeight: 50
+        )
+
+        let provider = MockScreenCaptureImageProvider(
+            displays: [displayA, displayB],
+            imagesByDisplayID: [
+                1: try makeSolidImage(width: 100, height: 50, color: CGColor(red: 1, green: 0, blue: 0, alpha: 1)),
+                2: try makeSolidImage(width: 50, height: 50, color: CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+            ]
+        )
+
+        let service = ScreenshotCaptureService(
+            permissionChecker: MockScreenCapturePermissionChecker(preflightAccessValue: true, requestAccessValue: false),
+            imageProvider: provider,
+            imageWriter: PNGScreenshotImageWriter()
+        )
+
+        let outputURL = temporaryRoot
+            .appendingPathComponent("nested", isDirectory: true)
+            .appendingPathComponent("capture.png")
+
+        try await service.captureScreenshot(to: outputURL)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+
+        let imageSource = try XCTUnwrap(CGImageSourceCreateWithURL(outputURL as CFURL, nil))
+        let properties = try XCTUnwrap(CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any])
+        XCTAssertEqual(properties[kCGImagePropertyPixelWidth] as? Int, 150)
+        XCTAssertEqual(properties[kCGImagePropertyPixelHeight] as? Int, 50)
+    }
+
+    func testCaptureScreenshotFailsWhenNoDisplaysAreAvailable() async {
+        let service = ScreenshotCaptureService(
+            permissionChecker: MockScreenCapturePermissionChecker(preflightAccessValue: true, requestAccessValue: false),
+            imageProvider: MockScreenCaptureImageProvider(displays: []),
+            imageWriter: PNGScreenshotImageWriter()
+        )
+
+        do {
+            try await service.captureScreenshot(to: temporaryDirectoryURL().appendingPathComponent("capture.png"))
+            XCTFail("Expected missing-display failure.")
+        } catch {
+            XCTAssertEqual(
+                error as? AppError,
+                .screenshotCaptureFailure("No displays were available to capture.")
+            )
+        }
+    }
+
+    private func temporaryDirectoryURL() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func makeSolidImage(width: Int, height: Int, color: CGColor) throws -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw AppError.screenshotCaptureFailure("Could not create a test screenshot image.")
+        }
+
+        context.setFillColor(color)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let image = context.makeImage() else {
+            throw AppError.screenshotCaptureFailure("Could not finalize a test screenshot image.")
+        }
+
+        return image
+    }
+}
+
+private struct MockScreenCapturePermissionChecker: ScreenCapturePermissionChecking {
+    let preflightAccessValue: Bool
+    let requestAccessValue: Bool
+
+    @MainActor
+    func preflightAccess() -> Bool {
+        preflightAccessValue
+    }
+
+    @MainActor
+    func requestAccess() -> Bool {
+        requestAccessValue
+    }
+}
+
+private struct MockScreenCaptureImageProvider: ScreenCaptureImageProviding {
+    var displays: [ScreenCaptureDisplaySnapshot] = []
+    var imagesByDisplayID: [CGDirectDisplayID: CGImage] = [:]
+    var error: Error?
+
+    @MainActor
+    func availableDisplays() async throws -> [ScreenCaptureDisplaySnapshot] {
+        if let error {
+            throw error
+        }
+
+        return displays
+    }
+
+    @MainActor
+    func captureDisplayImage(for display: ScreenCaptureDisplaySnapshot) async throws -> CapturedDisplayImage {
+        if let error {
+            throw error
+        }
+
+        guard let image = imagesByDisplayID[display.displayID] else {
+            throw AppError.screenshotCaptureFailure("Missing mock image for display \(display.displayID).")
+        }
+
+        return CapturedDisplayImage(display: display, image: image)
+    }
+}

--- a/Tests/BugNarratorTests/SessionLibraryTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryTests.swift
@@ -160,6 +160,49 @@ final class SessionLibraryTests: XCTestCase {
         XCTAssertEqual(SessionLibrary.count(for: .customRange, in: sessions, customDateRange: customDateRange, calendar: calendar, referenceDate: referenceDate), 1)
     }
 
+    func testDateBucketFilteringHandlesMidnightBoundariesInLocalTimezone() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        let formatter = ISO8601DateFormatter()
+        let referenceDate = formatter.date(from: "2026-03-14T00:30:00-04:00")!
+        let sessions = [
+            makeSession(
+                transcript: "Just after midnight transcript",
+                createdAt: formatter.date(from: "2026-03-14T00:05:00-04:00")!,
+                summary: ""
+            ),
+            makeSession(
+                transcript: "Just before midnight transcript",
+                createdAt: formatter.date(from: "2026-03-13T23:55:00-04:00")!,
+                summary: ""
+            )
+        ]
+        let query = SessionLibraryQuery(
+            filter: .today,
+            customDateRange: SessionLibraryDateRange(startDate: referenceDate, endDate: referenceDate)
+        )
+
+        let todaySessions = SessionLibrary.filteredSessions(
+            from: sessions,
+            query: query,
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+        let yesterdaySessions = SessionLibrary.filteredSessions(
+            from: sessions,
+            query: SessionLibraryQuery(
+                filter: .yesterday,
+                customDateRange: query.customDateRange
+            ),
+            calendar: calendar,
+            referenceDate: referenceDate
+        )
+
+        XCTAssertEqual(todaySessions.map(\.transcript), ["Just after midnight transcript"])
+        XCTAssertEqual(yesterdaySessions.map(\.transcript), ["Just before midnight transcript"])
+    }
+
     func testEmptyStateCoversNoSessionsNoResultsAndNoFilterMatches() {
         let emptyQuery = SessionLibraryQuery(
             filter: .allSessions,

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -204,6 +204,58 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testStartupSkipsInteractiveLegacyExportKeychainPromptsUntilUserInitiatesAccess() {
+        let suiteName = "BugNarrator-SettingsDeferredExportKeychainTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychain = MockKeychainService()
+        let legacyGitHubKey = "SessionMic.GitHub::github-token"
+        let legacyJiraKey = "SessionMic.Jira::jira-api-token"
+        keychain.values[legacyGitHubKey] = "legacy-github-token"
+        keychain.values[legacyJiraKey] = "legacy-jira-token"
+        keychain.interactionRequiredKeys = [legacyGitHubKey, legacyJiraKey]
+
+        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+
+        XCTAssertEqual(store.githubToken, "")
+        XCTAssertEqual(store.jiraAPIToken, "")
+        XCTAssertTrue(
+            keychain.readRequests.contains {
+                $0.service == "SessionMic.GitHub" && !$0.allowInteraction
+            }
+        )
+        XCTAssertTrue(
+            keychain.readRequests.contains {
+                $0.service == "SessionMic.Jira" && !$0.allowInteraction
+            }
+        )
+
+        store.refreshExportSecretsForUserInitiatedAccess()
+
+        XCTAssertEqual(store.githubToken, "legacy-github-token")
+        XCTAssertEqual(store.jiraAPIToken, "legacy-jira-token")
+        XCTAssertTrue(
+            keychain.readRequests.contains {
+                $0.service == "SessionMic.GitHub" && $0.allowInteraction
+            }
+        )
+        XCTAssertTrue(
+            keychain.readRequests.contains {
+                $0.service == "SessionMic.Jira" && $0.allowInteraction
+            }
+        )
+        XCTAssertEqual(
+            keychain.values["BugNarrator.GitHub::github-token"],
+            "legacy-github-token"
+        )
+        XCTAssertEqual(
+            keychain.values["BugNarrator.Jira::jira-api-token"],
+            "legacy-jira-token"
+        )
+    }
+
     func testMaskedExportTokensOnlyExposeSuffix() {
         let suiteName = "BugNarrator-SettingsExportMaskTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -113,12 +113,27 @@ final class MockHotkeyManager: HotkeyManaging {
     }
 }
 
-struct MockScreenshotCaptureService: ScreenshotCapturing {
+final class MockScreenshotCaptureService: ScreenshotCapturing {
     var error: Error?
+    var delayNanoseconds: UInt64 = 0
+    var onCaptureStart: (() -> Void)?
 
-    func captureScreenshot(to url: URL) throws {
+    init(error: Error? = nil, delayNanoseconds: UInt64 = 0, onCaptureStart: (() -> Void)? = nil) {
+        self.error = error
+        self.delayNanoseconds = delayNanoseconds
+        self.onCaptureStart = onCaptureStart
+    }
+
+    @MainActor
+    func captureScreenshot(to url: URL) async throws {
         if let error {
             throw error
+        }
+
+        onCaptureStart?()
+
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
         }
 
         try Data("screenshot".utf8).write(to: url)
@@ -241,10 +256,15 @@ final class MockClipboardService: ClipboardWriting {
 final class MockURLHandler: URLOpening {
     private(set) var openedURLs: [URL] = []
     var shouldSucceed = true
+    var openResults: [Bool] = []
 
     @discardableResult
     func open(_ url: URL) -> Bool {
         openedURLs.append(url)
+        if !openResults.isEmpty {
+            return openResults.removeFirst()
+        }
+
         return shouldSucceed
     }
 }

--- a/docs/Distribution.md
+++ b/docs/Distribution.md
@@ -1,6 +1,6 @@
 # BugNarrator Distribution
 
-This document explains how to build the BugNarrator release app and package it as a distributable macOS DMG.
+This document explains how to build the BugNarrator release app, package it as a distributable macOS DMG, and validate it before publishing on GitHub Releases.
 
 ## What This Produces
 
@@ -9,11 +9,13 @@ The packaging workflow creates:
 - a Release build of `BugNarrator.app`
 - a DMG containing `BugNarrator.app`
 - an `Applications` shortcut inside the DMG
+- validation that branded icon resources are present in the app bundle
+- validation that the mounted DMG contains the app plus the `Applications` shortcut
 - two output filenames in `dist/`
 
 By default you will get:
 
-- `BugNarrator-vX.Y-macOS.dmg`
+- `BugNarrator-vX.Y.Z-macOS.dmg`
 - `BugNarrator-macOS.dmg`
 
 The non-versioned filename is useful for a stable GitHub Releases download link.
@@ -46,7 +48,9 @@ The script:
 2. stages `BugNarrator.app`
 3. adds an `Applications` symlink
 4. creates a compressed DMG
-5. writes the finished artifacts to `dist/`
+5. verifies `AppIcon.icns` and `Assets.car` exist in the built app
+6. mounts the DMG and verifies the expected layout
+7. writes the finished artifacts to `dist/`
 
 ## Output Location
 
@@ -54,6 +58,14 @@ By default the script writes:
 
 - the DMG files to `dist/`
 - intermediate build data to `build/DerivedData`
+
+## Release App Output
+
+The built Release app is left at:
+
+- `build/DerivedData/Build/Products/Release/BugNarrator.app`
+
+Use that path for extra manual checks if you want to inspect codesigning or bundle resources directly.
 
 ## Release Signing Notes
 
@@ -113,21 +125,46 @@ NOTARY_PROFILE=BugNarratorNotary \
 The packaging script will:
 
 1. build the Release app
-2. verify the app is signed
-3. create the DMG
-4. submit the DMG to Apple's notarization service
-5. staple the notarization ticket to the DMG
-6. run `stapler validate` and `spctl` checks
+2. re-sign the app explicitly when a Developer ID build requires manual distribution signing
+3. verify the app is signed
+4. verify icon resources are present in the built app
+5. create the DMG
+6. mount the DMG and verify `BugNarrator.app` plus the `Applications` shortcut are present
+7. submit the DMG to Apple's notarization service
+8. staple the notarization ticket to the DMG
+9. run `stapler validate` and `spctl` checks
+
+Because BugNarrator targets macOS 14 or later, the shipped app now uses ScreenCaptureKit for screenshot capture. No extra packaging step is required for that API, but your release smoke test should still verify that Screen Recording permission prompts only when the user requests a screenshot.
+
+## Example Public Release Command
+
+If your local Mac already has a `Developer ID Application` certificate and a `BugNarratorNotary` profile configured, this is the practical public-release command:
+
+```bash
+CODE_SIGNING_ALLOWED=YES \
+CODE_SIGN_IDENTITY="Developer ID Application" \
+DEVELOPMENT_TEAM=2R4WAH4R53 \
+ALLOW_PROVISIONING_UPDATES=YES \
+NOTARIZE=YES \
+NOTARY_PROFILE=BugNarratorNotary \
+./scripts/build_dmg.sh
+```
+
+That produces:
+
+- `dist/BugNarrator-vX.Y.Z-macOS.dmg`
+- `dist/BugNarrator-macOS.dmg`
 
 ## Releasing On GitHub
 
 Recommended flow:
 
-1. run `./scripts/build_dmg.sh`
+1. run the signed/notarized packaging command
 2. create a GitHub Release
 3. upload `dist/BugNarrator-macOS.dmg`
-4. optionally upload the versioned `dist/BugNarrator-vX.Y-macOS.dmg`
-5. update release notes and changelog if needed
+4. optionally upload the versioned `dist/BugNarrator-vX.Y.Z-macOS.dmg`
+5. add release notes and link back to the changelog if needed
+6. verify the README top download link matches the uploaded stable DMG filename
 
 ## Verify The DMG
 
@@ -137,13 +174,25 @@ After building:
 2. confirm `BugNarrator.app` is present
 3. confirm the `Applications` shortcut is present
 4. drag the app into `Applications`
-5. launch the installed app and verify first-run behavior
+5. confirm the installed app shows the branded BugNarrator icon in Finder
+6. launch the installed app and verify first-run behavior
 
 For a public release, also verify:
 
-1. `xcrun stapler validate dist/BugNarrator-vX.Y-macOS.dmg`
-2. `spctl -a -vv -t open dist/BugNarrator-vX.Y-macOS.dmg`
+1. `xcrun stapler validate dist/BugNarrator-vX.Y.Z-macOS.dmg`
+2. `spctl -a -vv build/DerivedData/Build/Products/Release/BugNarrator.app`
 3. Gatekeeper accepts the downloaded DMG on a second Mac that has never built the app locally
+
+Note: `spctl -a -vv -t open` against a locally produced DMG can report `Insufficient Context` on the build machine because the file is not a quarantined download. Treat `stapler validate` plus an app-level `spctl` check as the reliable local validation, then do a real download/open smoke test before publishing.
+
+## Updating Release Links
+
+The README intentionally points to:
+
+- the stable direct asset path: `BugNarrator-macOS.dmg`
+- the latest GitHub release page
+
+If you change the stable DMG filename in the script, update the README download section in the same change so public visitors do not hit a broken link.
 
 ## Related Docs
 

--- a/docs/PostV1BugLog.md
+++ b/docs/PostV1BugLog.md
@@ -1,0 +1,89 @@
+# Post-1.0.0 Bug Log
+
+This document tracks the bugs surfaced after `BugNarrator 1.0.0` was cut and what happened to each one.
+
+It is intentionally product-facing rather than code-facing: the goal is to preserve what users actually experienced, the impact, and the release or patch where the issue was addressed.
+
+## Summary
+
+After `1.0.0`, the bugs surfaced fell into four buckets:
+
+- install and first-run trust issues
+- branding and icon packaging problems
+- support / donation UX inconsistencies
+- permission-recovery and error-message usability gaps
+
+## Issues Surfaced Since 1.0.0
+
+| ID | Surfaced behavior | User impact | Status | Fixed in |
+| --- | --- | --- | --- | --- |
+| `BN-P1-001` | The shipped app sometimes showed a generic app icon instead of the BugNarrator icon. | Made the app feel unfinished and harder to trust after install. | Fixed | `1.0.1` |
+| `BN-P1-002` | The DMG / public release artifact could still contain an app bundle with missing icon resources, so Finder showed the generic placeholder icon even when source assets were correct. | Public downloads could look broken even after the source-side icon fix existed. | Fixed | `1.0.1` release artifact refresh |
+| `BN-P1-003` | The menu bar label and visual identity still felt generic. | Reduced product polish and made the app feel less distinctive in the menu bar. | Fixed | `1.0.1` |
+| `BN-P1-004` | First launch could trigger a credential prompt while the app tried to read or migrate stored OpenAI credentials. | Created immediate trust friction during install and made the app feel unsafe. | Fixed | `1.0.1` |
+| `BN-P1-005` | The Support Development flow used three donation amounts even though the product only needed a simple path to the PayPal support page. | Added unnecessary decision friction and UI clutter. | Fixed | `1.0.1` |
+| `BN-P1-006` | When microphone permission was denied, BugNarrator only showed an error message and did not help the user recover. | Users could get stuck without a direct path to fix the problem. | Fixed | `1.0.2` |
+| `BN-P1-007` | Long error messages could be truncated in the top status card of the menu bar window. | Important recovery guidance was cut off exactly when the user needed it most. | Fixed | `1.0.2` |
+
+## Notes Per Issue
+
+### BN-P1-001: Generic app icon in the built app
+
+- Symptom: the installed app showed the standard generic app icon.
+- Root cause: the icon asset catalog was not reliably making it into the built app bundle in every distribution path.
+- Fix: the asset catalog pipeline was corrected and the generated icon assets were rebuilt.
+
+### BN-P1-002: Generic icon in the DMG / release artifact
+
+- Symptom: even when the source app icon looked correct locally, the downloaded DMG could still install a copy that showed the generic icon.
+- Root cause: the release packaging path was using an incomplete app bundle without the expected `Contents/Resources` icon assets.
+- Fix: the packaging flow was rebuilt, verified against the actual DMG contents, then reissued as a signed, notarized, stapled `1.0.1` release artifact.
+
+### BN-P1-003: Generic menu bar identity
+
+- Symptom: the menu bar presentation still felt like a stock utility rather than a branded product.
+- Root cause: the menu bar label relied on a generic SF Symbol treatment.
+- Fix: the menu bar label was replaced with a more BugNarrator-specific visual treatment.
+
+### BN-P1-004: First-run credential prompt
+
+- Symptom: first launch could trigger a Keychain / credential prompt before the user intentionally opened Settings or started a key-dependent action.
+- Root cause: startup secret-loading and legacy credential migration were still touching Keychain paths too eagerly.
+- Fix: startup reads were made non-interactive, and interactive legacy-key migration was deferred until the user explicitly initiated a relevant action.
+
+### BN-P1-005: Overcomplicated support / donation flow
+
+- Symptom: the app exposed multiple donation amounts even though the hosted PayPal page already handled support.
+- Root cause: the support UI modeled donation tiers instead of the actual support path.
+- Fix: the app now presents a single `Open PayPal Donation Page` action and aligns docs/tests with that simpler flow.
+
+### BN-P1-006: Microphone-denied flow lacked recovery guidance
+
+- Symptom: users saw a microphone-denied error but were not given a direct fix path.
+- Root cause: the app surfaced the error but did not attach a recovery action to the menu bar status area.
+- Fix: the menu bar status card now includes explicit guidance plus an `Open Microphone Settings` action with a fallback chain:
+  - direct Microphone privacy pane
+  - Security / Privacy settings
+  - System Settings app
+
+### BN-P1-007: Status card truncated long error messages
+
+- Symptom: long error text could be clipped in the top status card.
+- Root cause: the menu bar window used a fixed width with status text that did not explicitly wrap and expand.
+- Fix: the status text now wraps, the card grows vertically, and the menu widens for longer error states when needed.
+
+## Current State
+
+As of the current local workspace state:
+
+- `1.0.1` already covers the icon pipeline, support-flow simplification, and first-run credential-prompt fix.
+- `1.0.2` covers the microphone-recovery UX, multiline status-card sizing, and the ScreenCaptureKit screenshot modernization.
+- the release-hardening pass now keeps successfully transcribed sessions visible as unsaved drafts if local history persistence fails, and it prevents exports from running against stale or deleted session snapshots.
+- the DMG packaging script now validates icon resources in both the built app and the mounted DMG, which reduces regression risk for the original icon-shipping bugs.
+- screenshot capture now uses ScreenCaptureKit on macOS 14+, which removes the deprecated CoreGraphics capture path from the primary screenshot workflow.
+
+## Remaining Spec-Alignment / Release Notes
+
+These items were reviewed during the release-hardening audit and were left as documented limitations rather than changed in this pass:
+
+- If a user removes or invalidates their OpenAI API key while a recording is already in progress, BugNarrator still does not preserve that finished audio for a later transcription retry. The user must restore the key and record the session again.

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -7,6 +7,7 @@
 - Drag `BugNarrator.app` to `Applications` and launch that installed copy once.
 - Build and run `BugNarrator` from Xcode.
 - Confirm the menu bar item appears after launch.
+- Confirm the first launch does not trigger an unexpected Keychain or admin-style credential prompt before you open Settings or start a key-dependent action.
 - Confirm the menu bar explains that the app requires the user's own OpenAI API key.
 - Open Settings and verify the onboarding copy explains that OpenAI usage may incur charges.
 - Verify the OpenAI API key can be entered, remains masked, and shows a secure-storage note.
@@ -84,6 +85,7 @@
 - Delete a session from the row context menu and verify the same behavior.
 - Delete a session that contains screenshots and verify the app warns that local screenshots will also be removed.
 - Verify exported files outside BugNarrator remain untouched after deleting the session.
+- After deleting the selected session, verify GitHub and Jira export actions are no longer available for that removed session state.
 
 ## Issue Extraction Workflow
 
@@ -129,15 +131,17 @@
 - Start recording, remove the OpenAI API key from Settings, then stop the session.
   Expected: the app fails gracefully, explains that the key is missing, and remains usable for the next session.
 - Deny microphone permission and attempt to start a session.
-  Expected: recording does not start and the error explains how to re-enable access in System Settings.
+  Expected: recording does not start, the error explains how to re-enable access in System Settings, and `Open Microphone Settings` opens the expected privacy pane or a safe fallback.
 - Capture a screenshot without Screen Recording permission.
-  Expected: recording continues and BugNarrator shows a screenshot-specific error.
+  Expected: recording continues, BugNarrator shows a screenshot-specific error, and `Open Screen Recording Settings` opens the expected privacy pane or a safe fallback.
 - Delete or move a saved screenshot file outside the app, then open it from the session detail view.
   Expected: BugNarrator explains that the local screenshot file is no longer available instead of failing silently.
 - Disconnect networking or force a timeout during transcription.
   Expected: transcription ends in a clear timeout or API error state and the app returns to a usable state.
 - Use an invalid OpenAI API key.
-  Expected: transcription or issue extraction ends in a clear invalid-key error and Settings opens.
+  Expected: transcription or issue extraction ends in a clear invalid-key error, Settings opens, and the menu bar offers a direct `Open Settings` recovery action.
+- Simulate a local history write failure after a successful transcription if practical.
+  Expected: the transcript window still opens, the completed session remains available as an unsaved session, screenshots remain accessible, and `Save to History` can be retried later after storage is fixed.
 - Cancel an active recording.
   Expected: discard confirmation appears first, then the session returns to `Idle` with no stale timer.
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -10,7 +10,9 @@ Use this checklist before cutting a public test build or release candidate.
 - If shipping a signed build, verify the Apple signing team, bundle identifier, and entitlements are correct.
 - For a public download, use `Developer ID Application` signing rather than `Apple Development`.
 - If publishing broadly, notarize the DMG and staple the ticket before release.
+- Confirm the Release app bundle contains `Contents/Resources/AppIcon.icns` and `Contents/Resources/Assets.car`.
 - Launch the built app and confirm the menu bar item appears.
+- Confirm first launch does not trigger an unexpected Keychain prompt before the user opens Settings or starts a credential-dependent workflow.
 
 ## Core Product Workflow
 
@@ -39,6 +41,7 @@ Use this checklist before cutting a public test build or release candidate.
 ## Artifact And Persistence Safety
 
 - Quit and relaunch the app and confirm existing sessions reload correctly.
+- If local history storage fails after a successful transcription, confirm the transcript still opens as an unsaved session and can be saved later after storage is restored.
 - Delete a session with screenshots and verify the local managed screenshot folder is removed.
 - Confirm exported bundles outside the app remain untouched after deletion.
 - In non-debug mode, verify temporary audio files are cleaned up after success, failure, and cancellation.
@@ -51,13 +54,18 @@ Use this checklist before cutting a public test build or release candidate.
 - Confirm every link opens the expected external destination.
 - Review the README, user guide, changelog, and support links for stale wording or placeholder text.
 - Review the `Download` and `Support Development` sections in `README.md` for visibility and accuracy.
+- Confirm the top-of-README quick links for documentation, issue reporting, and support all work.
+- Delete a session from the library and confirm stale GitHub or Jira export actions are not still available for that removed selection.
 
 ## Before Publishing
 
 - Confirm no secrets, tokens, personal paths, or local-only files are tracked in git.
 - Review `.gitignore` for generated Xcode data and result bundles.
 - Upload `dist/BugNarrator-macOS.dmg` to the release and confirm the release asset name matches the README link strategy.
+- Open the final DMG and confirm Finder shows the branded BugNarrator icon instead of the generic macOS app placeholder.
+- Confirm the DMG contains `BugNarrator.app` plus the `Applications` shortcut and supports the normal drag-to-Applications install flow.
 - Run `xcrun stapler validate` on the final DMG.
-- Run `spctl -a -vv -t open` on the final DMG and confirm Gatekeeper accepts it.
+- Run `spctl -a -vv build/DerivedData/Build/Products/Release/BugNarrator.app` and confirm the notarized app is accepted.
+- If `spctl -a -vv -t open` on the local DMG reports `Insufficient Context`, treat that as a local-check limitation and verify the published download on a second Mac instead.
 - Run the automated test suite and confirm it passes.
 - Note any known limitations in the release notes or changelog before publishing.

--- a/docs/TESTING_NOTES.md
+++ b/docs/TESTING_NOTES.md
@@ -6,10 +6,10 @@
 - Build result: passed
 - Packaging command run: `./scripts/build_dmg.sh`
 - Packaging result: passed
-- Packaging validation: generated `dist/BugNarrator-v1.0-macOS.dmg` and `dist/BugNarrator-macOS.dmg`, mounted the DMG successfully, and verified it contains `BugNarrator.app` plus an `Applications` shortcut
+- Packaging validation: generated `dist/BugNarrator-v1.0.1-macOS.dmg` and `dist/BugNarrator-macOS.dmg`, mounted the DMG successfully, and verified it contains `BugNarrator.app` plus an `Applications` shortcut
 - Test command run: `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test`
 - Test result: passed
-- Test count: 69
+- Test count: 91
 
 ## What The Tests Cover
 
@@ -33,6 +33,7 @@
 - support window callback wiring and PayPal support-page URL dispatch
 - partial-success export failure reporting for GitHub and Jira issue creation
 - screenshot open failure handling that preserves app-state truthfulness during active sessions
+- ScreenCaptureKit screenshot metadata generation, output-directory creation, permission-denied handling, and repeated capture protection
 
 ## Manual Validation Still Required
 
@@ -43,9 +44,10 @@
 - real Jira Cloud export against a project you control
 - opening the generated DMG in Finder and validating the drag-to-Applications flow
 - visual review of the session library layout and menu bar UX
+- live multi-display screenshot capture with Screen Recording permission granted on the release build
 
 ## Notes
 
 - The automated suite does not exercise the live SwiftUI UI layer or AVFoundation microphone pipeline.
-- Screenshot capture still builds with one deprecation warning for `CGWindowListCreateImage`; migrating to ScreenCaptureKit remains future work.
+- Screenshot capture now uses ScreenCaptureKit on the app's supported macOS 14+ target. Permission prompting still relies on the macOS Screen Recording TCC helpers so the app can explain recovery steps before a capture attempt fails.
 - The unsigned build and test commands are intentional so the repo does not depend on a personal Apple signing team in project defaults.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -81,7 +81,7 @@ Markers let you flag moments that matter while the session is still running. The
 
 ### Screenshot Capture
 
-Use screenshot capture to save visual evidence during a review. Each screenshot is attached to the current session and can be associated with nearby markers.
+Use screenshot capture to save visual evidence during a review. On macOS 14 and later, BugNarrator uses ScreenCaptureKit for this capture path. Each screenshot is attached to the current session and can be associated with nearby markers.
 
 ### Review Summary
 
@@ -147,7 +147,8 @@ BugNarrator is free to use. Donations are optional and separate from any OpenAI 
 
 ### Microphone Permission Problems
 
-- open macOS System Settings
+- use BugNarrator's `Open Microphone Settings` button if it appears in the menu bar window
+- or open `System Settings > Privacy & Security > Microphone`
 - verify microphone permission is granted to BugNarrator
 - restart the app after changing permission settings if needed
 
@@ -156,11 +157,23 @@ BugNarrator is free to use. Donations are optional and separate from any OpenAI 
 - open `Settings`
 - paste your own OpenAI API key
 - click `Validate Key` if you want to check it before recording
+- BugNarrator stores the key in macOS Keychain when available
+
+### API Key Rejected Or Revoked
+
+- open `Settings`
+- replace the key or remove it and paste a new one
+- click `Validate Key`
+- try the session again after OpenAI accepts the new key
 
 ### Screenshots Not Appearing
 
 - confirm the session was actively recording when the screenshot was requested
+- use BugNarrator's `Open Screen Recording Settings` button if it appears in the menu bar window
+- or open `System Settings > Privacy & Security > Screen & System Audio Recording`
 - confirm Screen Recording permission is granted if macOS prompted for it
+- remember that this permission is only needed for screenshots; audio recording and transcription can still continue without it
+- remember that audio recording can continue even if screenshots are unavailable
 - try another screenshot to rule out a temporary storage failure
 
 ### Export Errors

--- a/project.yml
+++ b/project.yml
@@ -22,8 +22,8 @@ targets:
         PRODUCT_NAME: BugNarrator
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Resources/Info.plist
-        CURRENT_PROJECT_VERSION: 2
-        MARKETING_VERSION: 1.0.1
+        CURRENT_PROJECT_VERSION: 3
+        MARKETING_VERSION: 1.0.2
         CODE_SIGN_STYLE: Automatic
         ENABLE_HARDENED_RUNTIME: YES
   BugNarratorTests:

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -17,7 +17,20 @@ ALLOW_PROVISIONING_UPDATES="${ALLOW_PROVISIONING_UPDATES:-NO}"
 NOTARIZE="${NOTARIZE:-NO}"
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 VOLUME_NAME="${VOLUME_NAME:-BugNarrator}"
+APP_NAME="${APP_NAME:-BugNarrator}"
 MANUAL_DISTRIBUTION_SIGNING="NO"
+VERIFY_MOUNTPOINT=""
+
+cleanup_mountpoint() {
+    if [[ -n "$VERIFY_MOUNTPOINT" && -d "$VERIFY_MOUNTPOINT" ]]; then
+        if mount | grep -Fq "on $VERIFY_MOUNTPOINT "; then
+            hdiutil detach "$VERIFY_MOUNTPOINT" -quiet || true
+        fi
+        rmdir "$VERIFY_MOUNTPOINT" 2>/dev/null || true
+    fi
+}
+
+trap cleanup_mountpoint EXIT
 
 if [[ "$CODE_SIGN_IDENTITY" == Developer\ ID\ Application* && "$CODE_SIGN_STYLE" == "Automatic" ]]; then
     # Developer ID builds are direct-distribution builds and should not use
@@ -92,7 +105,7 @@ fi
 
 xcodebuild "${xcodebuild_args[@]}" build
 
-APP_PATH="$DERIVED_DATA_PATH/Build/Products/$CONFIGURATION/BugNarrator.app"
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/$CONFIGURATION/$APP_NAME.app"
 
 if [[ ! -d "$APP_PATH" ]]; then
     echo "error: built app not found at $APP_PATH" >&2
@@ -126,16 +139,28 @@ fi
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
 BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+APP_ICON_ICNS_PATH="$APP_PATH/Contents/Resources/AppIcon.icns"
+APP_ASSETS_CAR_PATH="$APP_PATH/Contents/Resources/Assets.car"
 
-VERSIONED_DMG_NAME="BugNarrator-v${VERSION}-macOS.dmg"
-STABLE_DMG_NAME="BugNarrator-macOS.dmg"
-TEMP_DMG_PATH="$OUTPUT_DIR/BugNarrator-temp.dmg"
+if [[ ! -f "$APP_ICON_ICNS_PATH" ]]; then
+    echo "error: expected app icon resource at $APP_ICON_ICNS_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$APP_ASSETS_CAR_PATH" ]]; then
+    echo "error: expected asset catalog resource at $APP_ASSETS_CAR_PATH" >&2
+    exit 1
+fi
+
+VERSIONED_DMG_NAME="${APP_NAME}-v${VERSION}-macOS.dmg"
+STABLE_DMG_NAME="${APP_NAME}-macOS.dmg"
+TEMP_DMG_PATH="$OUTPUT_DIR/${APP_NAME}-temp.dmg"
 VERSIONED_DMG_PATH="$OUTPUT_DIR/$VERSIONED_DMG_NAME"
 STABLE_DMG_PATH="$OUTPUT_DIR/$STABLE_DMG_NAME"
 
 rm -f "$TEMP_DMG_PATH" "$VERSIONED_DMG_PATH" "$STABLE_DMG_PATH"
 
-ditto "$APP_PATH" "$STAGING_DIR/BugNarrator.app"
+ditto "$APP_PATH" "$STAGING_DIR/$APP_NAME.app"
 ln -s /Applications "$STAGING_DIR/Applications"
 
 hdiutil create \
@@ -154,19 +179,60 @@ hdiutil convert \
 rm -f "$TEMP_DMG_PATH"
 rm -rf "$STAGING_DIR"
 
+VERIFY_MOUNTPOINT="$(mktemp -d "${TMPDIR:-/tmp}/${APP_NAME}-dmg-check.XXXXXX")"
+hdiutil attach "$VERSIONED_DMG_PATH" -readonly -nobrowse -mountpoint "$VERIFY_MOUNTPOINT" -quiet
+
+MOUNTED_APP_PATH="$VERIFY_MOUNTPOINT/$APP_NAME.app"
+MOUNTED_APPLICATIONS_LINK="$VERIFY_MOUNTPOINT/Applications"
+
+if [[ ! -d "$MOUNTED_APP_PATH" ]]; then
+    echo "error: mounted DMG does not contain $APP_NAME.app" >&2
+    exit 1
+fi
+
+if [[ ! -L "$MOUNTED_APPLICATIONS_LINK" ]]; then
+    echo "error: mounted DMG does not contain an Applications shortcut" >&2
+    exit 1
+fi
+
+if [[ ! -f "$MOUNTED_APP_PATH/Contents/Resources/AppIcon.icns" ]]; then
+    echo "error: mounted DMG app is missing AppIcon.icns" >&2
+    exit 1
+fi
+
+if [[ ! -f "$MOUNTED_APP_PATH/Contents/Resources/Assets.car" ]]; then
+    echo "error: mounted DMG app is missing Assets.car" >&2
+    exit 1
+fi
+
+cleanup_mountpoint
+VERIFY_MOUNTPOINT=""
+
 if [[ "$NOTARIZE" == "YES" ]]; then
     echo "Submitting DMG for notarization with profile '$NOTARY_PROFILE'..."
     xcrun notarytool submit "$VERSIONED_DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
     xcrun stapler staple -v "$VERSIONED_DMG_PATH"
     xcrun stapler validate "$VERSIONED_DMG_PATH"
+    if ! dmg_spctl_output="$(spctl -a -vv -t open "$VERSIONED_DMG_PATH" 2>&1)"; then
+        if [[ "$dmg_spctl_output" == *"Insufficient Context"* ]]; then
+            echo "warning: spctl could not fully assess the local DMG (Insufficient Context). This is expected for some locally built, non-quarantined disk images. Rely on stapler validation here and do a second-Mac download smoke test before publishing." >&2
+        else
+            printf '%s\n' "$dmg_spctl_output" >&2
+            exit 1
+        fi
+    else
+        printf '%s\n' "$dmg_spctl_output"
+    fi
+
     spctl -a -vv "$APP_PATH"
 fi
 
 cp "$VERSIONED_DMG_PATH" "$STABLE_DMG_PATH"
 
-echo "Built BugNarrator $VERSION ($BUILD_NUMBER)"
+echo "Built $APP_NAME $VERSION ($BUILD_NUMBER)"
 if [[ -n "$SIGNING_AUTHORITY" ]]; then
     echo "Signing authority: $SIGNING_AUTHORITY"
 fi
+echo "Release app: $APP_PATH"
 echo "Versioned DMG: $VERSIONED_DMG_PATH"
 echo "Stable DMG: $STABLE_DMG_PATH"


### PR DESCRIPTION
## Version
- Marketing version: `1.0.2`
- Build number: `3`

## What changed
- migrated screenshot capture to ScreenCaptureKit on macOS 14+ and preserved session screenshot metadata, marker proximity, and artifact paths
- improved permission and error recovery in the menu bar, including microphone recovery guidance and multiline status presentation
- hardened session persistence and stale-session export handling for GitHub and Jira flows
- simplified and aligned the support/donation flow, documentation, QA notes, and post-1.0 bug tracking
- added regression coverage for screenshot capture, status presentation, session library edge cases, and deferred secret access

## Validation
- `xcodegen generate`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Release CODE_SIGNING_ALLOWED=NO build`