### PR TITLE
Promote lodash remediation and validator regressions

### DIFF
--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -6,7 +6,7 @@ This document is the human-readable roadmap companion to [state.json](state.json
 
 - current production app version: `1.0.22`
 - current in-progress phase: `RR-002 Windows Runtime Validation And Hardening`
-- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, and advanced OPS-012 with a pushed docs-site dependency-remediation commit, a passing hosted CI run, and a repo-local Node 22 wrapper for docs-site installs while the remaining RR-002 blocker stays real Windows desktop runtime validation
+- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, promoted the original OPS-012 remediation to `main`, and advanced the follow-up docs-site dependency work with a repo-local Node 22 wrapper plus a branch-local `lodash` `4.18.1` patch while the remaining RR-002 blocker stays real Windows desktop runtime validation
 
 ## Execution System
 
@@ -153,13 +153,13 @@ Priority: Medium
 
 Grouped risks:
 
-- GitHub reported four open Dependabot alerts on the default branch during push operations on April 4, 2026
+- GitHub still reports two open `lodash` Dependabot alerts on the default branch after the original four-alert remediation was promoted and verified on `main`
 
 Current execution slice:
 
-- patch the docs-site dependency tree with targeted overrides for `serialize-javascript`, `brace-expansion`, and the Express `path-to-regexp` line
-- validate the patched dependency graph with `npm ls`, a production Docusaurus build, hosted CI on `phase/bootstrap`, and the repo-local `./scripts/site_npm.sh` wrapper pinned to Node `v22.22.2`
-- keep the phase open until the remediation is promoted to the default branch and GitHub clears the default-branch alerts
+- patch the docs-site dependency tree with a `lodash` `4.18.1` override after the original `serialize-javascript`, `brace-expansion`, and Express `path-to-regexp` remediation cleared the first alert set on `main`
+- validate the patched dependency graph with `./scripts/site_npm.sh ls`, a production Docusaurus build, and a fresh hosted CI run on `phase/bootstrap`
+- keep the phase open until the follow-up `lodash` remediation is promoted to the default branch and GitHub clears the remaining alerts
 
 ## Upcoming Feature / Opportunity Phases
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -6,7 +6,7 @@ This document is the human-readable roadmap companion to [state.json](state.json
 
 - current production app version: `1.0.22`
 - current in-progress phase: `RR-002 Windows Runtime Validation And Hardening`
-- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, promoted the original OPS-012 remediation to `main`, and advanced the follow-up docs-site dependency work with a repo-local Node 22 wrapper plus a branch-local `lodash` `4.18.1` patch while the remaining RR-002 blocker stays real Windows desktop runtime validation
+- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, promoted the original OPS-012 remediation to `main`, and advanced the follow-up docs-site dependency work with a repo-local Node 22 wrapper plus a branch-local `lodash` `4.18.1` patch that now also has a passing hosted CI rerun while the remaining RR-002 blocker stays real Windows desktop runtime validation
 
 ## Execution System
 
@@ -158,8 +158,8 @@ Grouped risks:
 Current execution slice:
 
 - patch the docs-site dependency tree with a `lodash` `4.18.1` override after the original `serialize-javascript`, `brace-expansion`, and Express `path-to-regexp` remediation cleared the first alert set on `main`
-- validate the patched dependency graph with `./scripts/site_npm.sh ls`, a production Docusaurus build, and a fresh hosted CI run on `phase/bootstrap`
-- keep the phase open until the follow-up `lodash` remediation is promoted to the default branch and GitHub clears the remaining alerts
+- validate the patched dependency graph with `./scripts/site_npm.sh ls`, a production Docusaurus build, and the passing hosted CI run `23989366196` on `phase/bootstrap`
+- keep the phase open until the follow-up `lodash` remediation is promoted to the default branch and GitHub clears the remaining alerts there
 
 ## Upcoming Feature / Opportunity Phases
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -6,7 +6,7 @@ This document is the human-readable roadmap companion to [state.json](state.json
 
 - current production app version: `1.0.22`
 - current in-progress phase: `RR-002 Windows Runtime Validation And Hardening`
-- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, promoted the original OPS-012 remediation to `main`, and advanced the follow-up docs-site dependency work with a repo-local Node 22 wrapper plus a branch-local `lodash` `4.18.1` patch that now also has a passing hosted CI rerun while the remaining RR-002 blocker stays real Windows desktop runtime validation
+- phase outcome so far: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real hardware runtime validation, completed the hosted Node24 workflow validation slice, promoted the original OPS-012 remediation to `main`, and advanced the follow-up docs-site dependency work with a repo-local Node 22 wrapper, a branch-local `lodash` `4.18.1` patch, and direct runtime-guardrails regression tests while the remaining RR-002 blocker stays real Windows desktop runtime validation
 
 ## Execution System
 
@@ -158,7 +158,7 @@ Grouped risks:
 Current execution slice:
 
 - patch the docs-site dependency tree with a `lodash` `4.18.1` override after the original `serialize-javascript`, `brace-expansion`, and Express `path-to-regexp` remediation cleared the first alert set on `main`
-- validate the patched dependency graph with `./scripts/site_npm.sh ls`, a production Docusaurus build, and the passing hosted CI run `23989366196` on `phase/bootstrap`
+- validate the patched dependency graph with `./scripts/site_npm.sh ls`, a production Docusaurus build, the passing hosted CI run `23989366196` on `phase/bootstrap`, and direct runtime-guardrails regression tests
 - keep the phase open until the follow-up `lodash` remediation is promoted to the default branch and GitHub clears the remaining alerts there
 
 ## Upcoming Feature / Opportunity Phases

--- a/docs/roadmap/state.json
+++ b/docs/roadmap/state.json
@@ -401,7 +401,7 @@
       "description": "After the first default-branch remediation landed, GitHub still reported two open lodash Dependabot alerts on site/package-lock.json on 2026-04-04 (1 high, 1 moderate).",
       "severity": "medium",
       "impact": "The default branch remains exposed to the remaining lodash vulnerabilities until the follow-up dependency remediation is validated and promoted.",
-      "mitigation": "Track in OPS-012. phase/bootstrap now includes the lodash 4.18.1 override, synced state, and a passing hosted CI run 23989366196 on commit 40ddf31, but the default-branch promotion and alert-closure confirmation still remain.",
+      "mitigation": "Track in OPS-012. phase/bootstrap now includes the lodash 4.18.1 override, synced state, validator regression tests for the guardrails that previously blocked the branch, and a passing hosted CI run 23989366196 on commit 40ddf31, but the default-branch promotion and alert-closure confirmation still remain.",
       "affected_components": [
         "dependencies",
         "site",
@@ -504,10 +504,10 @@
     "name": "Windows Runtime Validation And Hardening",
     "status": "in_progress",
     "started_on": "2026-03-24",
-    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 has now promoted the original dependency remediation to main, cleared the first Dependabot alert set there, and replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper. The active OPS-012 follow-up is the branch-local lodash 4.18.1 remediation, which now has passing local dependency-tree, docs-site build, and hosted CI validation and only needs default-branch promotion plus alert-closure confirmation."
+    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 has now promoted the original dependency remediation to main, cleared the first Dependabot alert set there, and replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper. The active OPS-012 follow-up is the branch-local lodash 4.18.1 remediation, which now has passing local dependency-tree, docs-site build, runtime-guardrails regression-test, and hosted CI validation and only needs default-branch promotion plus alert-closure confirmation."
   },
   "current_phase_branch": "phase/bootstrap",
-  "last_updated": "2026-04-04",
+  "last_updated": "2026-04-05",
   "tasks": {
     "active": [
       "RR-002-T4",
@@ -667,6 +667,10 @@
     {
       "date": "2026-04-04",
       "summary": "After syncing the canonical state files, reran hosted CI successfully on commit 40ddf31 and closed the tracked-branch validation step for the follow-up lodash remediation, leaving only the default-branch promotion and alert-closure confirmation open."
+    },
+    {
+      "date": "2026-04-05",
+      "summary": "Added direct runtime-guardrails regression tests for the FAIL evidence, NOT RUN evidence, and missing-state-update rules before promoting the remaining lodash remediation, so the exact branch-blocking validator behavior is now covered by local test execution."
     }
   ],
   "version": "1.0.22",

--- a/docs/roadmap/state.json
+++ b/docs/roadmap/state.json
@@ -401,7 +401,7 @@
       "description": "After the first default-branch remediation landed, GitHub still reported two open lodash Dependabot alerts on site/package-lock.json on 2026-04-04 (1 high, 1 moderate).",
       "severity": "medium",
       "impact": "The default branch remains exposed to the remaining lodash vulnerabilities until the follow-up dependency remediation is validated and promoted.",
-      "mitigation": "Track in OPS-012. phase/bootstrap now includes a lodash 4.18.1 override plus passing local dependency-tree and docs-site build validation, but the hosted CI rerun and default-branch promotion still remain.",
+      "mitigation": "Track in OPS-012. phase/bootstrap now includes the lodash 4.18.1 override, synced state, and a passing hosted CI run 23989366196 on commit 40ddf31, but the default-branch promotion and alert-closure confirmation still remain.",
       "affected_components": [
         "dependencies",
         "site",
@@ -504,14 +504,14 @@
     "name": "Windows Runtime Validation And Hardening",
     "status": "in_progress",
     "started_on": "2026-03-24",
-    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 has now promoted the original dependency remediation to main, cleared the first Dependabot alert set there, and replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper. The active OPS-012 follow-up is the new branch-local lodash 4.18.1 remediation, which passed local dependency-tree and docs-site build validation and now needs a clean hosted CI rerun plus default-branch promotion."
+    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 has now promoted the original dependency remediation to main, cleared the first Dependabot alert set there, and replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper. The active OPS-012 follow-up is the branch-local lodash 4.18.1 remediation, which now has passing local dependency-tree, docs-site build, and hosted CI validation and only needs default-branch promotion plus alert-closure confirmation."
   },
   "current_phase_branch": "phase/bootstrap",
   "last_updated": "2026-04-04",
   "tasks": {
     "active": [
       "RR-002-T4",
-      "OPS-012-T5"
+      "OPS-012-T6"
     ],
     "completed": [
       "OPS-011-T1",
@@ -531,7 +531,8 @@
       "OPS-012-T1",
       "OPS-012-T2",
       "OPS-012-T3",
-      "OPS-012-T4"
+      "OPS-012-T4",
+      "OPS-012-T5"
     ]
   },
   "decisions": [
@@ -662,6 +663,10 @@
     {
       "date": "2026-04-04",
       "summary": "Split the two newly surfaced lodash Dependabot alerts into a follow-up OPS-012 slice, pinned lodash to the non-deprecated patched release 4.18.1, and treated the initial hosted CI failure on commit 64633e9 as a guardrail-enforced state-sync miss rather than a code regression."
+    },
+    {
+      "date": "2026-04-04",
+      "summary": "After syncing the canonical state files, reran hosted CI successfully on commit 40ddf31 and closed the tracked-branch validation step for the follow-up lodash remediation, leaving only the default-branch promotion and alert-closure confirmation open."
     }
   ],
   "version": "1.0.22",

--- a/docs/roadmap/state.json
+++ b/docs/roadmap/state.json
@@ -150,7 +150,7 @@
       "name": "Dependency Alert Remediation",
       "priority": "medium",
       "grouped_risks": [
-        "RISK-SEC-001"
+        "RISK-SEC-002"
       ],
       "scope": "Review and remediate the open Dependabot alerts on the default branch, validate the patched dependency graph on the tracked branch, and promote the remediation so GitHub clears the default-branch alerts."
     }
@@ -387,10 +387,24 @@
       "description": "GitHub reported four open Dependabot alerts on the default branch during push operations on 2026-04-04 (2 high, 2 moderate).",
       "severity": "medium",
       "impact": "Open dependency vulnerabilities can leave the repo and release workflows exposed until the affected packages or action pins are remediated and revalidated.",
-      "mitigation": "Track in OPS-012. The phase/bootstrap branch now patches the docs-site dependency graph locally with targeted overrides and verified build evidence, but the risk remains open until the remediation is merged to the default branch and the hosted CI/default-branch alert state is revalidated.",
+      "mitigation": "Resolved in OPS-012 by merging PR #6 into main at merge commit dc7a66aa7b2fc42a0b05edddec6169c0f6a88135 and rechecking the GitHub Dependabot alert API, which no longer showed the original four default-branch alerts on 2026-04-04.",
       "affected_components": [
         "github-workflows",
         "dependencies",
+        "default-branch"
+      ],
+      "phase_association": "OPS-012",
+      "status": "resolved"
+    },
+    {
+      "id": "RISK-SEC-002",
+      "description": "After the first default-branch remediation landed, GitHub still reported two open lodash Dependabot alerts on site/package-lock.json on 2026-04-04 (1 high, 1 moderate).",
+      "severity": "medium",
+      "impact": "The default branch remains exposed to the remaining lodash vulnerabilities until the follow-up dependency remediation is validated and promoted.",
+      "mitigation": "Track in OPS-012. phase/bootstrap now includes a lodash 4.18.1 override plus passing local dependency-tree and docs-site build validation, but the hosted CI rerun and default-branch promotion still remain.",
+      "affected_components": [
+        "dependencies",
+        "site",
         "default-branch"
       ],
       "phase_association": "OPS-012",
@@ -490,14 +504,14 @@
     "name": "Windows Runtime Validation And Hardening",
     "status": "in_progress",
     "started_on": "2026-03-24",
-    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 now has a pushed dependency-remediation commit, a passing hosted CI run (23988782016), and a repo-local Node 22 wrapper that replaces the broken system npm 11 / Node 25 docs-site install path. The remaining OPS-012 follow-up is promoting the dependency patch to the default branch so the Dependabot alerts can close there."
+    "summary": "RR-002 remains blocked on real Windows desktop runtime validation while OPS-012 has now promoted the original dependency remediation to main, cleared the first Dependabot alert set there, and replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper. The active OPS-012 follow-up is the new branch-local lodash 4.18.1 remediation, which passed local dependency-tree and docs-site build validation and now needs a clean hosted CI rerun plus default-branch promotion."
   },
   "current_phase_branch": "phase/bootstrap",
   "last_updated": "2026-04-04",
   "tasks": {
     "active": [
       "RR-002-T4",
-      "OPS-012-T4"
+      "OPS-012-T5"
     ],
     "completed": [
       "OPS-011-T1",
@@ -516,7 +530,8 @@
       "OPS-011-T2",
       "OPS-012-T1",
       "OPS-012-T2",
-      "OPS-012-T3"
+      "OPS-012-T3",
+      "OPS-012-T4"
     ]
   },
   "decisions": [
@@ -639,6 +654,14 @@
     {
       "date": "2026-04-04",
       "summary": "Closed OPS-012-T3 by replacing the broken system npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper aligned to the docs-site CI runtime, then validated npm ci and the production site build through that pinned toolchain."
+    },
+    {
+      "date": "2026-04-04",
+      "summary": "Promoted the original OPS-012 remediation to main via PR #6, verified the original four default-branch Dependabot alerts were gone, and closed that cleared alert set as RISK-SEC-001 instead of leaving it open after promotion."
+    },
+    {
+      "date": "2026-04-04",
+      "summary": "Split the two newly surfaced lodash Dependabot alerts into a follow-up OPS-012 slice, pinned lodash to the non-deprecated patched release 4.18.1, and treated the initial hosted CI failure on commit 64633e9 as a guardrail-enforced state-sync miss rather than a code regression."
     }
   ],
   "version": "1.0.22",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,19 +14,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
-      "overrides": {
-        "copy-webpack-plugin": {
-          "serialize-javascript": "7.0.5"
-        },
-        "css-minimizer-webpack-plugin": {
-          "serialize-javascript": "7.0.5"
-        },
-        "express": {
-          "path-to-regexp": "0.1.13"
-        },
-        "minimatch": {
-          "brace-expansion": "1.1.13"
-        }
+      "engines": {
+        "node": ">=22 <25"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -10471,9 +10460,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/site/package.json
+++ b/site/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0"
   },
   "overrides": {
+    "lodash": "4.18.1",
     "copy-webpack-plugin": {
       "serialize-javascript": "7.0.5"
     },

--- a/state/decisions.json
+++ b/state/decisions.json
@@ -1,5 +1,5 @@
 {
-  "updated_on": "2026-04-04",
+  "updated_on": "2026-04-05",
   "entries": [
     {
       "date": "2026-03-24",
@@ -100,6 +100,11 @@
       "date": "2026-04-04",
       "phase": "OPS-012",
       "summary": "Kept the initial hosted CI failure on commit 64633e9 as evidence of the guardrail catching stale state, synced the canonical state files, and then reran hosted CI successfully on commit 40ddf31 before leaving only the default-branch promotion step open."
+    },
+    {
+      "date": "2026-04-05",
+      "phase": "OPS-012",
+      "summary": "Before promoting the remaining lodash remediation, added direct regression tests for the runtime-guardrails rules that had already blocked live branch pushes: FAIL evidence risk mapping, NOT RUN evidence handling, and mandatory canonical state updates after code changes."
     }
   ]
 }

--- a/state/decisions.json
+++ b/state/decisions.json
@@ -95,6 +95,11 @@
       "date": "2026-04-04",
       "phase": "OPS-012",
       "summary": "Split the two newly surfaced default-branch lodash alerts into a new follow-up risk and task inside OPS-012, and pinned lodash to the non-deprecated patched release 4.18.1 after 4.18.0 reported a registry deprecation notice during the first branch-local test."
+    },
+    {
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "summary": "Kept the initial hosted CI failure on commit 64633e9 as evidence of the guardrail catching stale state, synced the canonical state files, and then reran hosted CI successfully on commit 40ddf31 before leaving only the default-branch promotion step open."
     }
   ]
 }

--- a/state/decisions.json
+++ b/state/decisions.json
@@ -85,6 +85,16 @@
       "date": "2026-04-04",
       "phase": "OPS-012",
       "summary": "Replaced the broken local npm 11 / Node 25 docs-site install path with a repo-local Node 22 wrapper pinned in site/.node-version, then validated a clean docs-site reinstall and production build through that path before closing the environment risk."
+    },
+    {
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "summary": "Promoted the original OPS-012 remediation to main via PR #6, verified the original four default-branch Dependabot alerts were gone, and closed RISK-SEC-001 instead of leaving the already-cleared alert set open."
+    },
+    {
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "summary": "Split the two newly surfaced default-branch lodash alerts into a new follow-up risk and task inside OPS-012, and pinned lodash to the non-deprecated patched release 4.18.1 after 4.18.0 reported a registry deprecation notice during the first branch-local test."
     }
   ]
 }

