### PR TITLE
[codex] Fix launch-at-login DI follow-up

### DIFF
--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -355,7 +355,7 @@ final class SettingsStore: ObservableObject {
     init(
         defaults: UserDefaults = .standard,
         keychainService: KeychainServicing = KeychainService(),
-        launchAtLoginService: any LaunchAtLoginControlling = SystemLaunchAtLoginService(),
+        launchAtLoginService: any LaunchAtLoginControlling,
         legacyDefaultsDomains: [String]? = nil
     ) {
         self.defaults = defaults

--- a/Tests/BugNarratorTests/DebugBundleExporterTests.swift
+++ b/Tests/BugNarratorTests/DebugBundleExporterTests.swift
@@ -16,7 +16,11 @@ final class DebugBundleExporterTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
 
         let keychainService = MockKeychainService()
-        let settingsStore = SettingsStore(defaults: defaults, keychainService: keychainService)
+        let settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychainService,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         settingsStore.apiKey = "fixture-openai-key"
         settingsStore.preferredModel = "whisper-1"
         settingsStore.issueExtractionModel = "gpt-4.1-mini"

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -16,7 +16,11 @@ final class SettingsStoreTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.startRecordingHotkeyShortcut, .disabled)
         XCTAssertEqual(store.stopRecordingHotkeyShortcut, .disabled)
@@ -117,7 +121,11 @@ final class SettingsStoreTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let keychain = MockKeychainService()
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.apiKey = "saved-in-keychain"
 
         XCTAssertFalse(defaults.dictionaryRepresentation().keys.contains { $0.localizedCaseInsensitiveContains("apikey") })
@@ -131,7 +139,11 @@ final class SettingsStoreTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let keychain = MockKeychainService()
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.jiraEmail = "secure@example.com"
 
         XCTAssertNil(defaults.string(forKey: "settings.jiraEmail"))
@@ -151,10 +163,18 @@ final class SettingsStoreTests: XCTestCase {
         let keychain = MockKeychainService()
         keychain.setError = AppError.storageFailure("Keychain unavailable")
 
-        let firstStore = SettingsStore(defaults: defaults, keychainService: keychain)
+        let firstStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         firstStore.apiKey = "fallback-key"
 
-        let secondStore = SettingsStore(defaults: defaults, keychainService: keychain)
+        let secondStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(firstStore.apiKeyPersistenceState, .sessionOnly)
         XCTAssertEqual(secondStore.apiKey, "")
@@ -166,7 +186,11 @@ final class SettingsStoreTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.apiKey = "fixture-openai-key-1234"
 
         XCTAssertEqual(store.maskedAPIKey, "••••••••1234")
@@ -202,6 +226,7 @@ final class SettingsStoreTests: XCTestCase {
         let store = SettingsStore(
             defaults: defaults,
             keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService(),
             legacyDefaultsDomains: [legacyDomainName]
         )
 
@@ -224,7 +249,11 @@ final class SettingsStoreTests: XCTestCase {
         defaults.set("legacy@example.com", forKey: "settings.jiraEmail")
 
         let keychain = MockKeychainService()
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.jiraEmail, "legacy@example.com")
         XCTAssertEqual(store.jiraEmailPersistenceState, .keychain)
@@ -241,7 +270,11 @@ final class SettingsStoreTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         let duplicateShortcut = HotkeyShortcut(
             keyCode: 7,
             modifiers: NSEvent.ModifierFlags.command.union(.option).rawValue
@@ -273,7 +306,11 @@ final class SettingsStoreTests: XCTestCase {
             encoder.encode(try XCTUnwrap(HotkeyAction.stopRecording.legacyBuiltInShortcut)),
             forKey: "settings.stopRecordingHotkeyShortcut"
         )
-        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.startRecordingHotkeyShortcut, .disabled)
         XCTAssertEqual(store.stopRecordingHotkeyShortcut, .disabled)
@@ -296,7 +333,11 @@ final class SettingsStoreTests: XCTestCase {
             forKey: "settings.markerHotkeyShortcut"
         )
 
-        _ = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        _ = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertNil(defaults.object(forKey: "settings.markerHotkeyShortcut"))
     }
@@ -310,7 +351,11 @@ final class SettingsStoreTests: XCTestCase {
         let keychain = MockKeychainService()
         keychain.values["SessionMic.OpenAI::openai-api-key"] = "legacy-api-key"
 
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.apiKey, "legacy-api-key")
         XCTAssertEqual(
@@ -330,7 +375,11 @@ final class SettingsStoreTests: XCTestCase {
         keychain.values["BugNarrator.OpenAI::openai-api-key"] = "locked-api-key"
         keychain.interactionRequiredKeys = ["BugNarrator.OpenAI::openai-api-key"]
 
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.apiKey, "")
         XCTAssertEqual(store.apiKeyPersistenceState, .keychainLocked)
@@ -357,7 +406,11 @@ final class SettingsStoreTests: XCTestCase {
         keychain.values[legacyKey] = "legacy-api-key"
         keychain.interactionRequiredKeys = [legacyKey]
 
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.apiKey, "")
         XCTAssertEqual(store.apiKeyPersistenceState, .keychainLocked)
@@ -395,7 +448,11 @@ final class SettingsStoreTests: XCTestCase {
         keychain.values[legacyJiraKey] = "legacy-fixture-jira-token"
         keychain.interactionRequiredKeys = [legacyGitHubKey, legacyJiraKey]
 
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
 
         XCTAssertEqual(store.githubToken, "")
         XCTAssertEqual(store.jiraAPIToken, "")
@@ -442,7 +499,11 @@ final class SettingsStoreTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.githubToken = "fixture-github-token-9876"
         store.jiraAPIToken = "fixture-jira-token-4321"
 
@@ -457,7 +518,11 @@ final class SettingsStoreTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let keychain = MockKeychainService()
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.apiKey = "to-be-removed"
 
         store.removeAPIKey()
@@ -474,7 +539,11 @@ final class SettingsStoreTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let keychain = MockKeychainService()
-        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        let store = SettingsStore(
+            defaults: defaults,
+            keychainService: keychain,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         store.githubToken = "github-remove"
         store.jiraAPIToken = "jira-remove"
 

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -448,7 +448,11 @@ struct AppStateHarness {
         defaults.removePersistentDomain(forName: defaultsSuiteName)
 
         let keychainService = MockKeychainService()
-        let settingsStore = SettingsStore(defaults: defaults, keychainService: keychainService)
+        let settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychainService,
+            launchAtLoginService: TestingLaunchAtLoginService()
+        )
         settingsStore.apiKey = apiKey
         settingsStore.debugMode = debugMode
         settingsStore.autoCopyTranscript = autoCopyTranscript

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,7 +1,7 @@
 # Controller State
 
-current_state: ready_for_codex
-state_owner: Claude
+current_state: ready_for_review
+state_owner: Review
 
 ## allowed_transitions
 

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -2,14 +2,14 @@
 
 task_id: T2
 description: Fix any follow-up PR #5 CI or review failures without reopening planning.
-branch: main
+branch: codex/t2-follow-up-pr-5-failures
 pr_link: not_opened
 owner: Codex
-current_state: ready_for_codex
-failure_type: none
+current_state: ready_for_review
+failure_type: review_feedback
 acceptance_criteria_reference: /ai/acceptance.md#t2
-last_action: Claude replanned from blocked state -- Windows validation (T1) deferred to human.
-next_action: Codex implements T2.
+last_action: Codex removed the implicit launch-at-login service selection from SettingsStore and reran the required validator plus SettingsStore tests.
+next_action: Review the follow-up PR and collect the next review pass.
 execution_status: idle
 execution_branch:
 execution_started_at:
@@ -17,4 +17,4 @@ execution_heartbeat_at:
 execution_lease_expires_at:
 execution_host_id:
 execution_worker_id:
-review_failure_count: 0
+review_failure_count: 1

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,5 +1,23 @@
 # Implementation Notes
 
-task_id: T1
-status: idle
-summary: Standards adoption bootstrap has not started an implementation slice in this workflow file yet.
+task_id: T2
+status: completed
+
+CHANGED:
+- `Sources/BugNarrator/Services/SettingsStore.swift`
+- `Tests/BugNarratorTests/DebugBundleExporterTests.swift`
+- `Tests/BugNarratorTests/SettingsStoreTests.swift`
+- `Tests/BugNarratorTests/TestSupport.swift`
+
+DID:
+- Removed the implicit `SystemLaunchAtLoginService()` default from `SettingsStore` so launch-at-login wiring is chosen explicitly by the composition root.
+- Kept production wiring in `AppBootstrap` and updated test-only call sites to inject `TestingLaunchAtLoginService()` or a targeted mock.
+- Addressed the PR #5 review feedback about environment-specific service selection living outside the settings store.
+
+VALIDATED:
+- `git diff --check`
+- `./scripts/validate.sh 9a0048fc6397f1be3086b3753b2afa4a912399d2`
+- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-settings-tests test -only-testing:BugNarratorTests/SettingsStoreTests`
+
+NEXT:
+- Push `codex/t2-follow-up-pr-5-failures`, open the follow-up PR, and collect the next GitHub review pass.

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,5 +1,5 @@
 # Validation Report
 
-task_id: T1
-result: pending
-summary: Waiting for the current standards adoption slice to finish local validation.
+task_id: T2
+result: passed
+summary: Runtime guardrails and the targeted SettingsStore macOS test suite both passed after removing the implicit launch-at-login service selection from SettingsStore.


### PR DESCRIPTION
## Summary
- remove the implicit system launch-at-login dependency from `SettingsStore`
- keep launch-at-login wiring in `AppBootstrap` and inject explicit test doubles everywhere else
- rerun runtime guardrails and the targeted `SettingsStoreTests` suite

## Validation
- `git diff --check`
- `./scripts/validate.sh 9a0048fc6397f1be3086b3753b2afa4a912399d2`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-settings-tests test -only-testing:BugNarratorTests/SettingsStoreTests`