### PR TITLE
Potential fix for code scanning alert no. 1: Cleartext storage of sensitive information in an application preference store

### DIFF
--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -11,6 +11,8 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    @Published var jiraEmailPersistenceState: SecretPersistenceState = .unknown
+
     @Published var preferredModel: String = "whisper-1" {
         didSet {
             guard hasLoaded else { return }
@@ -119,7 +121,7 @@ final class SettingsStore: ObservableObject {
     @Published var jiraEmail: String = "" {
         didSet {
             guard hasLoaded else { return }
-            defaults.set(jiraEmail, forKey: Keys.jiraEmail)
+            jiraEmailPersistenceState = persistSecret(jiraEmail, for: .jiraEmail)
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/deffenda/bugnarrator/security/code-scanning/1](https://github.com/deffenda/bugnarrator/security/code-scanning/1)

In general, to fix cleartext storage issues in `UserDefaults`, any value that can be considered sensitive (credentials, tokens, identifiers like emails when used for login) should not be stored directly in `UserDefaults`. Instead, you either: (1) avoid persisting it at all, or (2) persist it using an encrypted/secure storage mechanism (such as the Keychain, or an existing helper like `persistSecret`) and retrieve it via a corresponding load function. `UserDefaults` can still hold non‑sensitive configuration.

In this codebase, `apiKey` and `jiraAPIToken` already use a dedicated method `persistSecret(_:for:)` and corresponding state (`apiKeyPersistenceState`, `jiraTokenPersistenceState`) rather than writing to `defaults`. To maintain existing behavior and patterns, the best change is to treat `jiraEmail` similarly to `jiraAPIToken`: stop writing it directly to `defaults` and instead call `persistSecret(jiraEmail, for: .jiraEmail)` (or re-use an existing `.jira` case if that is how other Jira secrets are grouped), and track its persistence state in a dedicated property. This assumes that `persistSecret` and its enum of secret types can accept a new case for the Jira email; if not currently present, that case should be added where the enum is defined (outside the shown snippet). Within `SettingsStore.swift`, you’ll need to:

- Replace the `defaults.set(jiraEmail, forKey: Keys.jiraEmail)` call in the `jiraEmail` `didSet` with a call to `persistSecret`.
- Add a `@Published` property (e.g., `jiraEmailPersistenceState`) next to the other persistence state properties, consistent with how `apiKeyPersistenceState` and `jiraTokenPersistenceState` are modeled and used elsewhere in this file.
- Ensure that the initial loading of `jiraEmail` (not shown) is updated elsewhere in the codebase to read from the secure store that corresponds to `persistSecret` rather than from `UserDefaults` keyed by `Keys.jiraEmail`.

All changes within this file will be limited to the `jiraEmail` property and the addition of its persistence state; enum cases or helper implementations will need to be updated in their respective files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