--- a/state/risks.json
+++ b/state/risks.json
@@ -42,6 +42,13 @@
       "status": "resolved",
       "assigned_phase": "OPS-012",
       "note": "Resolved by adding site/.node-version pinned to v22.22.2 and scripts/site_npm.sh, then validating ./scripts/site_npm.sh ci --ignore-scripts --no-audit --no-fund and ./scripts/site_npm.sh run build successfully on this machine."
+    },
+    {
+      "id": "RISK-SEC-001",
+      "severity": "medium",
+      "status": "resolved",
+      "assigned_phase": "OPS-012",
+      "note": "Resolved by merging PR #6 into main at merge commit dc7a66aa7b2fc42a0b05edddec6169c0f6a88135 and confirming the original four default-branch Dependabot alerts were no longer open in the GitHub alert API response on 2026-04-04."
     }
   ],
   "unresolved": [
@@ -67,11 +74,11 @@
       "note": "Live VoiceOver and hosted docs-site accessibility validation still remain for a later remediation phase."
     },
     {
-      "id": "RISK-SEC-001",
+      "id": "RISK-SEC-002",
       "severity": "medium",
       "status": "unresolved",
       "assigned_phase": "OPS-012",
-      "note": "phase/bootstrap now contains the docs-site dependency remediation commit 5369212, the repo-local Node 22 wrapper for local docs-site installs, and a passing hosted CI run 23988782016 on the branch commit before the wrapper sync. The remaining work is to promote the dependency remediation to the default branch and confirm GitHub clears the four Dependabot alerts there."
+      "note": "After the original four alerts were cleared on main, GitHub still reported two open lodash alerts on the default branch (#6 high, #5 medium). phase/bootstrap now contains commit 64633e9 with a lodash 4.18.1 override plus passing local dependency-tree and docs-site build validation, but the follow-up hosted CI rerun and default-branch promotion still remain."
     }
   ]
 }

--- a/state/risks.json
+++ b/state/risks.json
@@ -78,7 +78,7 @@
       "severity": "medium",
       "status": "unresolved",
       "assigned_phase": "OPS-012",
-      "note": "After the original four alerts were cleared on main, GitHub still reported two open lodash alerts on the default branch (#6 high, #5 medium). phase/bootstrap now contains commit 64633e9 with a lodash 4.18.1 override plus passing local dependency-tree and docs-site build validation, but the follow-up hosted CI rerun and default-branch promotion still remain."
+      "note": "After the original four alerts were cleared on main, GitHub still reported two open lodash alerts on the default branch (#6 high, #5 medium). phase/bootstrap now contains the lodash 4.18.1 override, synced phase state, and a passing hosted CI run 23989366196 on commit 40ddf31; the remaining work is promoting that follow-up remediation to the default branch and confirming the alerts close there."
     }
   ]
 }

--- a/state/risks.json
+++ b/state/risks.json
@@ -1,5 +1,5 @@
 {
-  "updated_on": "2026-04-04",
+  "updated_on": "2026-04-05",
   "resolved": [
     {
       "id": "RISK-WIN-003",
@@ -78,7 +78,7 @@
       "severity": "medium",
       "status": "unresolved",
       "assigned_phase": "OPS-012",
-      "note": "After the original four alerts were cleared on main, GitHub still reported two open lodash alerts on the default branch (#6 high, #5 medium). phase/bootstrap now contains the lodash 4.18.1 override, synced phase state, and a passing hosted CI run 23989366196 on commit 40ddf31; the remaining work is promoting that follow-up remediation to the default branch and confirming the alerts close there."
+      "note": "After the original four alerts were cleared on main, GitHub still reported two open lodash alerts on the default branch (#6 high, #5 medium). phase/bootstrap now contains the lodash 4.18.1 override, synced phase state, validator regression coverage for the runtime guardrails rules, and a passing hosted CI run 23989366196 on commit 40ddf31; the remaining work is promoting that follow-up remediation to the default branch and confirming the alerts close there."
     }
   ]
 }

--- a/state/session.json
+++ b/state/session.json
@@ -1,5 +1,5 @@
 {
-  "updated_on": "2026-04-04",
+  "updated_on": "2026-04-05",
   "phase": {
     "id": "OPS-012",
     "name": "Dependency Alert Remediation",
@@ -11,7 +11,7 @@
     "status": "blocked"
   },
   "branch": "phase/bootstrap",
-  "execution_summary": "RR-002 remains blocked on real Windows runtime validation. OPS-012 has already promoted the original dependency remediation to main and cleared that first alert set there, and the current follow-up slice now carries a branch-local lodash 4.18.1 patch with passing local plus hosted branch validation. The remaining work is promoting that follow-up remediation to the default branch so the two remaining lodash alerts can close there.",
+  "execution_summary": "RR-002 remains blocked on real Windows runtime validation. OPS-012 has already promoted the original dependency remediation to main and cleared that first alert set there, and the current follow-up slice now carries a branch-local lodash 4.18.1 patch plus validator regression coverage for the guardrails that previously blocked this branch. The remaining work is promoting that follow-up remediation to the default branch so the two remaining lodash alerts can close there.",
   "evidence": [
     {
       "id": "BOOTSTRAP-E1",
@@ -312,6 +312,26 @@
       "command": "GitHub Actions CI run 23989366196 on phase/bootstrap commit 40ddf31",
       "result": "PASS",
       "summary": "Hosted CI passed after syncing the canonical state files, including runtime-guardrails, docs-site validation, macOS validation, and Windows workspace validation."
+    },
+    {
+      "id": "OPS-012-E14",
+      "date": "2026-04-05",
+      "phase": "OPS-012",
+      "scope": "runtime-guardrails-regression-tests",
+      "type": "test",
+      "command": "node --test tools/validators/enforce-runtime-guardrails.test.js",
+      "result": "PASS",
+      "summary": "Validated five runtime-guardrails regression tests covering FAIL evidence, NOT RUN evidence, and missing state-update enforcement."
+    },
+    {
+      "id": "OPS-012-E15",
+      "date": "2026-04-05",
+      "phase": "OPS-012",
+      "scope": "runtime-guardrails-validator",
+      "type": "validation",
+      "command": "node tools/validators/enforce-runtime-guardrails.js --base-ref origin/main",
+      "result": "PASS",
+      "summary": "Validated the branch-local state sync and validator changes against origin/main before pushing the remaining lodash-remediation promotion work."
     }
   ]
 }

--- a/state/session.json
+++ b/state/session.json
@@ -11,7 +11,7 @@
     "status": "blocked"
   },
   "branch": "phase/bootstrap",
-  "execution_summary": "RR-002 remains blocked on real Windows runtime validation. OPS-012 has already promoted the original dependency remediation to main and cleared that first alert set there, and the current follow-up slice now carries a branch-local lodash 4.18.1 patch with passing local docs-site validation while the remaining work is a clean hosted CI rerun plus default-branch promotion for the new alert pair.",
+  "execution_summary": "RR-002 remains blocked on real Windows runtime validation. OPS-012 has already promoted the original dependency remediation to main and cleared that first alert set there, and the current follow-up slice now carries a branch-local lodash 4.18.1 patch with passing local plus hosted branch validation. The remaining work is promoting that follow-up remediation to the default branch so the two remaining lodash alerts can close there.",
   "evidence": [
     {
       "id": "BOOTSTRAP-E1",
@@ -302,6 +302,16 @@
         "RISK-SEC-002"
       ],
       "summary": "Hosted CI failed immediately in runtime-guardrails because the canonical state files had not yet been updated after the new lodash remediation work."
+    },
+    {
+      "id": "OPS-012-E13",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "github-hosted-ci",
+      "type": "validation",
+      "command": "GitHub Actions CI run 23989366196 on phase/bootstrap commit 40ddf31",
+      "result": "PASS",
+      "summary": "Hosted CI passed after syncing the canonical state files, including runtime-guardrails, docs-site validation, macOS validation, and Windows workspace validation."
     }
   ]
 }

--- a/state/session.json
+++ b/state/session.json
@@ -11,7 +11,7 @@
     "status": "blocked"
   },
   "branch": "phase/bootstrap",
-  "execution_summary": "RR-002 remains blocked on real Windows runtime validation, so OPS-012 now includes a repo-local Node 22 wrapper that replaces the broken system npm 11 / Node 25 docs-site install path. The dependency remediation stays in progress only for default-branch promotion and Dependabot alert closure.",
+  "execution_summary": "RR-002 remains blocked on real Windows runtime validation. OPS-012 has already promoted the original dependency remediation to main and cleared that first alert set there, and the current follow-up slice now carries a branch-local lodash 4.18.1 patch with passing local docs-site validation while the remaining work is a clean hosted CI rerun plus default-branch promotion for the new alert pair.",
   "evidence": [
     {
       "id": "BOOTSTRAP-E1",
@@ -249,6 +249,59 @@
       "command": "./scripts/site_npm.sh run build",
       "result": "PASS",
       "summary": "Validated the production Docusaurus build through the repo-local Node 22 wrapper."
+    },
+    {
+      "id": "OPS-012-E8",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "default-branch-promotion",
+      "type": "validation",
+      "command": "gh pr view 6 --json state,mergedAt,mergeCommit",
+      "result": "PASS",
+      "summary": "Confirmed PR #6 merged phase/bootstrap into main at merge commit dc7a66aa7b2fc42a0b05edddec6169c0f6a88135, promoting the original dependency remediation and workflow hardening to the default branch."
+    },
+    {
+      "id": "OPS-012-E9",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "default-branch-alert-audit",
+      "type": "validation",
+      "command": "gh api repos/deffenda/bug-narrator/dependabot/alerts --paginate --jq '[.[] | select(.state==\"open\") | {number:.number, dependency:.dependency.package.name, manifest:.dependency.manifest_path, severity:.security_advisory.severity}]'",
+      "result": "PASS",
+      "summary": "Confirmed the original four Dependabot alerts no longer appeared on the default branch and identified only the two remaining lodash alerts (#6 high, #5 medium)."
+    },
+    {
+      "id": "OPS-012-E10",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "site-dependency-tree",
+      "type": "validation",
+      "command": "./scripts/site_npm.sh ls path-to-regexp serialize-javascript brace-expansion lodash",
+      "result": "PASS",
+      "summary": "Confirmed the docs-site dependency tree now resolves serialize-javascript 7.0.5, brace-expansion 1.1.13, express path-to-regexp 0.1.13, and lodash 4.18.1 on the branch."
+    },
+    {
+      "id": "OPS-012-E11",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "docs-site",
+      "type": "build",
+      "command": "./scripts/site_npm.sh run build",
+      "result": "PASS",
+      "summary": "Validated a production Docusaurus build after adding the lodash 4.18.1 override."
+    },
+    {
+      "id": "OPS-012-E12",
+      "date": "2026-04-04",
+      "phase": "OPS-012",
+      "scope": "github-hosted-ci",
+      "type": "validation",
+      "command": "GitHub Actions CI run 23989339794 on phase/bootstrap commit 64633e9",
+      "result": "FAIL",
+      "risk_ids": [
+        "RISK-SEC-002"
+      ],
+      "summary": "Hosted CI failed immediately in runtime-guardrails because the canonical state files had not yet been updated after the new lodash remediation work."
     }
   ]
 }

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -9,9 +9,9 @@
       "blocking_for_phase_completion": true
     },
     {
-      "id": "OPS-012-T4",
+      "id": "OPS-012-T5",
       "phase": "OPS-012",
-      "title": "Promote the dependency remediation to the default branch and confirm the Dependabot alerts close there",
+      "title": "Patch the newly surfaced lodash Dependabot alerts on the tracked branch and validate the updated dependency graph locally plus in hosted CI",
       "status": "pending",
       "blocking_for_phase_completion": true
     }
@@ -117,6 +117,12 @@
       "id": "OPS-012-T3",
       "phase": "OPS-012",
       "title": "Stabilize or replace the local npm install path after the Node 25 / npm 11 EBADF registry-fetch failure",
+      "status": "completed"
+    },
+    {
+      "id": "OPS-012-T4",
+      "phase": "OPS-012",
+      "title": "Promote the dependency remediation to the default branch and confirm the Dependabot alerts close there",
       "status": "completed"
     }
   ]

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -9,9 +9,9 @@
       "blocking_for_phase_completion": true
     },
     {
-      "id": "OPS-012-T5",
+      "id": "OPS-012-T6",
       "phase": "OPS-012",
-      "title": "Patch the newly surfaced lodash Dependabot alerts on the tracked branch and validate the updated dependency graph locally plus in hosted CI",
+      "title": "Promote the lodash remediation to the default branch and confirm the remaining Dependabot alerts close there",
       "status": "pending",
       "blocking_for_phase_completion": true
     }
@@ -123,6 +123,12 @@
       "id": "OPS-012-T4",
       "phase": "OPS-012",
       "title": "Promote the dependency remediation to the default branch and confirm the Dependabot alerts close there",
+      "status": "completed"
+    },
+    {
+      "id": "OPS-012-T5",
+      "phase": "OPS-012",
+      "title": "Patch the newly surfaced lodash Dependabot alerts on the tracked branch and validate the updated dependency graph locally plus in hosted CI",
       "status": "completed"
     }
   ]

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,5 +1,5 @@
 {
-  "updated_on": "2026-04-04",
+  "updated_on": "2026-04-05",
   "active": [
     {
       "id": "RR-002-T4",

--- a/tools/validators/enforce-runtime-guardrails.js
+++ b/tools/validators/enforce-runtime-guardrails.js
@@ -4,7 +4,9 @@ const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
-const repoRoot = path.resolve(__dirname, "..", "..");
+const repoRoot = process.env.RUNTIME_GUARDRAILS_REPO_ROOT
+  ? path.resolve(process.env.RUNTIME_GUARDRAILS_REPO_ROOT)
+  : path.resolve(__dirname, "..", "..");
 process.chdir(repoRoot);
 
 const failures = [];

--- a/tools/validators/enforce-runtime-guardrails.test.js
+++ b/tools/validators/enforce-runtime-guardrails.test.js
@@ -165,6 +165,25 @@ function buildFixtureRoot() {
   return fixtureRoot;
 }
 
+function writeFixtureSession(fixtureRoot, evidence, phase = { id: "OPS-TEST", name: "Validator Fixture" }) {
+  writeJson(path.join(fixtureRoot, "state", "session.json"), {
+    updated_on: "2026-04-04",
+    phase: {
+      id: phase.id,
+      name: phase.name,
+      status: "in_progress"
+    },
+    roadmap_phase_context: {
+      id: phase.id,
+      name: phase.name,
+      status: "in_progress"
+    },
+    branch: "main",
+    execution_summary: "Fixture summary.",
+    evidence
+  });
+}
+
 function runValidator(fixtureRoot) {
   try {
     const stdout = execFileSync("node", [validatorPath], {
@@ -191,33 +210,18 @@ test("validator fails when FAIL evidence omits risk_ids", () => {
   const fixtureRoot = buildFixtureRoot();
 
   writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
-  writeJson(path.join(fixtureRoot, "state", "session.json"), {
-    updated_on: "2026-04-04",
-    phase: {
-      id: "OPS-TEST",
-      name: "Validator Fixture",
-      status: "in_progress"
-    },
-    roadmap_phase_context: {
-      id: "OPS-TEST",
-      name: "Validator Fixture",
-      status: "in_progress"
-    },
-    branch: "main",
-    execution_summary: "Fixture summary.",
-    evidence: [
-      {
-        id: "OPS-TEST-E1",
-        date: "2026-04-04",
-        phase: "OPS-TEST",
-        scope: "fixture-validation",
-        type: "validation",
-        command: "node tools/validators/enforce-runtime-guardrails.js",
-        result: "FAIL",
-        summary: "Missing risk IDs should fail validation."
-      }
-    ]
-  });
+  writeFixtureSession(fixtureRoot, [
+    {
+      id: "OPS-TEST-E1",
+      date: "2026-04-04",
+      phase: "OPS-TEST",
+      scope: "fixture-validation",
+      type: "validation",
+      command: "node tools/validators/enforce-runtime-guardrails.js",
+      result: "FAIL",
+      summary: "Missing risk IDs should fail validation."
+    }
+  ]);
 
   const result = runValidator(fixtureRoot);
   assert.equal(result.status, 1);
@@ -231,36 +235,111 @@ test("validator passes when FAIL evidence includes risk_ids", () => {
   const fixtureRoot = buildFixtureRoot();
 
   writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
-  writeJson(path.join(fixtureRoot, "state", "session.json"), {
-    updated_on: "2026-04-04",
-    phase: {
-      id: "OPS-TEST",
-      name: "Validator Fixture",
-      status: "in_progress"
-    },
-    roadmap_phase_context: {
-      id: "OPS-TEST",
-      name: "Validator Fixture",
-      status: "in_progress"
-    },
-    branch: "main",
-    execution_summary: "Fixture summary.",
-    evidence: [
-      {
-        id: "OPS-TEST-E1",
-        date: "2026-04-04",
-        phase: "OPS-TEST",
-        scope: "fixture-validation",
-        type: "validation",
-        command: "node tools/validators/enforce-runtime-guardrails.js",
-        result: "FAIL",
-        risk_ids: ["RISK-TEST-001"],
-        summary: "Known failure with mapped risk."
-      }
-    ]
-  });
+  writeFixtureSession(fixtureRoot, [
+    {
+      id: "OPS-TEST-E1",
+      date: "2026-04-04",
+      phase: "OPS-TEST",
+      scope: "fixture-validation",
+      type: "validation",
+      command: "node tools/validators/enforce-runtime-guardrails.js",
+      result: "FAIL",
+      risk_ids: ["RISK-TEST-001"],
+      summary: "Known failure with mapped risk."
+    }
+  ]);
 
   const result = runValidator(fixtureRoot);
   assert.equal(result.status, 0);
   assert.match(result.output, /^PASS/m);
+});
+
+test("validator allows NOT RUN evidence without risk_ids in docs phases", () => {
+  const fixtureRoot = buildFixtureRoot();
+
+  writeJson(path.join(fixtureRoot, "docs", "roadmap", "state.json"), {
+    current_phase: {
+      id: "DOC-TEST",
+      name: "Documentation Follow-up",
+      status: "in_progress"
+    },
+    risk_remediation_phases: [
+      {
+        id: "OPS-TEST",
+        name: "Validator Fixture",
+        priority: "low",
+        grouped_risks: ["RISK-TEST-001"],
+        scope: "Fixture scope."
+      }
+    ],
+    upcoming_phases: [],
+    completed_phases: [],
+    opportunities: [],
+    incidents: [],
+    risks: [
+      {
+        id: "RISK-TEST-001",
+        description: "Fixture risk",
+        severity: "medium",
+        impact: "Fixture impact",
+        mitigation: "Fixture mitigation",
+        affected_components: ["tests"],
+        phase_association: "OPS-TEST",
+        status: "unresolved"
+      }
+    ],
+    tasks: {
+      active: ["OPS-TEST-T1"],
+      completed: []
+    },
+    decisions: [],
+    last_updated: "2026-04-04"
+  });
+
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
+  writeFixtureSession(
+    fixtureRoot,
+    [
+      {
+        id: "DOC-TEST-E1",
+        date: "2026-04-04",
+        phase: "DOC-TEST",
+        scope: "docs-validation",
+        type: "validation",
+        command: "node tools/validators/enforce-runtime-guardrails.js",
+        result: "NOT RUN",
+        summary: "Docs-phase evidence can defer execution without a mapped risk."
+      }
+    ],
+    { id: "DOC-TEST", name: "Documentation Follow-up" }
+  );
+
+  const result = runValidator(fixtureRoot);
+  assert.equal(result.status, 0);
+  assert.match(result.output, /^PASS/m);
+});
+
+test("validator requires risk_ids for NOT RUN evidence outside docs phases", () => {
+  const fixtureRoot = buildFixtureRoot();
+
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
+  writeFixtureSession(fixtureRoot, [
+    {
+      id: "OPS-TEST-E1",
+      date: "2026-04-04",
+      phase: "OPS-TEST",
+      scope: "fixture-validation",
+      type: "validation",
+      command: "node tools/validators/enforce-runtime-guardrails.js",
+      result: "NOT RUN",
+      summary: "Non-docs NOT RUN entries must carry risks."
+    }
+  ]);
+
+  const result = runValidator(fixtureRoot);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.output,
+    /Evidence entry OPS-TEST-E1 must reference risk_ids when result is NOT RUN\./
+  );
 });

--- a/tools/validators/enforce-runtime-guardrails.test.js
+++ b/tools/validators/enforce-runtime-guardrails.test.js
@@ -343,3 +343,16 @@ test("validator requires risk_ids for NOT RUN evidence outside docs phases", () 
     /Evidence entry OPS-TEST-E1 must reference risk_ids when result is NOT RUN\./
   );
 });
+
+test("validator fails when code changes skip canonical state updates", () => {
+  const fixtureRoot = buildFixtureRoot();
+
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
+
+  const result = runValidator(fixtureRoot);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.output,
+    /Work progressed without updating the canonical state files\./
+  );
+});

--- a/tools/validators/enforce-runtime-guardrails.test.js
+++ b/tools/validators/enforce-runtime-guardrails.test.js
@@ -1,0 +1,266 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const validatorPath = path.join(repoRoot, "tools", "validators", "enforce-runtime-guardrails.js");
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeText(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value);
+}
+
+function buildFixtureRoot() {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "runtime-guardrails-"));
+  const updatedOn = "2026-04-04";
+  const unresolvedRisk = {
+    id: "RISK-TEST-001",
+    severity: "medium",
+    status: "unresolved",
+    assigned_phase: "OPS-TEST",
+    note: "Fixture risk for validator testing."
+  };
+
+  writeText(
+    path.join(fixtureRoot, ".github", "workflows", "ci.yml"),
+    [
+      "name: CI",
+      "on:",
+      "  pull_request:",
+      "",
+      "env:",
+      "  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: \"true\"",
+      "",
+      "jobs:",
+      "  runtime-guardrails:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - name: Run runtime guardrails validator",
+      "        run: node tools/validators/enforce-runtime-guardrails.js"
+    ].join("\n")
+  );
+
+  writeText(path.join(fixtureRoot, "docs", "roadmap", "roadmap.md"), "# Fixture roadmap\n");
+  writeText(path.join(fixtureRoot, "agents", "codex.md"), "codex\n");
+  writeText(path.join(fixtureRoot, "agents", "claude.md"), "claude\n");
+  writeText(path.join(fixtureRoot, "agents", "reviewer.md"), "reviewer\n");
+  writeText(path.join(fixtureRoot, "prompts", "mega.md"), "mega\n");
+  writeText(path.join(fixtureRoot, "prompts", "lean.md"), "lean\n");
+  writeText(path.join(fixtureRoot, "prompts", "deploy.md"), "deploy\n");
+  writeText(path.join(fixtureRoot, "tools", "validators", "enforce-runtime-guardrails.js"), "// fixture copy marker\n");
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 1;\n");
+
+  writeJson(path.join(fixtureRoot, "docs", "roadmap", "state.json"), {
+    current_phase: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    risk_remediation_phases: [
+      {
+        id: "OPS-TEST",
+        name: "Validator Fixture",
+        priority: "low",
+        grouped_risks: ["RISK-TEST-001"],
+        scope: "Fixture scope."
+      }
+    ],
+    upcoming_phases: [],
+    completed_phases: [],
+    opportunities: [],
+    incidents: [],
+    risks: [
+      {
+        id: "RISK-TEST-001",
+        description: "Fixture risk",
+        severity: "medium",
+        impact: "Fixture impact",
+        mitigation: "Fixture mitigation",
+        affected_components: ["tests"],
+        phase_association: "OPS-TEST",
+        status: "unresolved"
+      }
+    ],
+    tasks: {
+      active: ["OPS-TEST-T1"],
+      completed: []
+    },
+    decisions: [],
+    last_updated: updatedOn
+  });
+
+  writeJson(path.join(fixtureRoot, "state", "tasks.json"), {
+    updated_on: updatedOn,
+    active: [
+      {
+        id: "OPS-TEST-T1",
+        phase: "OPS-TEST",
+        title: "Fixture task",
+        status: "pending",
+        blocking_for_phase_completion: true
+      }
+    ],
+    completed: []
+  });
+
+  writeJson(path.join(fixtureRoot, "state", "risks.json"), {
+    updated_on: updatedOn,
+    resolved: [],
+    unresolved: [unresolvedRisk]
+  });
+
+  writeJson(path.join(fixtureRoot, "state", "decisions.json"), {
+    updated_on: updatedOn,
+    entries: [
+      {
+        date: updatedOn,
+        phase: "OPS-TEST",
+        summary: "Created fixture state."
+      }
+    ]
+  });
+
+  writeJson(path.join(fixtureRoot, "state", "session.json"), {
+    updated_on: updatedOn,
+    phase: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    roadmap_phase_context: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    branch: "main",
+    execution_summary: "Fixture summary.",
+    evidence: [
+      {
+        id: "OPS-TEST-E1",
+        date: updatedOn,
+        phase: "OPS-TEST",
+        scope: "fixture-validation",
+        type: "validation",
+        command: "node tools/validators/enforce-runtime-guardrails.js",
+        result: "PASS",
+        summary: "Fixture validation entry."
+      }
+    ]
+  });
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: fixtureRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd: fixtureRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: fixtureRoot, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: fixtureRoot, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "fixture"], { cwd: fixtureRoot, stdio: "ignore" });
+
+  return fixtureRoot;
+}
+
+function runValidator(fixtureRoot) {
+  try {
+    const stdout = execFileSync("node", [validatorPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        RUNTIME_GUARDRAILS_REPO_ROOT: fixtureRoot,
+        RUNTIME_GUARDRAILS_BASE_REF: "main"
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    return { status: 0, output: stdout };
+  } catch (error) {
+    return {
+      status: error.status ?? 1,
+      output: `${error.stdout ?? ""}${error.stderr ?? ""}`
+    };
+  }
+}
+
+test("validator fails when FAIL evidence omits risk_ids", () => {
+  const fixtureRoot = buildFixtureRoot();
+
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
+  writeJson(path.join(fixtureRoot, "state", "session.json"), {
+    updated_on: "2026-04-04",
+    phase: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    roadmap_phase_context: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    branch: "main",
+    execution_summary: "Fixture summary.",
+    evidence: [
+      {
+        id: "OPS-TEST-E1",
+        date: "2026-04-04",
+        phase: "OPS-TEST",
+        scope: "fixture-validation",
+        type: "validation",
+        command: "node tools/validators/enforce-runtime-guardrails.js",
+        result: "FAIL",
+        summary: "Missing risk IDs should fail validation."
+      }
+    ]
+  });
+
+  const result = runValidator(fixtureRoot);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.output,
+    /Evidence entry OPS-TEST-E1 must reference risk_ids when result is FAIL\./
+  );
+});
+
+test("validator passes when FAIL evidence includes risk_ids", () => {
+  const fixtureRoot = buildFixtureRoot();
+
+  writeText(path.join(fixtureRoot, "src", "app.js"), "module.exports = 2;\n");
+  writeJson(path.join(fixtureRoot, "state", "session.json"), {
+    updated_on: "2026-04-04",
+    phase: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    roadmap_phase_context: {
+      id: "OPS-TEST",
+      name: "Validator Fixture",
+      status: "in_progress"
+    },
+    branch: "main",
+    execution_summary: "Fixture summary.",
+    evidence: [
+      {
+        id: "OPS-TEST-E1",
+        date: "2026-04-04",
+        phase: "OPS-TEST",
+        scope: "fixture-validation",
+        type: "validation",
+        command: "node tools/validators/enforce-runtime-guardrails.js",
+        result: "FAIL",
+        risk_ids: ["RISK-TEST-001"],
+        summary: "Known failure with mapped risk."
+      }
+    ]
+  });
+
+  const result = runValidator(fixtureRoot);
+  assert.equal(result.status, 0);
+  assert.match(result.output, /^PASS/m);
+});


### PR DESCRIPTION
## Summary
- promote the docs-site lodash remediation and state sync to main
- add runtime guardrails regression tests for fail/not-run/state-update rules
- keep OPS-012 evidence and risk tracking aligned with the promoted branch state

## Validation
- node --test tools/validators/enforce-runtime-guardrails.test.js
- node tools/validators/enforce-runtime-guardrails.js --base-ref origin/main
- GitHub Actions CI run 23995836693
