### PR TITLE
[codex] N1 harden recording review flow

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -392,7 +392,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            setStatus(.transcribing("Step 1 of 3: Uploading audio to OpenAI for transcription..."))
+            setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Uploading audio to OpenAI for transcription...")))
             swapActivity(reason: "Uploading audio for transcription")
 
             let transcriptionResult = try await transcriptionClient.transcribe(
@@ -432,7 +432,7 @@ final class AppState: ObservableObject {
                 ]
             )
 
-            setStatus(.transcribing("Step 2 of 3: Saving the finished session locally..."))
+            setStatus(.transcribing(transcriptionProgressMessage(step: 2, action: "Saving the finished session locally...")))
 
             do {
                 try persistCompletedTranscript(session)
@@ -462,7 +462,7 @@ final class AppState: ObservableObject {
 
             if settingsStore.autoExtractIssues {
                 issueExtractionSessionID = session.id
-                setStatus(.transcribing("Step 3 of 3: Extracting reviewable issues..."))
+                setStatus(.transcribing(transcriptionProgressMessage(step: 3, action: "Extracting reviewable issues...")))
                 swapActivity(reason: "Extracting review issues")
 
                 do {
@@ -757,7 +757,7 @@ final class AppState: ObservableObject {
         let request = makeTranscriptionRequest()
         selectedTranscriptID = session.id
         currentTranscript = session
-        setStatus(.transcribing("Step 1 of 3: Retrying transcription from the preserved recording..."))
+        setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
         swapActivity(reason: "Retrying transcription from preserved audio")
         transcriptionLogger.info(
             "transcription_retry_requested",
@@ -799,7 +799,7 @@ final class AppState: ObservableObject {
                 artifactsDirectoryPath: session.artifactsDirectoryPath
             )
 
-            setStatus(.transcribing("Step 2 of 3: Saving the recovered session locally..."))
+            setStatus(.transcribing(transcriptionProgressMessage(step: 2, action: "Saving the recovered session locally...")))
             try persistUpdatedSession(updatedSession)
 
             if settingsStore.autoCopyTranscript {
@@ -808,7 +808,7 @@ final class AppState: ObservableObject {
 
             if settingsStore.autoExtractIssues {
                 issueExtractionSessionID = updatedSession.id
-                setStatus(.transcribing("Step 3 of 3: Extracting reviewable issues..."))
+                setStatus(.transcribing(transcriptionProgressMessage(step: 3, action: "Extracting reviewable issues...")))
                 swapActivity(reason: "Extracting review issues")
 
                 do {
@@ -1018,6 +1018,11 @@ final class AppState: ObservableObject {
             )
             setStatus(.recording(appError.userMessage), error: appError)
         }
+    }
+
+    private func transcriptionProgressMessage(step: Int, action: String) -> String {
+        let totalSteps = settingsStore.autoExtractIssues ? 3 : 2
+        return "Step \(step) of \(totalSteps): \(action)"
     }
 
     func extractIssuesForDisplayedTranscript() async {

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -392,7 +392,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            setStatus(.transcribing("Uploading audio to OpenAI and waiting for transcription..."))
+            setStatus(.transcribing("Step 1 of 3: Uploading audio to OpenAI for transcription..."))
             swapActivity(reason: "Uploading audio for transcription")
 
             let transcriptionResult = try await transcriptionClient.transcribe(
@@ -432,6 +432,8 @@ final class AppState: ObservableObject {
                 ]
             )
 
+            setStatus(.transcribing("Step 2 of 3: Saving the finished session locally..."))
+
             do {
                 try persistCompletedTranscript(session)
             } catch {
@@ -460,7 +462,7 @@ final class AppState: ObservableObject {
 
             if settingsStore.autoExtractIssues {
                 issueExtractionSessionID = session.id
-                setStatus(.transcribing("Extracting reviewable issues..."))
+                setStatus(.transcribing("Step 3 of 3: Extracting reviewable issues..."))
                 swapActivity(reason: "Extracting review issues")
 
                 do {
@@ -494,10 +496,10 @@ final class AppState: ObservableObject {
             endActivity()
             setStatus(.success(
                 settingsStore.autoExtractIssues
-                    ? "Transcript and extracted issues are ready."
+                    ? "Session saved. Transcript and extracted issues are ready."
                     : (settingsStore.autoCopyTranscript
-                        ? "Transcript copied to the clipboard."
-                        : "Transcript ready.")
+                        ? "Session saved. Transcript copied to the clipboard."
+                        : "Session saved locally and ready for review.")
             ))
         } catch {
             if let failureReason = recoverablePendingTranscriptionReason(for: error),
@@ -755,7 +757,7 @@ final class AppState: ObservableObject {
         let request = makeTranscriptionRequest()
         selectedTranscriptID = session.id
         currentTranscript = session
-        setStatus(.transcribing("Retrying transcription from the preserved recording..."))
+        setStatus(.transcribing("Step 1 of 3: Retrying transcription from the preserved recording..."))
         swapActivity(reason: "Retrying transcription from preserved audio")
         transcriptionLogger.info(
             "transcription_retry_requested",
@@ -797,6 +799,7 @@ final class AppState: ObservableObject {
                 artifactsDirectoryPath: session.artifactsDirectoryPath
             )
 
+            setStatus(.transcribing("Step 2 of 3: Saving the recovered session locally..."))
             try persistUpdatedSession(updatedSession)
 
             if settingsStore.autoCopyTranscript {
@@ -805,7 +808,7 @@ final class AppState: ObservableObject {
 
             if settingsStore.autoExtractIssues {
                 issueExtractionSessionID = updatedSession.id
-                setStatus(.transcribing("Extracting reviewable issues..."))
+                setStatus(.transcribing("Step 3 of 3: Extracting reviewable issues..."))
                 swapActivity(reason: "Extracting review issues")
 
                 do {
@@ -832,10 +835,10 @@ final class AppState: ObservableObject {
             endActivity()
             setStatus(.success(
                 settingsStore.autoExtractIssues
-                    ? "Transcript and extracted issues are ready."
+                    ? "Session saved. Transcript and extracted issues are ready."
                     : (settingsStore.autoCopyTranscript
-                        ? "Transcript copied to the clipboard."
-                        : "Transcript ready.")
+                        ? "Session saved. Transcript copied to the clipboard."
+                        : "Session saved locally and ready for review.")
             ))
         } catch {
             if let failureReason = recoverablePendingTranscriptionReason(for: error) {
@@ -1026,7 +1029,7 @@ final class AppState: ObservableObject {
 
         guard let preflightError = preflightForIssueExtraction(transcriptSession) else {
             issueExtractionSessionID = transcriptSession.id
-            setStatus(.transcribing("Extracting reviewable issues..."))
+            setStatus(.transcribing("Running issue extraction with a 10-second time limit..."))
             beginActivity(reason: "Extracting review issues")
             transcriptionLogger.info(
                 "issue_extraction_requested",
@@ -1560,12 +1563,8 @@ final class AppState: ObservableObject {
     }
 
     private func persistCompletedTranscript(_ session: TranscriptSession) throws {
-        if settingsStore.autoSaveTranscript {
-            try transcriptStore.add(session)
-            selectedTranscriptID = session.id
-        } else {
-            selectedTranscriptID = session.id
-        }
+        try transcriptStore.add(session)
+        selectedTranscriptID = session.id
 
         if settingsStore.autoCopyTranscript {
             clipboardService.copy(session.transcript)
@@ -1576,7 +1575,7 @@ final class AppState: ObservableObject {
             "Persisted a completed transcript session.",
             metadata: [
                 "session_id": session.id.uuidString,
-                "auto_saved": settingsStore.autoSaveTranscript ? "yes" : "no",
+                "auto_saved": "required",
                 "auto_copied": settingsStore.autoCopyTranscript ? "yes" : "no"
             ]
         )

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -3,9 +3,10 @@ import Foundation
 actor IssueExtractionService: IssueExtracting {
     private let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
     private let session: URLSession
+    private let timeoutDuration: Duration
     private let logger = DiagnosticsLogger(category: .transcription)
 
-    init(session: URLSession? = nil) {
+    init(session: URLSession? = nil, timeoutDuration: Duration = .seconds(10)) {
         if let session {
             self.session = session
         } else {
@@ -14,6 +15,7 @@ actor IssueExtractionService: IssueExtracting {
             configuration.timeoutIntervalForResource = 180
             self.session = URLSession(configuration: configuration)
         }
+        self.timeoutDuration = timeoutDuration
     }
 
     func extractIssues(
@@ -31,101 +33,46 @@ actor IssueExtractionService: IssueExtracting {
                 "screenshot_count": "\(reviewSession.screenshotCount)"
             ]
         )
-        let body = try JSONEncoder().encode(
-            ChatCompletionRequest(
-                model: model,
-                temperature: 0.1,
-                responseFormat: .jsonObject,
-                messages: [
-                    .init(
-                        role: "system",
-                        content: """
-                        You convert spoken software review notes into structured, reviewable draft issues.
-                        Use only information explicitly present in the transcript, markers, and screenshot references.
-                        Return strict JSON with keys summary, guidanceNote, issues.
-                        Each issue must contain title, category, summary, evidenceExcerpt, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview.
-                        Valid categories are exactly: Bug, UX Issue, Enhancement, Question / Follow-up.
-                        Prefer conservative output. If evidence is weak, set requiresReview to true and use a lower confidence.
-                        """
-                    ),
-                    .init(role: "user", content: makePrompt(for: reviewSession))
-                ]
-            )
-        )
-
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = body
-
         do {
-            let (data, response) = try await session.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw AppError.issueExtractionFailure("The server response was invalid.")
+            let request = try Self.makeRequest(
+                endpoint: endpoint,
+                reviewSession: reviewSession,
+                apiKey: apiKey,
+                model: model
+            )
+
+            let result = try await withThrowingTaskGroup(of: IssueExtractionResult.self) { group in
+                let session = self.session
+                let timeoutDuration = self.timeoutDuration
+
+                group.addTask {
+                    try await Self.performRequest(request, using: session, reviewSession: reviewSession)
+                }
+
+                group.addTask {
+                    try await Task.sleep(for: timeoutDuration)
+                    throw AppError.issueExtractionFailure(
+                        "Issue extraction took longer than 10 seconds. Retry the extraction or choose a faster model in Settings."
+                    )
+                }
+
+                guard let firstResult = try await group.next() else {
+                    throw AppError.issueExtractionFailure("The extraction response was empty.")
+                }
+
+                group.cancelAll()
+                return firstResult
             }
 
-            guard (200...299).contains(httpResponse.statusCode) else {
-                logger.warning(
-                    "issue_extraction_request_rejected",
-                    "OpenAI rejected the issue extraction request.",
-                    metadata: ["status_code": "\(httpResponse.statusCode)"]
-                )
-                throw OpenAIErrorMapper.mapResponse(
-                    statusCode: httpResponse.statusCode,
-                    data: data,
-                    fallback: AppError.issueExtractionFailure
-                )
-            }
-
-            let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
-            guard let message = completion.choices.first?.message else {
-                logger.warning("issue_extraction_empty", "OpenAI returned an empty issue extraction response.")
-                throw AppError.issueExtractionFailure("The extraction response was empty.")
-            }
-
-            if let refusal = message.refusal?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !refusal.isEmpty {
-                logger.warning(
-                    "issue_extraction_refused",
-                    "OpenAI refused the issue extraction request.",
-                    metadata: ["session_id": reviewSession.id.uuidString]
-                )
-                throw AppError.issueExtractionFailure(refusal)
-            }
-
-            guard let content = message.content?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !content.isEmpty else {
-                logger.warning("issue_extraction_empty", "OpenAI returned an empty issue extraction response.")
-                throw AppError.issueExtractionFailure("The extraction response was empty.")
-            }
-
-            let payload: IssueExtractionPayload
-            do {
-                payload = try IssueExtractionPayload.parse(from: content)
-            } catch {
-                logger.error(
-                    "issue_extraction_response_parse_failed",
-                    "OpenAI returned issue data that BugNarrator could not parse.",
-                    metadata: [
-                        "session_id": reviewSession.id.uuidString,
-                        "content_length": "\(content.count)",
-                        "parse_error": String(describing: error)
-                    ]
-                )
-                throw AppError.issueExtractionFailure(
-                    "OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings."
-                )
-            }
             logger.info(
                 "issue_extraction_request_succeeded",
                 "OpenAI returned extracted review issues.",
                 metadata: [
                     "session_id": reviewSession.id.uuidString,
-                    "issue_count": "\(payload.issues.count)"
+                    "issue_count": "\(result.issues.count)"
                 ]
             )
-            return payload.makeIssueExtractionResult(using: reviewSession)
+            return result
         } catch {
             logger.error(
                 "issue_extraction_request_failed",
@@ -136,7 +83,7 @@ actor IssueExtractionService: IssueExtracting {
         }
     }
 
-    private func makePrompt(for session: TranscriptSession) -> String {
+    private static func makePrompt(for session: TranscriptSession) -> String {
         var lines: [String] = [
             "Session metadata:",
             "- Recorded: \(session.createdAt.formatted(date: .abbreviated, time: .standard))",
@@ -198,6 +145,85 @@ actor IssueExtractionService: IssueExtracting {
 
         lines.append("Return a concise summary plus reviewable draft issues for product and engineering triage.")
         return lines.joined(separator: "\n")
+    }
+
+    private static func makeRequest(
+        endpoint: URL,
+        reviewSession: TranscriptSession,
+        apiKey: String,
+        model: String
+    ) throws -> URLRequest {
+        let body = try JSONEncoder().encode(
+            ChatCompletionRequest(
+                model: model,
+                temperature: 0.1,
+                responseFormat: .jsonObject,
+                messages: [
+                    .init(
+                        role: "system",
+                        content: """
+                        You convert spoken software review notes into structured, reviewable draft issues.
+                        Use only information explicitly present in the transcript, markers, and screenshot references.
+                        Return strict JSON with keys summary, guidanceNote, issues.
+                        Each issue must contain title, category, summary, evidenceExcerpt, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview.
+                        Valid categories are exactly: Bug, UX Issue, Enhancement, Question / Follow-up.
+                        Prefer conservative output. If evidence is weak, set requiresReview to true and use a lower confidence.
+                        """
+                    ),
+                    .init(role: "user", content: makePrompt(for: reviewSession))
+                ]
+            )
+        )
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        return request
+    }
+
+    private static func performRequest(
+        _ request: URLRequest,
+        using session: URLSession,
+        reviewSession: TranscriptSession
+    ) async throws -> IssueExtractionResult {
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError.issueExtractionFailure("The server response was invalid.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw OpenAIErrorMapper.mapResponse(
+                statusCode: httpResponse.statusCode,
+                data: data,
+                fallback: AppError.issueExtractionFailure
+            )
+        }
+
+        let completion = try JSONDecoder().decode(ChatCompletionResponse.self, from: data)
+        guard let message = completion.choices.first?.message else {
+            throw AppError.issueExtractionFailure("The extraction response was empty.")
+        }
+
+        if let refusal = message.refusal?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !refusal.isEmpty {
+            throw AppError.issueExtractionFailure(refusal)
+        }
+
+        guard let content = message.content?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !content.isEmpty else {
+            throw AppError.issueExtractionFailure("The extraction response was empty.")
+        }
+
+        do {
+            let payload = try IssueExtractionPayload.parse(from: content)
+            return payload.makeIssueExtractionResult(using: reviewSession)
+        } catch {
+            throw AppError.issueExtractionFailure(
+                "OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings."
+            )
+        }
     }
 }
 

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 actor IssueExtractionService: IssueExtracting {
+    static let defaultTimeoutDuration: Duration = .seconds(10)
+
     private let endpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
     private let session: URLSession
     private let timeoutDuration: Duration
     private let logger = DiagnosticsLogger(category: .transcription)
 
-    init(session: URLSession? = nil, timeoutDuration: Duration = .seconds(10)) {
+    init(session: URLSession? = nil, timeoutDuration: Duration = IssueExtractionService.defaultTimeoutDuration) {
         if let session {
             self.session = session
         } else {
@@ -51,9 +53,7 @@ actor IssueExtractionService: IssueExtracting {
 
                 group.addTask {
                     try await Task.sleep(for: timeoutDuration)
-                    throw AppError.issueExtractionFailure(
-                        "Issue extraction took longer than 10 seconds. Retry the extraction or choose a faster model in Settings."
-                    )
+                    throw AppError.issueExtractionFailure(Self.timeoutFailureMessage(for: timeoutDuration))
                 }
 
                 guard let firstResult = try await group.next() else {
@@ -81,6 +81,26 @@ actor IssueExtractionService: IssueExtracting {
             )
             throw OpenAIErrorMapper.mapTransportError(error, fallback: AppError.issueExtractionFailure)
         }
+    }
+
+    private static func timeoutFailureMessage(for duration: Duration) -> String {
+        "Issue extraction took longer than \(timeoutDisplayText(for: duration)). Retry the extraction or choose a faster model in Settings."
+    }
+
+    private static func timeoutDisplayText(for duration: Duration) -> String {
+        let components = duration.components
+        let rawSeconds = max(
+            0,
+            Double(components.seconds) + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+        )
+
+        if rawSeconds.rounded() == rawSeconds {
+            let wholeSeconds = Int(rawSeconds)
+            return "\(wholeSeconds) second\(wholeSeconds == 1 ? "" : "s")"
+        }
+
+        let roundedTenths = ceil(rawSeconds * 10) / 10
+        return "\(String(format: "%.1f", roundedTenths)) seconds"
     }
 
     private static func makePrompt(for session: TranscriptSession) -> String {

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -145,7 +145,6 @@ struct SettingsView: View {
                         sectionIntro("Control what BugNarrator does automatically after recording, transcription, and support workflows.")
 
                         Toggle("Auto-copy transcript to clipboard", isOn: $settingsStore.autoCopyTranscript)
-                        Toggle("Auto-save transcript to local history", isOn: $settingsStore.autoSaveTranscript)
                         Toggle("Open BugNarrator at startup", isOn: $settingsStore.openAtStartup)
                             .disabled(!settingsStore.openAtStartupSupported)
                         Toggle("Debug mode enables verbose local diagnostics", isOn: $settingsStore.debugMode)
@@ -157,6 +156,10 @@ struct SettingsView: View {
                         }
 
                         Text("Screenshot capture prompts for Screen Recording permission the first time you use it if macOS requires access.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+
+                        Text("Completed recordings are always saved to the local session library as soon as you stop. BugNarrator keeps the session even if the app quits before you review it.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
 

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -13,7 +13,6 @@ struct TranscriptView: View {
     @State private var selectedFilter: SessionLibraryDateFilter = .today
     @State private var customStartDate = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
     @State private var customEndDate = Date()
-    @State private var selectedDetailTab: ReviewWorkspaceTab = .rawTranscript
     @State private var hasResolvedInitialFilter = false
 
     private let exporter = TranscriptExporter()
@@ -64,40 +63,27 @@ struct TranscriptView: View {
         .onAppear {
             resolveInitialFilterIfNeeded()
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: selectedFilter) { _, _ in
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: searchText) { _, _ in
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: sortOrder) { _, _ in
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: customStartDate) { _, _ in
             selectedFilter = .customRange
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: customEndDate) { _, _ in
             selectedFilter = .customRange
             syncSelection()
-            syncDetailTabSelection()
         }
         .onChange(of: sessionIDSignature) { _, _ in
             resolveInitialFilterIfNeeded()
             syncSelection()
-            syncDetailTabSelection()
-        }
-        .onChange(of: appState.selectedTranscriptID) { _, _ in
-            selectedDetailTab = .rawTranscript
-        }
-        .onChange(of: selectedSessionWorkspaceSignature) { _, _ in
-            syncDetailTabSelection()
         }
     }
 
@@ -502,20 +488,6 @@ struct TranscriptView: View {
         allSessionEntries.map(\.id.uuidString).joined(separator: "|")
     }
 
-    private var selectedSessionWorkspaceSignature: String {
-        guard let selectedSession else {
-            return "none"
-        }
-
-        return [
-            selectedSession.id.uuidString,
-            selectedSession.summaryText.isEmpty ? "summary:0" : "summary:1",
-            selectedSession.issueExtraction == nil ? "extraction:0" : "extraction:1",
-            "issue-count:\(selectedSession.issueCount)"
-        ]
-        .joined(separator: "|")
-    }
-
     private var deletionAlertTitle: String {
         pendingDeletionIDs.count == 1 ? "Delete Session?" : "Delete \(pendingDeletionIDs.count) Sessions?"
     }
@@ -576,11 +548,6 @@ struct TranscriptView: View {
         searchText = ""
         appState.selectedTranscriptID = transcriptStore.latestPendingTranscriptionSession?.id
         syncSelection()
-        syncDetailTabSelection()
-    }
-
-    private func syncDetailTabSelection() {
-        selectedDetailTab = ReviewWorkspace.clampedTab(selectedDetailTab, for: selectedSession)
     }
 
     private func requestDeletion(for ids: Set<UUID>) {
@@ -695,9 +662,8 @@ struct TranscriptView: View {
             workspaceHeader(session, availableWidth: availableWidth)
             dividerSection
             workspaceActions(session, availableWidth: availableWidth)
-            workspaceTabs(session)
             dividerSection
-            detailContent(for: session, availableWidth: availableWidth)
+            workspaceSections(for: session, availableWidth: availableWidth)
                 .padding(.horizontal, 14)
                 .padding(.top, 10)
                 .padding(.bottom, 12)
@@ -818,51 +784,39 @@ struct TranscriptView: View {
         .padding(.vertical, 10)
     }
 
-    private func workspaceTabs(_ session: TranscriptSession) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(ReviewWorkspace.availableTabs(for: session)) { tab in
-                    Button {
-                        selectedDetailTab = tab
-                    } label: {
-                        Text(tab.title)
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(selectedDetailTab == tab ? Color.white : Color.primary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(
-                                selectedDetailTab == tab
-                                    ? Color.accentColor
-                                    : Color(nsColor: .separatorColor).opacity(0.18),
-                                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(tab.title)
-                    .accessibilityValue(selectedDetailTab == tab ? "Selected" : "Not selected")
-                    .accessibilityHint("Shows the \(tab.title.lowercased()) view for the selected session.")
-                    .accessibilityAddTraits(selectedDetailTab == tab ? .isSelected : [])
-                }
+    private func workspaceSections(for session: TranscriptSession, availableWidth: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            reviewSectionCard("Review Summary") {
+                reviewSummarySection(session)
+            }
+
+            reviewSectionCard("Extracted Issues") {
+                extractedIssuesSection(session, availableWidth: availableWidth)
+            }
+
+            reviewSectionCard("Screenshots") {
+                screenshotsSection(session, availableWidth: availableWidth)
+            }
+
+            reviewSectionCard("Transcript Timeline") {
+                rawTranscriptSection(session, availableWidth: availableWidth)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 14)
-        .padding(.top, 4)
-        .padding(.bottom, 8)
     }
 
-    @ViewBuilder
-    private func detailContent(for session: TranscriptSession, availableWidth: CGFloat) -> some View {
-        switch selectedDetailTab {
-        case .rawTranscript:
-            rawTranscriptSection(session, availableWidth: availableWidth)
-        case .reviewSummary:
-            reviewSummarySection(session)
-        case .screenshots:
-            screenshotsSection(session, availableWidth: availableWidth)
-        case .extractedIssues:
-            extractedIssuesSection(session, availableWidth: availableWidth)
+    private func reviewSectionCard<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            content()
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(.quaternary.opacity(0.24), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     @ViewBuilder
@@ -871,9 +825,6 @@ struct TranscriptView: View {
             let groupedIssues = ReviewWorkspace.summaryGroups(for: extraction.issues)
 
             VStack(alignment: .leading, spacing: 18) {
-                Text("Review Summary")
-                    .font(.headline)
-
                 if !groupedIssues.isEmpty {
                     VStack(alignment: .leading, spacing: 18) {
                         ForEach(groupedIssues, id: \.category) { group in
@@ -899,9 +850,6 @@ struct TranscriptView: View {
             }
         } else if !session.summaryText.isEmpty {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Review Summary")
-                    .font(.headline)
-
                 Text(session.summaryText)
                     .textSelection(.enabled)
             }
@@ -1026,19 +974,11 @@ struct TranscriptView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     screenshotMetadataBlock(screenshot, index: index, linkedMarker: linkedMarker)
 
-                    HStack(spacing: 10) {
-                        Button("Show in Transcript") {
-                            selectedDetailTab = .rawTranscript
-                        }
-                        .buttonStyle(.link)
-                        .accessibilityLabel("Show Screenshot \(index + 1) in transcript")
-
-                        Button("Open Screenshot") {
-                            appState.openScreenshot(screenshot)
-                        }
-                        .buttonStyle(.link)
-                        .accessibilityLabel(screenshotActionLabel(for: screenshot, index: index, action: "Open"))
+                    Button("Open Screenshot") {
+                        appState.openScreenshot(screenshot)
                     }
+                    .buttonStyle(.link)
+                    .accessibilityLabel(screenshotActionLabel(for: screenshot, index: index, action: "Open"))
                 }
             } else {
                 HStack(alignment: .firstTextBaseline, spacing: 12) {
@@ -1046,19 +986,11 @@ struct TranscriptView: View {
 
                     Spacer()
 
-                    HStack(spacing: 10) {
-                        Button("Show in Transcript") {
-                            selectedDetailTab = .rawTranscript
-                        }
-                        .buttonStyle(.link)
-                        .accessibilityLabel("Show Screenshot \(index + 1) in transcript")
-
-                        Button("Open Screenshot") {
-                            appState.openScreenshot(screenshot)
-                        }
-                        .buttonStyle(.link)
-                        .accessibilityLabel(screenshotActionLabel(for: screenshot, index: index, action: "Open"))
+                    Button("Open Screenshot") {
+                        appState.openScreenshot(screenshot)
                     }
+                    .buttonStyle(.link)
+                    .accessibilityLabel(screenshotActionLabel(for: screenshot, index: index, action: "Open"))
                 }
             }
 
@@ -1135,9 +1067,6 @@ struct TranscriptView: View {
         VStack(alignment: .leading, spacing: 14) {
             if let extraction = session.issueExtraction {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Extracted Issues")
-                        .font(.headline)
-
                     Text(extraction.guidanceNote.isEmpty ? "Review before exporting." : extraction.guidanceNote)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -811,6 +811,7 @@ struct TranscriptView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(.headline)
+                .accessibilityAddTraits(.isHeader)
 
             content()
         }

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -364,6 +364,24 @@ final class AppStateTests: XCTestCase {
         XCTAssertNil(harness.appState.activeRecordingSession)
     }
 
+    func testCompletedSessionStillSavesWhenAutoSavePreferenceIsDisabled() async throws {
+        let harness = AppStateHarness(autoSaveTranscript: false)
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "forced-auto-save")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        await harness.transcriptionClient.enqueue(
+            .success(TranscriptionResult(text: "Forced save transcript.", segments: []))
+        )
+
+        await harness.appState.startSession()
+        await harness.appState.stopSession()
+
+        XCTAssertEqual(harness.transcriptStore.sessions.count, 1)
+        XCTAssertEqual(harness.transcriptStore.sessions.first?.transcript, "Forced save transcript.")
+        XCTAssertEqual(harness.appState.status.detail, "Session saved. Transcript copied to the clipboard.")
+    }
+
     func testTranscriptionFailureTransitionsToErrorAndDeletesTemporaryAudioFile() async throws {
         let harness = AppStateHarness()
         defer { harness.cleanup() }
@@ -598,7 +616,7 @@ final class AppStateTests: XCTestCase {
 
         let completedSession = try XCTUnwrap(harness.transcriptStore.session(with: preservedSession.id))
         XCTAssertEqual(completedSession.issueExtraction?.summary, "Recovered summary")
-        XCTAssertEqual(harness.appState.status.detail, "Transcript and extracted issues are ready.")
+        XCTAssertEqual(harness.appState.status.detail, "Session saved. Transcript and extracted issues are ready.")
     }
 
     func testValidateAPIKeyUpdatesValidationStateOnSuccess() async {

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -138,12 +138,13 @@ final class IssueExtractionServiceTests: XCTestCase {
         let session = makeReviewSession()
 
         MockURLProtocol.requestHandler = { request in
-            (self.successResponse(for: request), self.makeChatCompletionData(content: #"{"summary":"","guidanceNote":"","issues":[]}"#))
+            Thread.sleep(forTimeInterval: 0.3)
+            return (self.successResponse(for: request), self.makeChatCompletionData(content: #"{"summary":"","guidanceNote":"","issues":[]}"#))
         }
 
         let service = IssueExtractionService(
             session: makeMockURLSession(),
-            timeoutDuration: .zero
+            timeoutDuration: .milliseconds(250)
         )
 
         do {
@@ -153,7 +154,7 @@ final class IssueExtractionServiceTests: XCTestCase {
             XCTAssertEqual(
                 error as? AppError,
                 .issueExtractionFailure(
-                    "Issue extraction took longer than 10 seconds. Retry the extraction or choose a faster model in Settings."
+                    "Issue extraction took longer than 0.3 seconds. Retry the extraction or choose a faster model in Settings."
                 )
             )
         }

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -134,6 +134,31 @@ final class IssueExtractionServiceTests: XCTestCase {
         }
     }
 
+    func testExtractIssuesTimesOutAfterConfiguredBudget() async throws {
+        let session = makeReviewSession()
+
+        MockURLProtocol.requestHandler = { request in
+            (self.successResponse(for: request), self.makeChatCompletionData(content: #"{"summary":"","guidanceNote":"","issues":[]}"#))
+        }
+
+        let service = IssueExtractionService(
+            session: makeMockURLSession(),
+            timeoutDuration: .zero
+        )
+
+        do {
+            _ = try await service.extractIssues(from: session, apiKey: "fixture-openai-key", model: "gpt-4.1-mini")
+            XCTFail("Expected issue extraction to time out.")
+        } catch {
+            XCTAssertEqual(
+                error as? AppError,
+                .issueExtractionFailure(
+                    "Issue extraction took longer than 10 seconds. Retry the extraction or choose a faster model in Settings."
+                )
+            )
+        }
+    }
+
     private func makeReviewSession() -> TranscriptSession {
         let screenshot = SessionScreenshot(elapsedTime: 8, filePath: "/tmp/review-shot.png")
         return TranscriptSession(

--- a/Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
+++ b/Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
@@ -44,7 +44,7 @@ final class MenuBarStatusPresentationTests: XCTestCase {
 
     func testTranscribingStateExpandsWidthForLongRunningStatus() {
         let presentation = MenuBarStatusPresentation(
-            status: .transcribing("Uploading audio to OpenAI and waiting for transcription..."),
+            status: .transcribing("Step 1 of 3: Uploading audio to OpenAI for transcription..."),
             currentError: nil
         )
 

--- a/artifacts/n1-recording-flow-hardening/validate.log
+++ b/artifacts/n1-recording-flow-hardening/validate.log
@@ -1,0 +1,5 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 7 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Config loaded from ai.config.json

--- a/artifacts/n1-recording-flow-hardening/xcodebuild-test.log
+++ b/artifacts/n1-recording-flow-hardening/xcodebuild-test.log
@@ -1,0 +1,1246 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test
+
+Build settings from command line:
+    CODE_SIGNING_ALLOWED = NO
+
+ComputePackagePrebuildTargetDependencyGraph
+
+Prepare packages
+
+CreateBuildRequest
+
+SendProjectDescription
+
+CreateBuildOperation
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'BugNarratorTests' in project 'BugNarrator'
+        ➜ Explicit dependency on target 'BugNarrator' in project 'BugNarrator'
+    Target 'BugNarrator' in project 'BugNarrator' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details
+
+Build description signature: bc3cb9cffcdff4e069a3ab1d53ab4695
+Build description path: /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/XCBuildData/bc3cb9cffcdff4e069a3ab1d53ab4695.xcbuilddata
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /Users/deffenda/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+    cd /Users/deffenda/Code/bug-narrator/BugNarrator.xcodeproj
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /Users/deffenda/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+CopySwiftLibs /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Library/SystemExtensions --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+ProcessInfoPlistFile /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Info.plist /Users/deffenda/Code/bug-narrator/Resources/Info.plist (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-infoPlistUtility /Users/deffenda/Code/bug-narrator/Resources/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/assetcatalog_generated_info.plist -o /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/Info.plist
+
+CopySwiftLibs /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/PlugIns --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Library/SystemExtensions --scan-folder /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+ProcessInfoPlistFile /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-infoPlistUtility /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist -producttype com.apple.product-type.bundle.unit-test -expandbuildsettings -platform macosx -o /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist
+
+Validate /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-validationUtility /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app -no-validate-extension -infoplist-subpath Contents/Info.plist
+
+RegisterWithLaunchServices /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app
+
+2026-04-12 20:06:40.164584-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.163Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-12 20:06:40.165244-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.165Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.170520-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.170Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:40.182527-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.182Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Build/Products/Debug/BugNarrator.app is_local_testing_build=yes microphone_status=notDetermined screen_capture_status=notDetermined
+2026-04-12 20:06:40.182796-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.183Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Suite 'All tests' started at 2026-04-12 20:06:40.419.
+Test Suite 'BugNarratorTests.xctest' started at 2026-04-12 20:06:40.419.
+Test Suite 'AppBootstrapTests' started at 2026-04-12 20:06:40.420.
+Test Case '-[BugNarratorTests.AppBootstrapTests testBootstrapUsesIsolatedStoresUnderXCTest]' started.
+2026-04-12 20:06:40.423177-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.423Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-12 20:06:40.423466-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.423Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+Test Case '-[BugNarratorTests.AppBootstrapTests testBootstrapUsesIsolatedStoresUnderXCTest]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.AppBootstrapTests testBootstrapUsesProductionStoresOutsideXCTest]' started.
+2026-04-12 20:06:40.430090-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.430Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.468016-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.468Z [INFO] [session-library] session_store_loaded - Loaded session history from primary storage. session_count=17
+Test Case '-[BugNarratorTests.AppBootstrapTests testBootstrapUsesProductionStoresOutsideXCTest]' passed (0.046 seconds).
+Test Suite 'AppBootstrapTests' passed at 2026-04-12 20:06:40.471.
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.050 (0.051) seconds
+Test Suite 'AppErrorTests' started at 2026-04-12 20:06:40.471.
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophonePermissionDeniedUsesSpecificStatusPresentation]' started.
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophonePermissionDeniedUsesSpecificStatusPresentation]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophonePermissionRestrictedUsesSpecificStatusPresentation]' started.
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophonePermissionRestrictedUsesSpecificStatusPresentation]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophoneUnavailableUsesSpecificStatusPresentation]' started.
+Test Case '-[BugNarratorTests.AppErrorTests testMicrophoneUnavailableUsesSpecificStatusPresentation]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.AppErrorTests testOpenAIKeyErrorsUseSpecificStatusPresentation]' started.
+Test Case '-[BugNarratorTests.AppErrorTests testOpenAIKeyErrorsUseSpecificStatusPresentation]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.AppErrorTests testScreenRecordingPermissionDeniedUsesSpecificStatusPresentation]' started.
+Test Case '-[BugNarratorTests.AppErrorTests testScreenRecordingPermissionDeniedUsesSpecificStatusPresentation]' passed (0.001 seconds).
+Test Suite 'AppErrorTests' passed at 2026-04-12 20:06:40.476.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.003 (0.005) seconds
+Test Suite 'AppStateTests' started at 2026-04-12 20:06:40.476.
+Test Case '-[BugNarratorTests.AppStateTests testAboutChangelogAndSupportActionsTriggerWindowCallbacks]' started.
+2026-04-12 20:06:40.483234-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.483Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.483496-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.483Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:40.483895-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.484Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:40.484577-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.484Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.485141-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.485Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:40.485471-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.485Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:40.485696-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.486Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testAboutChangelogAndSupportActionsTriggerWindowCallbacks]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testApplicationTerminationUnregistersHotkeys]' started.
+2026-04-12 20:06:40.492903-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.493Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.493136-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.493Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:40.493462-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.493Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:40.494056-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.494Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.494469-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.494Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:40.494788-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.495Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:40.495007-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.495Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:40.495386-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.495Z [INFO] [settings] application_will_terminate - BugNarrator is preparing for application shutdown. has_active_recording_session=no is_exporting=no is_extracting_issues=no status_phase=idle
+2026-04-12 20:06:40.496018-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.496Z [INFO] [settings] application_will_terminate - BugNarrator is preparing for application shutdown. has_active_recording_session=no is_exporting=no is_extracting_issues=no status_phase=idle
+Test Case '-[BugNarratorTests.AppStateTests testApplicationTerminationUnregistersHotkeys]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testAppStateRegistersDistinctRecordingHotkeys]' started.
+2026-04-12 20:06:40.503469-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.503Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.503714-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.504Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:40.504086-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.504Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:40.504671-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.504Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.505148-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.505Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:40.505447-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.505Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:40.505692-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.506Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testAppStateRegistersDistinctRecordingHotkeys]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testAutomaticIssueExtractionPersistsDraftIssuesAfterTranscription]' started.
+2026-04-12 20:06:40.528549-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.528Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.528780-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.529Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:40.529172-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.529Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:40.529904-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.530Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.530326-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.530Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:40.530648-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.530Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:40.530879-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.531Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:40.532746-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:40.533Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:40.532942-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.533Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:40.534050-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:40.534Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=37193BBF-7118-45A6-849E-318F4F7E0475
+2026-04-12 20:06:40.534327-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:40.534Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=37193BBF-7118-45A6-849E-318F4F7E0475
+2026-04-12 20:06:40.535126-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:40.535Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=37193BBF-7118-45A6-849E-318F4F7E0475
+2026-04-12 20:06:40.536306-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.536Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=37193BBF-7118-45A6-849E-318F4F7E0475
+2026-04-12 20:06:40.556574-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:40.556Z [INFO] [transcription] issue_extraction_completed_after_transcription - Automatic issue extraction completed after transcription. issue_count=1 session_id=37193BBF-7118-45A6-849E-318F4F7E0475
+Test Case '-[BugNarratorTests.AppStateTests testAutomaticIssueExtractionPersistsDraftIssuesAfterTranscription]' passed (0.051 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCancelSessionResetsToIdleStopsTimerAndRemovesArtifacts]' started.
+2026-04-12 20:06:40.564784-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.565Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:40.565015-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.565Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:40.565336-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.565Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:40.565936-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.566Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:40.566382-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:40.566Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:40.566688-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.567Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:40.566927-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:40.567Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:40.567111-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:40.567Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:40.567300-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:40.567Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:40.568029-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:40.568Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=BEFF0374-619E-49D2-91CB-1F4C771ED0F8
+2026-04-12 20:06:41.895120-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.894Z [INFO] [recording] session_cancelled - The active feedback session was discarded. session_id=BEFF0374-619E-49D2-91CB-1F4C771ED0F8
+Test Case '-[BugNarratorTests.AppStateTests testCancelSessionResetsToIdleStopsTimerAndRemovesArtifacts]' passed (1.341 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCanExportIssuesRequiresConfiguredDestinationAndSelectedIssue]' started.
+2026-04-12 20:06:41.913982-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.914Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.914228-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.914Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.914623-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.914Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.915374-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.915Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.915847-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.916Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.916153-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.916Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.916377-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.916Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.917441-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.917Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+Test Case '-[BugNarratorTests.AppStateTests testCanExportIssuesRequiresConfiguredDestinationAndSelectedIssue]' passed (0.018 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotCancellationKeepsRecordingWithoutCreatingMarkerOrScreenshot]' started.
+2026-04-12 20:06:41.925183-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.925Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.925422-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.925Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.925887-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.926Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.926642-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.926Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.927045-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.927Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.927342-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.927Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.927573-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.927Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.927752-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.928Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.927942-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.928Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.928429-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.928Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=8AE0AA2C-43AC-4ED5-B53A-D6C36CCA49FA
+2026-04-12 20:06:41.928636-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.928Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotCancellationKeepsRecordingWithoutCreatingMarkerOrScreenshot]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotFailureKeepsRecordingAndShowsMessage]' started.
+2026-04-12 20:06:41.936728-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.936Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.936973-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.937Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.937368-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.937Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.937993-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.938Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.938409-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.938Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.938709-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.939Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.938925-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.939Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.939093-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.939Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.939261-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.939Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.939823-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.940Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=5638597D-E0B5-4920-87C5-9E86922D548E
+2026-04-12 20:06:41.940037-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.940Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:41.940462-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:41.940Z [ERROR] [screenshots] screenshot_capture_failed - Screenshot capture failed: The screenshot file could not be written to disk. session_id=5638597D-E0B5-4920-87C5-9E86922D548E
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotFailureKeepsRecordingAndShowsMessage]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotStoresMetadataAndCreatesAutoMarker]' started.
+2026-04-12 20:06:41.948061-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.948Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.948297-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.948Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.948734-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.949Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.949396-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.949Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.949836-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.950Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.950162-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.950Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.950399-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.950Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.950574-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.950Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.950747-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.951Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.951441-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.951Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=B6BFB4CE-36C3-4FAA-AB2F-904757192E7D
+2026-04-12 20:06:41.951676-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.952Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:41.952338-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:41.952Z [INFO] [screenshots] screenshot_captured - Captured a screenshot and inserted the automatic marker. marker_index=1 screenshot_index=1 session_id=B6BFB4CE-36C3-4FAA-AB2F-904757192E7D
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotStoresMetadataAndCreatesAutoMarker]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotWithDeniedScreenRecordingKeepsRecordingAndShowsRecoveryContext]' started.
+2026-04-12 20:06:41.959948-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.960Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.960170-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.960Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.960623-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.960Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.961303-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.961Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.961730-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.962Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.962026-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.962Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.962259-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.962Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.962439-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.962Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.962624-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.962Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.963136-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.963Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=CE54EBE4-5A57-4E9F-9C06-203E2DA2850C
+2026-04-12 20:06:41.963328-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.963Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:41.963529-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.963Z [WARNING] [permissions] screen_recording_permission_denied - Screen Recording access was denied.
+2026-04-12 20:06:41.963775-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:41.964Z [ERROR] [screenshots] screenshot_capture_failed - Screenshot capture requires Screen Recording permission. Recording can continue without screenshots. Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again. session_id=CE54EBE4-5A57-4E9F-9C06-203E2DA2850C
+Test Case '-[BugNarratorTests.AppStateTests testCaptureScreenshotWithDeniedScreenRecordingKeepsRecordingAndShowsRecoveryContext]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCompletedSessionStillSavesWhenAutoSavePreferenceIsDisabled]' started.
+2026-04-12 20:06:41.971619-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.971Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.971858-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.972Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.972216-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.972Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.972761-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.973Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.973160-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.973Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.973459-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.973Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.973678-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.974Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.974187-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.974Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.974396-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.974Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.974885-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.975Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=28AB1C7B-C63B-4FF9-9609-5890656E5396
+2026-04-12 20:06:41.975102-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.975Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=28AB1C7B-C63B-4FF9-9609-5890656E5396
+2026-04-12 20:06:41.975613-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:41.975Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=28AB1C7B-C63B-4FF9-9609-5890656E5396
+2026-04-12 20:06:41.976597-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.976Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=28AB1C7B-C63B-4FF9-9609-5890656E5396
+Test Case '-[BugNarratorTests.AppStateTests testCompletedSessionStillSavesWhenAutoSavePreferenceIsDisabled]' passed (0.013 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testConsecutiveSessionsWorkBackToBackWithoutRestart]' started.
+2026-04-12 20:06:41.983755-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.984Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:41.984030-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.984Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:41.984536-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.984Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:41.985225-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.985Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:41.985677-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:41.986Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:41.985987-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.986Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:41.986235-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.986Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:41.986989-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.987Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.987192-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.987Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.987739-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.988Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=1FF30142-4A0A-42C2-B2B6-84EFF5BBBAEE
+2026-04-12 20:06:41.987966-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.988Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=1FF30142-4A0A-42C2-B2B6-84EFF5BBBAEE
+2026-04-12 20:06:41.988463-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:41.988Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=1FF30142-4A0A-42C2-B2B6-84EFF5BBBAEE
+2026-04-12 20:06:41.989527-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.989Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=1FF30142-4A0A-42C2-B2B6-84EFF5BBBAEE
+2026-04-12 20:06:41.989897-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.990Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:41.990089-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:41.990Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:41.990586-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.990Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=0C35DD5C-A62B-45B2-9052-6C5E195F576A
+2026-04-12 20:06:41.990820-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:41.991Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=0C35DD5C-A62B-45B2-9052-6C5E195F576A
+2026-04-12 20:06:41.991334-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:41.991Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=0C35DD5C-A62B-45B2-9052-6C5E195F576A
+2026-04-12 20:06:41.992544-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:41.992Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=0C35DD5C-A62B-45B2-9052-6C5E195F576A
+Test Case '-[BugNarratorTests.AppStateTests testConsecutiveSessionsWorkBackToBackWithoutRestart]' passed (0.016 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testCopyDebugInfoCopiesSafeSupportMetadataToClipboard]' started.
+2026-04-12 20:06:42.000251-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.000Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.000483-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.000Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.000813-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.001Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.001719-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.001Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.002207-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.002Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.002553-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.002Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.002787-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.003Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.004000-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.004Z [INFO] [settings] debug_info_copied - Copied debug info to the clipboard. session_id=AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE
+Test Case '-[BugNarratorTests.AppStateTests testCopyDebugInfoCopiesSafeSupportMetadataToClipboard]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testDebugModePreservesTemporaryAudioFileAfterSuccessfulStop]' started.
+2026-04-12 20:06:42.010996-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.011Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.011221-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.011Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.011517-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.011Z [INFO] [settings] debug_mode_changed - Debug mode was enabled. Verbose diagnostics are now recorded locally. debug_mode=enabled
+2026-04-12 20:06:42.012036-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.012Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.012511-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.012Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=enabled has_openai_key=yes
+2026-04-12 20:06:42.012829-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.013Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.013061-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.013Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.013572-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.013Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.013760-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.014Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.014338-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.014Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=DC21A75F-117E-492A-90E5-955C0F9DC024
+2026-04-12 20:06:42.014572-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.014Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=DC21A75F-117E-492A-90E5-955C0F9DC024
+2026-04-12 20:06:42.015033-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.015Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=DC21A75F-117E-492A-90E5-955C0F9DC024
+2026-04-12 20:06:42.016189-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.016Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=DC21A75F-117E-492A-90E5-955C0F9DC024
+Test Case '-[BugNarratorTests.AppStateTests testDebugModePreservesTemporaryAudioFileAfterSuccessfulStop]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testDeleteDisplayedTranscriptRemovesStoredSessionAndSelectsNextSession]' started.
+2026-04-12 20:06:42.024754-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.024Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.025000-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.025Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.025372-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.025Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.026037-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.026Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.026454-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.026Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.026747-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.027Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.026975-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.027Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.029393-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.029Z [INFO] [session-library] sessions_deleted - Removed sessions from local history. remaining_sessions=1 removed_count=1
+2026-04-12 20:06:42.029928-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.030Z [INFO] [session-library] sessions_deleted_from_library - Deleted sessions from the library. deleted_count=1
+Test Case '-[BugNarratorTests.AppStateTests testDeleteDisplayedTranscriptRemovesStoredSessionAndSelectsNextSession]' passed (0.013 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testDuplicateStartWhileAlreadyRecordingDoesNotStartTwice]' started.
+2026-04-12 20:06:42.038371-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.038Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.038605-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.038Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.038966-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.039Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.039560-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.039Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.040012-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.040Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.040317-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.040Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.040555-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.040Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.040738-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.041Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.040925-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.041Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.041536-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.041Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=9A1F8F99-C04E-44AA-B96E-7103DFB7565B
+2026-04-12 20:06:42.041741-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.042Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.041934-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.042Z [WARNING] [recording] session_start_rejected - The start request was rejected because BugNarrator is already busy.
+Test Case '-[BugNarratorTests.AppStateTests testDuplicateStartWhileAlreadyRecordingDoesNotStartTwice]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesCallsGitHubProviderWhenConfigured]' started.
+2026-04-12 20:06:42.049680-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.049Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.049923-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.050Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.050226-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.050Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.050786-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.051Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.051268-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.051Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.051600-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.051Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.051830-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.052Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.052043-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.052Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:42.053558-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:42.053Z [INFO] [export] issue_export_requested - Exporting selected issues. destination=GitHub issue_count=1 session_id=343252BF-09DC-47BB-871C-B5468D158ADD
+2026-04-12 20:06:42.053936-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:42.054Z [INFO] [export] issue_export_completed - Finished exporting selected issues. destination=GitHub issue_count=1 session_id=343252BF-09DC-47BB-871C-B5468D158ADD
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesCallsGitHubProviderWhenConfigured]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesFailsFastWhenConfigurationIsMissing]' started.
+2026-04-12 20:06:42.061138-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.061Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.061368-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.061Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.061666-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.062Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.062263-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.062Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.062647-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.062Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.062933-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.063Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.063151-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.063Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.064101-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:42.064Z [ERROR] [export] app_error - Export setup is incomplete: GitHub export requires a token, repository owner, and repository name. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesFailsFastWhenConfigurationIsMissing]' passed (0.111 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesFailsWhenSessionIsNoLongerAvailable]' started.
+2026-04-12 20:06:42.172785-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.172Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.173021-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.173Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.173480-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.173Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.174179-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.174Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.174614-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.174Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.174933-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.175Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.175164-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.175Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.175373-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.175Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:42.175860-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:42.176Z [ERROR] [export] app_error - Export failed: This session is no longer available in the library. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testExportSelectedIssuesFailsWhenSessionIsNoLongerAvailable]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testExtractIssuesWithoutAPIKeyFailsAndOpensSettings]' started.
+2026-04-12 20:06:42.182987-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.183Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.183214-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.183Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.183521-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.183Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.184109-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.184Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.184592-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.184Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.184908-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.185Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.185136-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.185Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.186215-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.186Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.186408-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.186Z [INFO] [settings] remove_openai_key - The OpenAI API key was removed from local storage.
+2026-04-12 20:06:42.186644-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.186Z [WARNING] [transcription] issue_extraction_preflight_failed - BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription. session_id=8397C55B-F2A4-46B8-A8A5-47A3261774FE
+2026-04-12 20:06:42.186871-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.187Z [WARNING] [settings] app_error - BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testExtractIssuesWithoutAPIKeyFailsAndOpensSettings]' passed (0.112 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testLocalTestingBuildAddsMicrophoneRecoveryGuidance]' started.
+2026-04-12 20:06:42.296203-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.296Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.296435-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.296Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.296740-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.297Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.297281-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.297Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.297726-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.298Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.298081-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.298Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/tmp/DerivedData/BugNarrator/Build/Products/Debug/BugNarrator.app is_local_testing_build=yes microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.298350-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.298Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testLocalTestingBuildAddsMicrophoneRecoveryGuidance]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenMicrophoneSettingsFallsBackToSecuritySettings]' started.
+2026-04-12 20:06:42.305466-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.305Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.305705-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.306Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.306062-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.306Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.306764-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.307Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.307192-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.307Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.307491-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.307Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.307717-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.308Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenMicrophoneSettingsFallsBackToSecuritySettings]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenMicrophoneSettingsUsesPrivacyDeepLinkFirst]' started.
+2026-04-12 20:06:42.314050-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.314Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.314278-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.314Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.314574-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.314Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.315129-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.315Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.315561-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.315Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.315880-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.316Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.316112-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.316Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenMicrophoneSettingsUsesPrivacyDeepLinkFirst]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenRecordingControlsShowsPanelWithoutStartingSession]' started.
+2026-04-12 20:06:42.322817-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.323Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.323043-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.323Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.323419-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.323Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.323993-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.324Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.324409-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.324Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:42.324721-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.325Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.324950-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.325Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenRecordingControlsShowsPanelWithoutStartingSession]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenRecordingSettingsFallsBackToSecuritySettings]' started.
+2026-04-12 20:06:42.331930-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.332Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.332162-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.332Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.332531-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.332Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.333242-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.333Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.333696-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.334Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.333997-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.334Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.334228-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.334Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenRecordingSettingsFallsBackToSecuritySettings]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenRecordingSettingsUsesPrivacyDeepLinkFirst]' started.
+2026-04-12 20:06:42.340908-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.341Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.341138-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.341Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.341457-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.341Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.342251-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.342Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.342733-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.343Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.343071-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.343Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.343309-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.343Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenRecordingSettingsUsesPrivacyDeepLinkFirst]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenshotMissingFileShowsHelpfulError]' started.
+2026-04-12 20:06:42.350235-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.350Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.350470-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.350Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.350783-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.351Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.351444-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.351Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.351907-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.352Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.352230-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.352Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.352466-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.352Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.352716-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.353Z [WARNING] [settings] utility_action_failed - The selected screenshot file is no longer available on this Mac.
+Test Case '-[BugNarratorTests.AppStateTests testOpenScreenshotMissingFileShowsHelpfulError]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testOpenSettingsDoesNotForceInteractiveSecretRefresh]' started.
+2026-04-12 20:06:42.359703-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.359Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.359937-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.360Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.360271-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.360Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.360821-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.361Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.361209-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.361Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:42.361493-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.361Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.361705-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.362Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Case '-[BugNarratorTests.AppStateTests testOpenSettingsDoesNotForceInteractiveSecretRefresh]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleMicrophoneDeniedErrorAfterAccessIsGranted]' started.
+2026-04-12 20:06:42.368842-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.369Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.369104-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.369Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.369435-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.369Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.370053-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.370Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.370478-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.370Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.370774-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.371Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.370997-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.371Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.371166-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.371Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.371339-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.371Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.371503-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.371Z [WARNING] [permissions] microphone_permission_denied - Microphone access was denied.
+2026-04-12 20:06:42.371672-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.372Z [WARNING] [permissions] session_start_preflight_failed - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again.
+2026-04-12 20:06:42.371869-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.372Z [WARNING] [permissions] app_error - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleMicrophoneDeniedErrorAfterAccessIsGranted]' passed (0.111 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleMicrophoneRestrictedErrorAfterAccessIsGranted]' started.
+2026-04-12 20:06:42.480632-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.480Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.480868-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.481Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.481238-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.481Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.481855-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.482Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.482303-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.482Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.482604-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.482Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.482829-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.483Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.483008-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.483Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.483191-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.483Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.483364-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.483Z [WARNING] [permissions] microphone_permission_restricted - Microphone access is restricted.
+2026-04-12 20:06:42.483543-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.483Z [WARNING] [permissions] session_start_preflight_failed - Microphone access is restricted on this Mac. Check System Settings > Privacy & Security > Microphone and any device-management or parental-control restrictions, then try again.
+2026-04-12 20:06:42.483756-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.484Z [WARNING] [permissions] app_error - Microphone access is restricted on this Mac. Check System Settings > Privacy & Security > Microphone and any device-management or parental-control restrictions, then try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleMicrophoneRestrictedErrorAfterAccessIsGranted]' passed (0.112 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleScreenRecordingDeniedErrorAfterAccessIsGranted]' started.
+2026-04-12 20:06:42.592896-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.593Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.593141-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.593Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.593458-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.593Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.594219-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.594Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.594794-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.595Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.595155-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.595Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.595413-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.595Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.595599-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.595Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.595783-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.596Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.596328-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.596Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=1F5C9826-A5D8-439F-93CD-F28339CA55FB
+2026-04-12 20:06:42.596508-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.596Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:42.596673-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.597Z [WARNING] [permissions] screen_recording_permission_denied - Screen Recording access was denied.
+2026-04-12 20:06:42.596913-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:42.597Z [ERROR] [screenshots] screenshot_capture_failed - Screenshot capture requires Screen Recording permission. Recording can continue without screenshots. Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again. session_id=1F5C9826-A5D8-439F-93CD-F28339CA55FB
+Test Case '-[BugNarratorTests.AppStateTests testPermissionRefreshClearsStaleScreenRecordingDeniedErrorAfterAccessIsGranted]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testPersistUpdatedSessionFailureKeepsEditedIssueVisibleAsUnsavedOverlay]' started.
+2026-04-12 20:06:42.604989-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.605Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.605221-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.605Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.605718-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.606Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.606422-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.606Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.606858-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.607Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.607163-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.607Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.607394-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.607Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.609000-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.609Z [ERROR] [session-library] session_save_failed - Saving session history failed. session_id=26C4A6AD-FDF2-4E34-933E-A6590892BF49
+2026-04-12 20:06:42.611096-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.611Z [ERROR] [session-library] app_error - Could not save local session history: The file “sessions.json” couldn’t be saved in the folder “BugNarratorTests-6A0F98C1-B7FA-4FE8-984B-A89BFBA06026”. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testPersistUpdatedSessionFailureKeepsEditedIssueVisibleAsUnsavedOverlay]' passed (0.014 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionFailureDuringRecordingPreservesRecordingState]' started.
+2026-04-12 20:06:42.618767-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.618Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.619017-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.619Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.619439-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.619Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.620257-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.620Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.620690-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.621Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.620991-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.621Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.621213-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.621Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.621386-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.621Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.621557-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.621Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.622121-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.622Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=85ADB101-7FE5-4BDE-BF89-265E84B02C3E
+2026-04-12 20:06:42.622311-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.622Z [WARNING] [settings] utility_action_failed - BugNarrator could not open the documentation.
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionFailureDuringRecordingPreservesRecordingState]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionFailureShowsHelpfulError]' started.
+2026-04-12 20:06:42.629440-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.629Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.629670-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.630Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.629981-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.630Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.630584-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.630Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.631009-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.631Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.631301-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.631Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.631520-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.631Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.631689-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.632Z [WARNING] [settings] utility_action_failed - BugNarrator could not open the documentation.
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionFailureShowsHelpfulError]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionsOpenExpectedURLs]' started.
+2026-04-12 20:06:42.638595-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.638Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.638851-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.639Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.639240-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.639Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.639801-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.640Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.640225-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.640Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.640515-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.640Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.640729-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.641Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.640927-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.641Z [INFO] [settings] external_link_opened - Opened an external support or documentation link. label=GitHub repository
+2026-04-12 20:06:42.641116-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.641Z [INFO] [settings] external_link_opened - Opened an external support or documentation link. label=documentation
+2026-04-12 20:06:42.641305-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.641Z [INFO] [settings] external_link_opened - Opened an external support or documentation link. label=issue tracker
+2026-04-12 20:06:42.641507-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.641Z [INFO] [settings] external_link_opened - Opened an external support or documentation link. label=releases page
+Test Case '-[BugNarratorTests.AppStateTests testProjectInfoActionsOpenExpectedURLs]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testRapidRepeatedScreenshotRequestsOnlyPersistOneCaptureAtATime]' started.
+2026-04-12 20:06:42.648200-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.648Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.648431-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.648Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.648806-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.649Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.649341-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.649Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.649748-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.650Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.650037-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.650Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.650251-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.650Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.650418-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.650Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.650586-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.650Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.651100-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.651Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=FF2929DA-3472-42C1-86D6-41042CEE1B62
+2026-04-12 20:06:42.651518-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.651Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:42.652234-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:42.652Z [WARNING] [screenshots] screenshot_rejected_busy - Screenshot capture failed: Wait for the current screenshot to finish, then try again.
+2026-04-12 20:06:42.854285-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:42.854Z [INFO] [screenshots] screenshot_captured - Captured a screenshot and inserted the automatic marker. marker_index=1 screenshot_index=1 session_id=FF2929DA-3472-42C1-86D6-41042CEE1B62
+Test Case '-[BugNarratorTests.AppStateTests testRapidRepeatedScreenshotRequestsOnlyPersistOneCaptureAtATime]' passed (0.213 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testRecordingControlsStartFlowShowsPanelAndStartsSession]' started.
+2026-04-12 20:06:42.861939-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.862Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.862164-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.862Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.862548-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.862Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.863130-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.863Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.863570-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.863Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:42.863882-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.864Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.864113-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.864Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.864290-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.864Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.864459-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.864Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.865027-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.865Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=no session_id=24A24516-B879-4E65-9099-5E2B5C255EAC
+Test Case '-[BugNarratorTests.AppStateTests testRecordingControlsStartFlowShowsPanelAndStartsSession]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testRetryPendingTranscriptionCompletesPreservedSession]' started.
+2026-04-12 20:06:42.872712-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.872Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.872944-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.873Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.873287-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.873Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.873841-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.874Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.874252-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.874Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.874543-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.874Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.874775-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.875Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.875261-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.875Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.875459-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.875Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.876073-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.876Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=C0567C1C-CD17-4048-BF56-CDAD1AB49EA1
+2026-04-12 20:06:42.876309-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.876Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.876487-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.876Z [INFO] [settings] remove_openai_key - The OpenAI API key was removed from local storage.
+2026-04-12 20:06:42.876698-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.877Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=C0567C1C-CD17-4048-BF56-CDAD1AB49EA1
+2026-04-12 20:06:42.877928-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.878Z [INFO] [recording] recorded_audio_preserved_for_retry - Preserved the finished recording for a later transcription retry. file_name=recording.m4a
+2026-04-12 20:06:42.879046-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.879Z [WARNING] [transcription] transcription_deferred_for_retry - Recording finished and was preserved for a later transcription retry. failure_reason=missingAPIKey session_id=C0567C1C-CD17-4048-BF56-CDAD1AB49EA1
+2026-04-12 20:06:42.879277-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.879Z [WARNING] [settings] app_error - BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription. context=preserve_retryable_session
+2026-04-12 20:06:42.879544-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.879Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.880074-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.880Z [INFO] [transcription] transcription_retry_requested - Retrying transcription from preserved audio. failure_reason=missingAPIKey session_id=C0567C1C-CD17-4048-BF56-CDAD1AB49EA1
+Test Case '-[BugNarratorTests.AppStateTests testRetryPendingTranscriptionCompletesPreservedSession]' passed (0.016 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testRetryPendingTranscriptionHonorsAutoIssueExtraction]' started.
+2026-04-12 20:06:42.888374-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.888Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.888603-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.888Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.889007-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.889Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.889577-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.889Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.889962-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.890Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.890248-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.890Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.890461-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.890Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.890880-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.891Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.891067-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.891Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.891556-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.891Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=F0F2EE3E-0696-42E6-B59D-BBDE65610FA7
+2026-04-12 20:06:42.891774-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.892Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:42.891951-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.892Z [INFO] [settings] remove_openai_key - The OpenAI API key was removed from local storage.
+2026-04-12 20:06:42.892164-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.892Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=F0F2EE3E-0696-42E6-B59D-BBDE65610FA7
+2026-04-12 20:06:42.892790-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.893Z [INFO] [recording] recorded_audio_preserved_for_retry - Preserved the finished recording for a later transcription retry. file_name=recording.m4a
+2026-04-12 20:06:42.893868-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.894Z [WARNING] [transcription] transcription_deferred_for_retry - Recording finished and was preserved for a later transcription retry. failure_reason=missingAPIKey session_id=F0F2EE3E-0696-42E6-B59D-BBDE65610FA7
+2026-04-12 20:06:42.894089-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.894Z [WARNING] [settings] app_error - BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription. context=preserve_retryable_session
+2026-04-12 20:06:42.894317-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.894Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.894898-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:42.895Z [INFO] [transcription] transcription_retry_requested - Retrying transcription from preserved audio. failure_reason=missingAPIKey session_id=F0F2EE3E-0696-42E6-B59D-BBDE65610FA7
+Test Case '-[BugNarratorTests.AppStateTests testRetryPendingTranscriptionHonorsAutoIssueExtraction]' passed (0.015 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionDoesNotStartWhenPermissionLooksDeniedEvenIfProbeWouldSucceed]' started.
+2026-04-12 20:06:42.904511-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.904Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.904739-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.905Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.905112-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.905Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.905655-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.905Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.906073-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.906Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.906358-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.906Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.906577-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.906Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.906755-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.907Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.906932-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.907Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.907107-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.907Z [WARNING] [permissions] microphone_permission_denied - Microphone access was denied.
+2026-04-12 20:06:42.907280-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.907Z [WARNING] [permissions] session_start_preflight_failed - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again.
+2026-04-12 20:06:42.907489-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.907Z [WARNING] [permissions] app_error - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionDoesNotStartWhenPermissionLooksDeniedEvenIfProbeWouldSucceed]' passed (0.061 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionRequestsMicrophonePermissionBeforeRecording]' started.
+2026-04-12 20:06:42.965731-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.965Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.965967-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.966Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.966267-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.966Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.966945-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.967Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.967386-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.967Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.967685-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.968Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.967927-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.968Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.968131-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.968Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.968324-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.968Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.969054-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.969Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=17A9EA6A-8CD1-48D5-B439-39F235BA3279
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionRequestsMicrophonePermissionBeforeRecording]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionShowsCaptureUnavailableErrorWhenPrerequisitesFail]' started.
+2026-04-12 20:06:42.976624-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.976Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:42.976858-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.977Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:42.977235-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.977Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:42.977934-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.978Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:42.978418-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:42.978Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:42.978739-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.979Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:42.978961-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:42.979Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:42.979134-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:42.979Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:42.979305-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.979Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:42.979477-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.979Z [ERROR] [permissions] microphone_capture_setup_failed - BugNarrator could not start audio capture. The selected microphone could not be opened.
+2026-04-12 20:06:42.979644-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.980Z [WARNING] [permissions] session_start_preflight_failed - BugNarrator could not start audio capture. The selected microphone could not be opened.
+2026-04-12 20:06:42.979855-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:42.980Z [WARNING] [permissions] app_error - BugNarrator could not start audio capture. The selected microphone could not be opened. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionShowsCaptureUnavailableErrorWhenPrerequisitesFail]' passed (0.111 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithDeniedMicrophonePermissionFailsBeforeRecorderStarts]' started.
+2026-04-12 20:06:43.088948-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.089Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.089193-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.089Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.089541-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.089Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.090178-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.090Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.090619-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.090Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.090936-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.091Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.091165-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.091Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.091342-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.091Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.091523-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.091Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.091696-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.092Z [WARNING] [permissions] microphone_permission_denied - Microphone access was denied.
+2026-04-12 20:06:43.091874-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.092Z [WARNING] [permissions] session_start_preflight_failed - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again.
+2026-04-12 20:06:43.092073-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.092Z [WARNING] [permissions] app_error - Microphone permission was denied. Open System Settings > Privacy & Security > Microphone, enable BugNarrator, then try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithDeniedMicrophonePermissionFailsBeforeRecorderStarts]' passed (0.112 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithoutAPIKeyStillStartsRecordingAndShowsTranscriptionGuidance]' started.
+2026-04-12 20:06:43.200716-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.200Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.200945-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.201Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:43.201259-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.201Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.202130-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.202Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.202613-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.202Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:43.202933-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.203Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.203164-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.203Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.203331-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.203Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.203501-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.203Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.204150-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.204Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=no session_id=6CCB62AE-5E7E-4A47-80C8-E5A51A65DC47
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithoutAPIKeyStillStartsRecordingAndShowsTranscriptionGuidance]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithRestrictedMicrophonePermissionFailsBeforeRecorderStarts]' started.
+2026-04-12 20:06:43.211689-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.211Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.211912-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.212Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.212223-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.212Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.212866-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.213Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.213269-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.213Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.213557-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.213Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.213775-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.214Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.213957-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.214Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.214138-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.214Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.214312-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.214Z [WARNING] [permissions] microphone_permission_restricted - Microphone access is restricted.
+2026-04-12 20:06:43.214489-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.214Z [WARNING] [permissions] session_start_preflight_failed - Microphone access is restricted on this Mac. Check System Settings > Privacy & Security > Microphone and any device-management or parental-control restrictions, then try again.
+2026-04-12 20:06:43.214702-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.215Z [WARNING] [permissions] app_error - Microphone access is restricted on this Mac. Check System Settings > Privacy & Security > Microphone and any device-management or parental-control restrictions, then try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testStartSessionWithRestrictedMicrophonePermissionFailsBeforeRecorderStarts]' passed (0.111 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionIgnoresDuplicateStopsWhileStopping]' started.
+2026-04-12 20:06:43.323922-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.324Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.324151-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.324Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.324441-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.324Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.325011-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.325Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.325450-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.325Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.325764-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.326Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.325993-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.326Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.326494-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.326Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.326687-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.327Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.327182-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.327Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=1F0418E4-97C1-4780-A2DE-4E8BD6E4BBBA
+2026-04-12 20:06:43.327446-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.327Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=1F0418E4-97C1-4780-A2DE-4E8BD6E4BBBA
+2026-04-12 20:06:43.328071-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.328Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=1F0418E4-97C1-4780-A2DE-4E8BD6E4BBBA
+2026-04-12 20:06:43.329068-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.329Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=1F0418E4-97C1-4780-A2DE-4E8BD6E4BBBA
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionIgnoresDuplicateStopsWhileStopping]' passed (0.115 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionWithoutAPIKeyAfterRecordingPreservesRetryableSession]' started.
+2026-04-12 20:06:43.440169-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.440Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.440407-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.440Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.440846-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.441Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.441617-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.441Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.442088-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.442Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.442413-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.442Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.442637-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.442Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.443109-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.443Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.443295-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.443Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.443803-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.444Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=A3E33D88-230F-4A5D-90F5-006613CED557
+2026-04-12 20:06:43.444011-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.444Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:43.444182-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.444Z [INFO] [settings] remove_openai_key - The OpenAI API key was removed from local storage.
+2026-04-12 20:06:43.444400-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.444Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=A3E33D88-230F-4A5D-90F5-006613CED557
+2026-04-12 20:06:43.445098-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.445Z [INFO] [recording] recorded_audio_preserved_for_retry - Preserved the finished recording for a later transcription retry. file_name=recording.m4a
+2026-04-12 20:06:43.446364-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.446Z [WARNING] [transcription] transcription_deferred_for_retry - Recording finished and was preserved for a later transcription retry. failure_reason=missingAPIKey session_id=A3E33D88-230F-4A5D-90F5-006613CED557
+2026-04-12 20:06:43.446593-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.446Z [WARNING] [settings] app_error - BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription. context=preserve_retryable_session
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionWithoutAPIKeyAfterRecordingPreservesRetryableSession]' passed (0.016 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionWithRejectedAPIKeyPreservesRetryableSession]' started.
+2026-04-12 20:06:43.454563-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.454Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.454791-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.455Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.455173-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.455Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.455742-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.456Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.456164-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.456Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.456484-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.456Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.456708-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.457Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.457166-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.457Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.457342-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.457Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.457814-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.458Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=52AB5182-34B6-455B-A610-2AA8C69FCD1C
+2026-04-12 20:06:43.458028-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.458Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=52AB5182-34B6-455B-A610-2AA8C69FCD1C
+2026-04-12 20:06:43.458942-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.459Z [INFO] [recording] recorded_audio_preserved_for_retry - Preserved the finished recording for a later transcription retry. file_name=recording.m4a
+2026-04-12 20:06:43.459885-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.460Z [WARNING] [transcription] transcription_deferred_for_retry - Recording finished and was preserved for a later transcription retry. failure_reason=invalidAPIKey session_id=52AB5182-34B6-455B-A610-2AA8C69FCD1C
+2026-04-12 20:06:43.460083-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.460Z [WARNING] [settings] app_error - The OpenAI API key was rejected. Open Settings, replace it, and try again. context=preserve_retryable_session
+Test Case '-[BugNarratorTests.AppStateTests testStopSessionWithRejectedAPIKeyPreservesRetryableSession]' passed (0.013 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testSuccessfulSessionSavesCopiesAndDeletesTemporaryAudioFile]' started.
+2026-04-12 20:06:43.466972-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.467Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.467192-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.467Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.467536-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.467Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.468159-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.468Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.468639-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.468Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.468949-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.469Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.469186-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.469Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.469672-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.470Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.469853-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.470Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.470436-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.470Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=ACA10340-CEE5-443C-9FD3-69CF3BD9C145
+2026-04-12 20:06:43.470671-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.471Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=ACA10340-CEE5-443C-9FD3-69CF3BD9C145
+2026-04-12 20:06:43.471146-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.471Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=0 screenshot_count=0 session_id=ACA10340-CEE5-443C-9FD3-69CF3BD9C145
+2026-04-12 20:06:43.472148-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.472Z [INFO] [session-library] transcript_persisted - Persisted a completed transcript session. auto_copied=yes auto_saved=required session_id=ACA10340-CEE5-443C-9FD3-69CF3BD9C145
+Test Case '-[BugNarratorTests.AppStateTests testSuccessfulSessionSavesCopiesAndDeletesTemporaryAudioFile]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testSuccessfulTranscriptionWithStorageFailureKeepsTranscriptAvailableForManualSave]' started.
+2026-04-12 20:06:43.479629-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.479Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.479850-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.480Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.480138-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.480Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.480704-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.480Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.481116-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.481Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.481407-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.481Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.481635-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.481Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.482093-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.482Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.482278-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.482Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.482753-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.483Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+2026-04-12 20:06:43.482939-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.483Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:43.483505-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:43.483Z [INFO] [screenshots] screenshot_captured - Captured a screenshot and inserted the automatic marker. marker_index=1 screenshot_index=1 session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+2026-04-12 20:06:43.483903-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.484Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+2026-04-12 20:06:43.484697-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.484Z [INFO] [transcription] transcription_completed - BugNarrator finished transcription and created a transcript session. marker_count=1 screenshot_count=1 session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+2026-04-12 20:06:43.485538-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.485Z [ERROR] [session-library] session_save_failed - Saving session history failed. session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+2026-04-12 20:06:43.486564-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.486Z [ERROR] [session-library] transcript_persist_failed - Transcription succeeded, but saving the transcript locally failed. session_id=6FCC7E00-AB73-4B13-9EF2-47FAF28749BC
+Test Case '-[BugNarratorTests.AppStateTests testSuccessfulTranscriptionWithStorageFailureKeepsTranscriptAvailableForManualSave]' passed (0.014 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testSupportDonationActionOpensExpectedURL]' started.
+2026-04-12 20:06:43.493866-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.494Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.494095-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.494Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.494393-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.494Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.495062-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.495Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.495482-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.495Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.495776-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.496Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.495995-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.496Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.496196-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.496Z [INFO] [settings] external_link_opened - Opened an external support or documentation link. label=PayPal donation page
+Test Case '-[BugNarratorTests.AppStateTests testSupportDonationActionOpensExpectedURL]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testTranscriptionFailureTransitionsToErrorAndDeletesTemporaryAudioFile]' started.
+2026-04-12 20:06:43.503198-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.503Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.503430-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.503Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.503742-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.504Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.504342-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.504Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.504769-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.505Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.505082-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.505Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.505301-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.505Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.505761-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.506Z [INFO] [recording] session_start_requested - A feedback session start was requested.
+2026-04-12 20:06:43.505932-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.506Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.506397-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.506Z [INFO] [recording] session_started - A feedback session started successfully. has_openai_key=yes session_id=A30DD08C-6574-4A16-8410-2BEF8485093F
+2026-04-12 20:06:43.506616-0400 BugNarrator[64124:1112862] [recording] 2026-04-13T00:06:43.506Z [INFO] [recording] session_stop_requested - Stopping the active feedback session. session_id=A30DD08C-6574-4A16-8410-2BEF8485093F
+2026-04-12 20:06:43.507503-0400 BugNarrator[64124:1112862] [transcription] 2026-04-13T00:06:43.507Z [ERROR] [transcription] app_error - The request to OpenAI timed out. Check your connection and try again. context=present_error
+Test Case '-[BugNarratorTests.AppStateTests testTranscriptionFailureTransitionsToErrorAndDeletesTemporaryAudioFile]' passed (0.011 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testValidateAPIKeyUpdatesValidationStateOnSuccess]' started.
+2026-04-12 20:06:43.514394-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.514Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.514630-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.514Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.514943-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.515Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.515527-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.515Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.515960-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.516Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=yes
+2026-04-12 20:06:43.516275-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.516Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.516506-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.516Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.516753-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.517Z [INFO] [settings] validate_openai_key_succeeded - The OpenAI API key validation flow succeeded.
+Test Case '-[BugNarratorTests.AppStateTests testValidateAPIKeyUpdatesValidationStateOnSuccess]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.AppStateTests testValidateAPIKeyWithoutConfiguredKeyShowsFailure]' started.
+2026-04-12 20:06:43.523696-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.523Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.523930-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.524Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:43.524214-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.524Z [INFO] [settings] debug_mode_changed - Debug mode was disabled. BugNarrator will keep logging info, warnings, and errors. debug_mode=disabled
+2026-04-12 20:06:43.524780-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.525Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:43.525214-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.525Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 20:06:43.525531-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.525Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/Applications/BugNarrator.app is_local_testing_build=no microphone_status=granted screen_capture_status=granted
+2026-04-12 20:06:43.525763-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:43.526Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+2026-04-12 20:06:43.525952-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.526Z [WARNING] [settings] validate_openai_key_rejected - OpenAI key validation was requested without a saved key.
+Test Case '-[BugNarratorTests.AppStateTests testValidateAPIKeyWithoutConfiguredKeyShowsFailure]' passed (0.084 seconds).
+Test Suite 'AppStateTests' passed at 2026-04-12 20:06:43.602.
+	 Executed 54 tests, with 0 failures (0 unexpected) in 3.110 (3.126) seconds
+Test Suite 'DebugBundleExporterTests' started at 2026-04-12 20:06:43.602.
+Test Case '-[BugNarratorTests.DebugBundleExporterTests testWriteBundleCreatesExpectedFilesWithoutCredentials]' started.
+2026-04-12 20:06:43.609272-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.609Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:43.609504-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.609Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:43.610209-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:43.610Z [INFO] [settings] debug_mode_changed - Debug mode was enabled. Verbose diagnostics are now recorded locally. debug_mode=enabled
+Test Case '-[BugNarratorTests.DebugBundleExporterTests testWriteBundleCreatesExpectedFilesWithoutCredentials]' passed (0.012 seconds).
+Test Suite 'DebugBundleExporterTests' passed at 2026-04-12 20:06:43.614.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.012 (0.012) seconds
+Test Suite 'DiagnosticsLoggerTests' started at 2026-04-12 20:06:43.615.
+Test Case '-[BugNarratorTests.DiagnosticsLoggerTests testDebugLogsAreSuppressedUnlessDebugModeIsEnabled]' started.
+Test Case '-[BugNarratorTests.DiagnosticsLoggerTests testDebugLogsAreSuppressedUnlessDebugModeIsEnabled]' passed (0.156 seconds).
+Test Case '-[BugNarratorTests.DiagnosticsLoggerTests testLoggerRedactsCredentialsFromMetadataAndMessage]' started.
+2026-04-12 20:06:43.772024-0400 BugNarrator[64124:1112882] [settings] 2026-04-13T00:06:43.772Z [INFO] [settings] credential_event - Validation failed for <redacted> and <redacted> apiKey=<redacted> githubToken=<redacted> note=<redacted>
+Test Case '-[BugNarratorTests.DiagnosticsLoggerTests testLoggerRedactsCredentialsFromMetadataAndMessage]' passed (0.102 seconds).
+Test Suite 'DiagnosticsLoggerTests' passed at 2026-04-12 20:06:43.874.
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.258 (0.259) seconds
+Test Suite 'GitHubExportProviderTests' started at 2026-04-12 20:06:43.874.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' started.
+2026-04-12 20:06:43.875039-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.875Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=1 repository=acme/bugnarrator session_id=A176CA17-B964-45A5-A5E0-8EF59A36F571
+2026-04-12 20:06:43.878018-0400 BugNarrator[64124:1112876] [export] 2026-04-13T00:06:43.878Z [ERROR] [export] github_export_failed - Export failed: GitHub could not find acme/bugnarrator. Check the owner, repository name, and token permissions. source_issue_id=0EA0B59D-7235-4639-B23F-79A0304BD307 successful_count=0
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-12 20:06:43.879835-0400 BugNarrator[64124:1112918] [export] 2026-04-13T00:06:43.880Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=2 repository=acme/bugnarrator session_id=E3AE1F73-359E-4BBB-9862-D8B421CBF522
+2026-04-12 20:06:43.880679-0400 BugNarrator[64124:1112876] [export] 2026-04-13T00:06:43.880Z [INFO] [export] github_issue_exported - Exported one issue to GitHub. remote_identifier=#101 source_issue_id=2A911B18-DAD8-4A54-AB6A-C65077EAE08A
+2026-04-12 20:06:43.881379-0400 BugNarrator[64124:1112918] [export] 2026-04-13T00:06:43.881Z [ERROR] [export] github_export_failed - Export failed: GitHub rejected the issue payload: Validation Failed source_issue_id=C65A94BD-A74D-4772-A801-1C1FE4015DEA successful_count=1
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' started.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' passed (0.001 seconds).
+Test Suite 'GitHubExportProviderTests' passed at 2026-04-12 20:06:43.884.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.009 (0.010) seconds
+Test Suite 'IssueExtractionServiceTests' started at 2026-04-12 20:06:43.884.
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' started.
+2026-04-12 20:06:43.884910-0400 BugNarrator[64124:1112918] [transcription] 2026-04-13T00:06:43.885Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=70A327DD-4842-4E65-8EC1-4897C962CEBB
+2026-04-12 20:06:43.888011-0400 BugNarrator[64124:1112871] [transcription] 2026-04-13T00:06:43.888Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=70A327DD-4842-4E65-8EC1-4897C962CEBB
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' started.
+2026-04-12 20:06:43.889668-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:43.889Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=C754EFF8-6303-45C0-99A1-B4161333CC38
+2026-04-12 20:06:43.890657-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:43.890Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings. session_id=C754EFF8-6303-45C0-99A1-B4161333CC38
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' started.
+2026-04-12 20:06:43.892246-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:43.892Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=9FCEECC1-E339-47AA-AD0A-90D554322CB1
+2026-04-12 20:06:43.893231-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:43.893Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=9FCEECC1-E339-47AA-AD0A-90D554322CB1
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' started.
+2026-04-12 20:06:43.894842-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:43.895Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=36586B90-74DE-4184-A4DD-824ED27C0F3E
+2026-04-12 20:06:43.896541-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:43.896Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: Issue extraction took longer than 10 seconds. Retry the extraction or choose a faster model in Settings. session_id=36586B90-74DE-4184-A4DD-824ED27C0F3E
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' passed (0.003 seconds).
+Test Suite 'IssueExtractionServiceTests' passed at 2026-04-12 20:06:43.897.
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.012 (0.013) seconds
+Test Suite 'JiraExportProviderTests' started at 2026-04-12 20:06:43.897.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' started.
+2026-04-12 20:06:43.898413-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.898Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=1 project_key=FM session_id=8847F562-8BD6-4924-B2DD-A1CB1AB08AA1
+2026-04-12 20:06:43.899594-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.899Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=0167F252-FDFB-44DA-9D5B-C01D143D01B1 successful_count=0
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-12 20:06:43.901151-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.901Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=2 project_key=FM session_id=F6FD6FE3-3805-43BE-9E6D-78EB8445E208
+2026-04-12 20:06:43.901970-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.902Z [INFO] [export] jira_issue_exported - Exported one issue to Jira. remote_identifier=FM-101 source_issue_id=E978BFB3-2D94-44FE-B978-A9B41B8F6A19
+2026-04-12 20:06:43.902769-0400 BugNarrator[64124:1112871] [export] 2026-04-13T00:06:43.903Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=D5A116A8-61DB-4C6E-AA9E-6D92BB0DE5CE successful_count=1
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' started.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' passed (0.001 seconds).
+Test Suite 'JiraExportProviderTests' passed at 2026-04-12 20:06:43.905.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.007 (0.008) seconds
+Test Suite 'KeychainServiceTests' started at 2026-04-12 20:06:43.905.
+Test Case '-[BugNarratorTests.KeychainServiceTests testInteractiveReadQueryDoesNotForceAuthenticationUIFailure]' started.
+Test Case '-[BugNarratorTests.KeychainServiceTests testInteractiveReadQueryDoesNotForceAuthenticationUIFailure]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.KeychainServiceTests testNonInteractiveReadQueryDisablesKeychainUI]' started.
+Test Case '-[BugNarratorTests.KeychainServiceTests testNonInteractiveReadQueryDisablesKeychainUI]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.KeychainServiceTests testXCTestEnvironmentBypassesSystemKeychain]' started.
+Test Case '-[BugNarratorTests.KeychainServiceTests testXCTestEnvironmentBypassesSystemKeychain]' passed (0.001 seconds).
+Test Suite 'KeychainServiceTests' passed at 2026-04-12 20:06:43.910.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
+Test Suite 'MenuBarStatusPresentationTests' started at 2026-04-12 20:06:43.910.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testDefaultIdleStateStaysCompact]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testDefaultIdleStateStaysCompact]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testMicrophoneErrorUsesRecoveryWidthAndAction]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testMicrophoneErrorUsesRecoveryWidthAndAction]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testMicrophoneUnavailableUsesRecoveryWidthAndAction]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testMicrophoneUnavailableUsesRecoveryWidthAndAction]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testOpenAIErrorUsesSettingsRecoveryAction]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testOpenAIErrorUsesSettingsRecoveryAction]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testScreenRecordingErrorUsesRecoveryWidthAndAction]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testScreenRecordingErrorUsesRecoveryWidthAndAction]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testTranscribingStateExpandsWidthForLongRunningStatus]' started.
+Test Case '-[BugNarratorTests.MenuBarStatusPresentationTests testTranscribingStateExpandsWidthForLongRunningStatus]' passed (0.001 seconds).
+Test Suite 'MenuBarStatusPresentationTests' passed at 2026-04-12 20:06:43.916.
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.004 (0.006) seconds
+Test Suite 'MicrophonePermissionResolverTests' started at 2026-04-12 20:06:43.916.
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testAuthorizedWinsWhenPermissionSourcesDisagree]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testAuthorizedWinsWhenPermissionSourcesDisagree]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testDeniedIsReturnedWhenBothSourcesAreDenied]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testDeniedIsReturnedWhenBothSourcesAreDenied]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testNotDeterminedWinsOverDeniedWhenPermissionPromptIsStillPossible]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testNotDeterminedWinsOverDeniedWhenPermissionPromptIsStillPossible]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testRestrictedWinsWhenNothingIsAuthorizedOrRequestable]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionResolverTests testRestrictedWinsWhenNothingIsAuthorizedOrRequestable]' passed (0.001 seconds).
+Test Suite 'MicrophonePermissionResolverTests' passed at 2026-04-12 20:06:43.923.
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.007) seconds
+Test Suite 'MicrophonePermissionServiceTests' started at 2026-04-12 20:06:43.923.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testCurrentStatusReturnsGrantedWhenPermissionIsAuthorized]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testCurrentStatusReturnsGrantedWhenPermissionIsAuthorized]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightDoesNotOverrideDeniedPermissionEvenIfProbeCouldSucceed]' started.
+2026-04-12 20:06:43.928790-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.929Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.928994-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.929Z [WARNING] [permissions] microphone_permission_denied - Microphone access was denied.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightDoesNotOverrideDeniedPermissionEvenIfProbeCouldSucceed]' passed (0.028 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightRequestsPermissionAndSucceedsWhenGranted]' started.
+2026-04-12 20:06:43.953328-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.953Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightRequestsPermissionAndSucceedsWhenGranted]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsBlockedWhenPermissionRestricted]' started.
+2026-04-12 20:06:43.954944-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.955Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.955151-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.955Z [WARNING] [permissions] microphone_permission_restricted - Microphone access is restricted.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsBlockedWhenPermissionRestricted]' passed (0.015 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsFailureWhenGrantedPermissionStillCannotStartRecorder]' started.
+2026-04-12 20:06:43.969959-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.970Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.970162-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.970Z [ERROR] [permissions] microphone_capture_setup_failed - BugNarrator could not start audio capture. The selected microphone could not be opened.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsFailureWhenGrantedPermissionStillCannotStartRecorder]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsNeedsUserActionWhenPermissionDenied]' started.
+2026-04-12 20:06:43.971763-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.971Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+2026-04-12 20:06:43.971967-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:43.972Z [WARNING] [permissions] microphone_permission_denied - Microphone access was denied.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightReturnsNeedsUserActionWhenPermissionDenied]' passed (0.102 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightSucceedsWhenBlockedPermissionStateRefreshesToGranted]' started.
+2026-04-12 20:06:44.073872-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.074Z [INFO] [permissions] microphone_preflight_started - Running microphone permission and recorder preflight before starting a session.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testPreflightSucceedsWhenBlockedPermissionStateRefreshesToGranted]' passed (0.013 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testRecoveryGuidanceIncludesCaptureSetupFailureState]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testRecoveryGuidanceIncludesCaptureSetupFailureState]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testRecoveryGuidanceIncludesLocalTestingNoteForDerivedDataBuilds]' started.
+Test Case '-[BugNarratorTests.MicrophonePermissionServiceTests testRecoveryGuidanceIncludesLocalTestingNoteForDerivedDataBuilds]' passed (0.001 seconds).
+Test Suite 'MicrophonePermissionServiceTests' passed at 2026-04-12 20:06:44.088.
+	 Executed 9 tests, with 0 failures (0 unexpected) in 0.162 (0.165) seconds
+Test Suite 'ProductInfoTests' started at 2026-04-12 20:06:44.088.
+Test Case '-[BugNarratorTests.ProductInfoTests testChangelogHighlightsUseLatestReleaseSection]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testChangelogHighlightsUseLatestReleaseSection]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testMetadataBuildsVersionDescriptionFromInfoDictionary]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testMetadataBuildsVersionDescriptionFromInfoDictionary]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testMetadataFallsBackToDefaultsWhenBundleValuesAreMissing]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testMetadataFallsBackToDefaultsWhenBundleValuesAreMissing]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testProjectLinksUseExpectedPublicURLs]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testProjectLinksUseExpectedPublicURLs]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testRuntimeEnvironmentDetectsLocalTestingBuildsFromDerivedData]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testRuntimeEnvironmentDetectsLocalTestingBuildsFromDerivedData]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testRuntimeEnvironmentDoesNotTreatInstalledBuildAsLocalTestingBuild]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testRuntimeEnvironmentDoesNotTreatInstalledBuildAsLocalTestingBuild]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ProductInfoTests testSupportDevelopmentLinkUsesHostedPayPalPage]' started.
+Test Case '-[BugNarratorTests.ProductInfoTests testSupportDevelopmentLinkUsesHostedPayPalPage]' passed (0.001 seconds).
+Test Suite 'ProductInfoTests' passed at 2026-04-12 20:06:44.094.
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.005 (0.006) seconds
+Test Suite 'ReviewWorkspaceTests' started at 2026-04-12 20:06:44.094.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testAvailableTabsIncludeSummaryOnlyWhenSessionHasSummaryContent]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testAvailableTabsIncludeSummaryOnlyWhenSessionHasSummaryContent]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testClampedTabFallsBackToSummaryWhenReviewSummaryIsAvailable]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testClampedTabFallsBackToSummaryWhenReviewSummaryIsAvailable]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testPendingTranscriptionSessionUsesRecoveryTimelineEntry]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testPendingTranscriptionSessionUsesRecoveryTimelineEntry]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testSelectedIssueSummaryCountsOnlySelectedIssues]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testSelectedIssueSummaryCountsOnlySelectedIssues]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesCombineScreenshotAndLinkedMarkerAtSameTimestamp]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesCombineScreenshotAndLinkedMarkerAtSameTimestamp]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesKeepLegacyMarkerWithoutScreenshot]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesKeepLegacyMarkerWithoutScreenshot]' passed (0.001 seconds).
+Test Suite 'ReviewWorkspaceTests' passed at 2026-04-12 20:06:44.105.
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.004 (0.011) seconds
+Test Suite 'ScreenCapturePermissionServiceTests' started at 2026-04-12 20:06:44.106.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testCurrentStatusReturnsGrantedWhenPermissionIsAvailable]' started.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testCurrentStatusReturnsGrantedWhenPermissionIsAvailable]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightRequestsPermissionAndSucceedsWhenGranted]' started.
+2026-04-12 20:06:44.107379-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.107Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightRequestsPermissionAndSucceedsWhenGranted]' passed (0.104 seconds).
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsBlockedWhenThereIsNoActiveRecordingSession]' started.
+2026-04-12 20:06:44.213392-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.213Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:44.214062-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.214Z [WARNING] [permissions] screen_capture_preflight_no_session - Start a feedback session before capturing a screenshot.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsBlockedWhenThereIsNoActiveRecordingSession]' passed (0.106 seconds).
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsFailureWhenCaptureValidationFailsAfterPermissionIsGranted]' started.
+2026-04-12 20:06:44.320341-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.319Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:44.320947-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.321Z [ERROR] [permissions] screen_capture_capability_failed - Screenshot capture failed: No displays were available to capture.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsFailureWhenCaptureValidationFailsAfterPermissionIsGranted]' passed (0.106 seconds).
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsNeedsUserActionWhenPermissionIsDenied]' started.
+2026-04-12 20:06:44.427418-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.427Z [INFO] [permissions] screen_capture_preflight_started - Running screen capture permission and capability preflight before taking a screenshot.
+2026-04-12 20:06:44.428475-0400 BugNarrator[64124:1112862] [permissions] 2026-04-13T00:06:44.428Z [WARNING] [permissions] screen_recording_permission_denied - Screen Recording access was denied.
+Test Case '-[BugNarratorTests.ScreenCapturePermissionServiceTests testPreflightReturnsNeedsUserActionWhenPermissionIsDenied]' passed (0.108 seconds).
+Test Suite 'ScreenCapturePermissionServiceTests' passed at 2026-04-12 20:06:44.532.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.423 (0.427) seconds
+Test Suite 'ScreenshotCaptureServiceTests' started at 2026-04-12 20:06:44.533.
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotCreatesParentDirectoryAndWritesCompositePNG]' started.
+2026-04-12 20:06:44.692406-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:44.691Z [INFO] [screenshots] screenshot_capture_requested - Capturing a screenshot for the active review session. file_name=capture.png selection_height=50 selection_width=150
+2026-04-12 20:06:44.698112-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:44.697Z [INFO] [screenshots] screenshot_capture_succeeded - Saved a screenshot for the active review session. display_count=2 file_name=capture.png selection_height=50 selection_width=150
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotCreatesParentDirectoryAndWritesCompositePNG]' passed (0.172 seconds).
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotCropsToSelectedRegion]' started.
+2026-04-12 20:06:44.864072-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:44.863Z [INFO] [screenshots] screenshot_capture_requested - Capturing a screenshot for the active review session. file_name=capture.png selection_height=40 selection_width=30
+2026-04-12 20:06:44.868474-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:44.868Z [INFO] [screenshots] screenshot_capture_succeeded - Saved a screenshot for the active review session. display_count=1 file_name=capture.png selection_height=40 selection_width=30
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotCropsToSelectedRegion]' passed (0.165 seconds).
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotFailsWhenNoDisplaysAreAvailable]' started.
+2026-04-12 20:06:45.033564-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:45.033Z [INFO] [screenshots] screenshot_capture_requested - Capturing a screenshot for the active review session. file_name=capture.png selection_height=50 selection_width=100
+2026-04-12 20:06:45.034266-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:45.034Z [ERROR] [screenshots] screenshot_capture_no_displays - No displays were available for ScreenCaptureKit.
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotFailsWhenNoDisplaysAreAvailable]' passed (0.163 seconds).
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotFailsWhenSelectionDoesNotIntersectActiveDisplays]' started.
+2026-04-12 20:06:45.197455-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:45.197Z [INFO] [screenshots] screenshot_capture_requested - Capturing a screenshot for the active review session. file_name=capture.png selection_height=40 selection_width=40
+2026-04-12 20:06:45.198298-0400 BugNarrator[64124:1112862] [screenshots] 2026-04-13T00:06:45.198Z [WARNING] [screenshots] screenshot_capture_selection_off_display - The requested screenshot area did not overlap any active display.
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testCaptureScreenshotFailsWhenSelectionDoesNotIntersectActiveDisplays]' passed (0.163 seconds).
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testValidateCaptureAvailabilityReturnsPermissionDeniedError]' started.
+Test Case '-[BugNarratorTests.ScreenshotCaptureServiceTests testValidateCaptureAvailabilityReturnsPermissionDeniedError]' passed (0.064 seconds).
+Test Suite 'ScreenshotCaptureServiceTests' passed at 2026-04-12 20:06:45.265.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.727 (0.732) seconds
+Test Suite 'ScreenshotSelectionServiceTests' started at 2026-04-12 20:06:45.266.
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsNilForTinySelection]' started.
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsNilForTinySelection]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsNilForZeroSizedSelection]' started.
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsNilForZeroSizedSelection]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsStandardizedRect]' started.
+Test Case '-[BugNarratorTests.ScreenshotSelectionServiceTests testNormalizedSelectionRectReturnsStandardizedRect]' passed (0.002 seconds).
+Test Suite 'ScreenshotSelectionServiceTests' passed at 2026-04-12 20:06:45.276.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.008 (0.010) seconds
+Test Suite 'SessionArtifactsServiceTests' started at 2026-04-12 20:06:45.276.
+Test Case '-[BugNarratorTests.SessionArtifactsServiceTests testMakeScreenshotURLSanitizesPrefix]' started.
+Test Case '-[BugNarratorTests.SessionArtifactsServiceTests testMakeScreenshotURLSanitizesPrefix]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.SessionArtifactsServiceTests testRemoveArtifactsDirectoryOnlyDeletesManagedDirectories]' started.
+2026-04-12 20:06:45.286526-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:45.286Z [WARNING] [session-library] artifacts_directory_rejected - Skipped cleanup for a directory outside BugNarrator-managed artifacts storage. directory_name=External
+Test Case '-[BugNarratorTests.SessionArtifactsServiceTests testRemoveArtifactsDirectoryOnlyDeletesManagedDirectories]' passed (0.004 seconds).
+Test Suite 'SessionArtifactsServiceTests' passed at 2026-04-12 20:06:45.288.
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.009 (0.011) seconds
+Test Suite 'SessionLibraryTests' started at 2026-04-12 20:06:45.288.
+Test Case '-[BugNarratorTests.SessionLibraryTests testCustomDateRangeFilteringAndSearchWorkTogether]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testCustomDateRangeFilteringAndSearchWorkTogether]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testDateBucketFilteringHandlesMidnightBoundariesInLocalTimezone]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testDateBucketFilteringHandlesMidnightBoundariesInLocalTimezone]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testDateBucketFilteringReturnsExpectedSessions]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testDateBucketFilteringReturnsExpectedSessions]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testDisplayTitleFallsBackToUntitledSessionWhenTranscriptIsBlank]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testDisplayTitleFallsBackToUntitledSessionWhenTranscriptIsBlank]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testEmptyStateCoversNoSessionsNoResultsAndNoFilterMatches]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testEmptyStateCoversNoSessionsNoResultsAndNoFilterMatches]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testFilterCountsReflectUnderlyingSessions]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testFilterCountsReflectUnderlyingSessions]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testPreviewTextTruncatesAtWordBoundaryWithEllipsis]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testPreviewTextTruncatesAtWordBoundaryWithEllipsis]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testRetryNeededFilterReturnsOnlyPendingTranscriptionSessions]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testRetryNeededFilterReturnsOnlyPendingTranscriptionSessions]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testSearchMatchesTitleTranscriptAndSummary]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testSearchMatchesTitleTranscriptAndSummary]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testSnapshotSupportsIndexedEntriesForLargeHistory]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testSnapshotSupportsIndexedEntriesForLargeHistory]' passed (0.028 seconds).
+Test Case '-[BugNarratorTests.SessionLibraryTests testSortOrderCanSwitchToOldestFirst]' started.
+Test Case '-[BugNarratorTests.SessionLibraryTests testSortOrderCanSwitchToOldestFirst]' passed (0.002 seconds).
+Test Suite 'SessionLibraryTests' passed at 2026-04-12 20:06:45.331.
+	 Executed 11 tests, with 0 failures (0 unexpected) in 0.040 (0.043) seconds
+Test Suite 'SettingsStoreTests' started at 2026-04-12 20:06:45.331.
+Test Case '-[BugNarratorTests.SettingsStoreTests testAPIKeyFallsBackToSessionOnlyWhenKeychainWriteFails]' started.
+2026-04-12 20:06:45.338565-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.338Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.338888-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.339Z [WARNING] [settings] secret_persisted_in_memory - Keychain storage was unavailable, so a secure value is only kept in memory for this run. slot=openai
+2026-04-12 20:06:45.342298-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.342Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testAPIKeyFallsBackToSessionOnlyWhenKeychainWriteFails]' passed (0.012 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testAPIKeyStaysOutOfUserDefaultsWhenKeychainSucceeds]' started.
+2026-04-12 20:06:45.348850-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.349Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.349079-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.349Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+Test Case '-[BugNarratorTests.SettingsStoreTests testAPIKeyStaysOutOfUserDefaultsWhenKeychainSucceeds]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testDefaultLegacyDefaultsDomainsOnlyIncludeSessionMic]' started.
+Test Case '-[BugNarratorTests.SettingsStoreTests testDefaultLegacyDefaultsDomainsOnlyIncludeSessionMic]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testDuplicateHotkeyAssignmentsAreRejectedAndKeepExistingAction]' started.
+2026-04-12 20:06:45.357241-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.357Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.357820-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.358Z [WARNING] [settings] hotkey_conflict_rejected - A conflicting hotkey assignment was rejected. action=Stop Recording conflict_action=Start Recording shortcut=Opt+Cmd+X
+Test Case '-[BugNarratorTests.SettingsStoreTests testDuplicateHotkeyAssignmentsAreRejectedAndKeepExistingAction]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testFirstLaunchStartsWithAllHotkeysDisabled]' started.
+2026-04-12 20:06:45.364731-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.364Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testFirstLaunchStartsWithAllHotkeysDisabled]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testJiraEmailStaysOutOfUserDefaultsWhenKeychainSucceeds]' started.
+2026-04-12 20:06:45.371594-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.371Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.371841-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.372Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira-email
+Test Case '-[BugNarratorTests.SettingsStoreTests testJiraEmailStaysOutOfUserDefaultsWhenKeychainSucceeds]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginFailurePreservesStatusMessageWhenServiceProvidesOne]' started.
+2026-04-12 20:06:45.376155-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.376Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=enabled launch_at_login_supported=yes
+2026-04-12 20:06:45.376437-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.376Z [ERROR] [settings] launch_at_login_update_failed - Updating the launch-at-login setting failed. requested_state=disabled status=requires_approval
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginFailurePreservesStatusMessageWhenServiceProvidesOne]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginFailureRestoresActualStateAndShowsError]' started.
+2026-04-12 20:06:45.380652-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.380Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-12 20:06:45.380943-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.381Z [ERROR] [settings] launch_at_login_update_failed - Updating the launch-at-login setting failed. requested_state=enabled status=disabled
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginFailureRestoresActualStateAndShowsError]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginRequiresApprovalSurfacesWarningState]' started.
+2026-04-12 20:06:45.384612-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.384Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=enabled launch_at_login_supported=yes
+Test Case '-[BugNarratorTests.SettingsStoreTests testLaunchAtLoginRequiresApprovalSurfacesWarningState]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testLegacyBuiltInShortcutsAreClearedDuringMigration]' started.
+2026-04-12 20:06:45.391820-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.392Z [INFO] [settings] legacy_hotkey_defaults_cleared - Cleared previously built-in hotkey defaults so shortcuts start unassigned. cleared_actions=Start Recording,Stop Recording
+2026-04-12 20:06:45.392314-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.392Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testLegacyBuiltInShortcutsAreClearedDuringMigration]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testLegacyPlaintextJiraEmailIsMigratedToSecureStorage]' started.
+2026-04-12 20:06:45.398420-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.398Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira-email
+2026-04-12 20:06:45.398978-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.399Z [INFO] [settings] migrated_plaintext_jira_email - Migrated the Jira export email out of plain preferences storage. persistence_state=keychain
+2026-04-12 20:06:45.399948-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.400Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testLegacyPlaintextJiraEmailIsMigratedToSecureStorage]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testMaskedAPIKeyOnlyExposesSuffix]' started.
+2026-04-12 20:06:45.407148-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.407Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.407388-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.407Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+Test Case '-[BugNarratorTests.SettingsStoreTests testMaskedAPIKeyOnlyExposesSuffix]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testMaskedExportTokensOnlyExposeSuffix]' started.
+2026-04-12 20:06:45.414474-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.414Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.414703-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.415Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:45.414916-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.415Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira
+Test Case '-[BugNarratorTests.SettingsStoreTests testMaskedExportTokensOnlyExposeSuffix]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testObsoleteMarkerHotkeyIsRemovedDuringLoad]' started.
+2026-04-12 20:06:45.421664-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.421Z [INFO] [settings] removed_obsolete_marker_hotkey - Removed the obsolete standalone marker hotkey assignment during settings load.
+2026-04-12 20:06:45.422653-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.422Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testObsoleteMarkerHotkeyIsRemovedDuringLoad]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testRemoveAPIKeyClearsStoredValue]' started.
+2026-04-12 20:06:45.428975-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.429Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.429208-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.429Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:45.429405-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.429Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=openai
+2026-04-12 20:06:45.429574-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.429Z [INFO] [settings] remove_openai_key - The OpenAI API key was removed from local storage.
+Test Case '-[BugNarratorTests.SettingsStoreTests testRemoveAPIKeyClearsStoredValue]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testRemoveExportTokensClearsStoredValues]' started.
+2026-04-12 20:06:45.436600-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.436Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.436858-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.437Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:45.437082-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.437Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira
+2026-04-12 20:06:45.437297-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.437Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=github
+2026-04-12 20:06:45.437477-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.437Z [INFO] [settings] remove_github_token - The GitHub export token was removed from local storage.
+2026-04-12 20:06:45.437677-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.438Z [INFO] [settings] secret_cleared - A secure value was cleared from persistent storage. slot=jira
+2026-04-12 20:06:45.437853-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.438Z [INFO] [settings] remove_jira_token - The Jira API token was removed from local storage.
+Test Case '-[BugNarratorTests.SettingsStoreTests testRemoveExportTokensClearsStoredValues]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsLoadFromLegacyDefaultsDomain]' started.
+2026-04-12 20:06:45.447300-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.447Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsLoadFromLegacyDefaultsDomain]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsLoadLegacyKeychainServiceAndMigrateToBugNarratorNamespace]' started.
+2026-04-12 20:06:45.449822-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.450Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:45.455490-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.455Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=yes launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsLoadLegacyKeychainServiceAndMigrateToBugNarratorNamespace]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsPersistAcrossReloads]' started.
+2026-04-12 20:06:45.459168-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.459Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-12 20:06:45.459409-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.459Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+2026-04-12 20:06:45.460394-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.460Z [INFO] [settings] launch_at_login_updated - BugNarrator will open automatically at login. status=enabled
+2026-04-12 20:06:45.460898-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.461Z [INFO] [settings] debug_mode_changed - Debug mode was enabled. Verbose diagnostics are now recorded locally. debug_mode=enabled
+2026-04-12 20:06:45.461559-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.461Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:45.462157-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.462Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira-email
+2026-04-12 20:06:45.462382-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.462Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira
+2026-04-12 20:06:45.463880-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.464Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=enabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=yes launch_at_login=enabled launch_at_login_supported=yes
+Test Case '-[BugNarratorTests.SettingsStoreTests testSettingsPersistAcrossReloads]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupShowsKeychainLockedStateWithoutUnlockPrompt]' started.
+2026-04-12 20:06:45.471347-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.471Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupShowsKeychainLockedStateWithoutUnlockPrompt]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupSkipsInteractiveLegacyExportKeychainPromptsUntilUserInitiatesAccess]' started.
+2026-04-12 20:06:45.477651-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.477Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.477900-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.478Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=github
+2026-04-12 20:06:45.478105-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.478Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=jira
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupSkipsInteractiveLegacyExportKeychainPromptsUntilUserInitiatesAccess]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupSkipsInteractiveLegacyKeychainPromptUntilUserInitiatesAccess]' started.
+2026-04-12 20:06:45.485066-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.485Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=no
+2026-04-12 20:06:45.485331-0400 BugNarrator[64124:1112862] [settings] 2026-04-13T00:06:45.485Z [INFO] [settings] secret_persisted - A secure value was saved to Keychain. slot=openai
+Test Case '-[BugNarratorTests.SettingsStoreTests testStartupSkipsInteractiveLegacyKeychainPromptUntilUserInitiatesAccess]' passed (0.007 seconds).
+Test Suite 'SettingsStoreTests' passed at 2026-04-12 20:06:45.486.
+	 Executed 22 tests, with 0 failures (0 unexpected) in 0.149 (0.155) seconds
+Test Suite 'SingleInstanceControllerTests' started at 2026-04-12 20:06:45.486.
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionIsPrimaryWhenNoOtherInstanceMatchesBundleIdentifier]' started.
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionIsPrimaryWhenNoOtherInstanceMatchesBundleIdentifier]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionRejectsSecondInstanceWhenAnotherProcessSharesBundleIdentifier]' started.
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionRejectsSecondInstanceWhenAnotherProcessSharesBundleIdentifier]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionUsesLowestExistingProcessIdentifierWhenMultipleInstancesAreVisible]' started.
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testLaunchDispositionUsesLowestExistingProcessIdentifierWhenMultipleInstancesAreVisible]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testRuntimeEnvironmentBypassesSingleInstanceEnforcementUnderXCTest]' started.
+Test Case '-[BugNarratorTests.SingleInstanceControllerTests testRuntimeEnvironmentBypassesSingleInstanceEnforcementUnderXCTest]' passed (0.001 seconds).
+Test Suite 'SingleInstanceControllerTests' passed at 2026-04-12 20:06:45.491.
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
+Test Suite 'TranscriptExporterTests' started at 2026-04-12 20:06:45.491.
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleCreatesExpectedFilesAndCopiesScreenshots]' started.
+2026-04-12 20:06:45.494005-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:45.494Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=1 missing_screenshot_count=0 screenshot_count=1 session_id=23923EA9-AC98-452C-9FB1-50171B073D7B
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleCreatesExpectedFilesAndCopiesScreenshots]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames]' started.
+2026-04-12 20:06:45.498726-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:45.498Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=2 missing_screenshot_count=0 screenshot_count=2 session_id=C5E0FD76-DD95-45C7-A726-985C88CEECDE
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleSkipsMissingScreenshotFilesButStillCreatesScreenshotsDirectory]' started.
+2026-04-12 20:06:45.502737-0400 BugNarrator[64124:1112862] [export] 2026-04-13T00:06:45.502Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=0 missing_screenshot_count=1 screenshot_count=1 session_id=FFD0B759-0B2A-4915-BB5A-7F825C2355F7
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleSkipsMissingScreenshotFilesButStillCreatesScreenshotsDirectory]' passed (0.003 seconds).
+Test Suite 'TranscriptExporterTests' passed at 2026-04-12 20:06:45.504.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.012 (0.013) seconds
+Test Suite 'TranscriptStoreTests' started at 2026-04-12 20:06:45.504.
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreKeepsMostRecentFiveHundredSessions]' started.
+2026-04-12 20:06:45.505403-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:45.505Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreKeepsMostRecentFiveHundredSessions]' passed (4.663 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStorePersistsPendingTranscriptionMetadataAcrossReloads]' started.
+2026-04-12 20:06:50.168885-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.169Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.170471-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.170Z [INFO] [session-library] session_store_loaded - Loaded session history from primary storage. session_count=1
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStorePersistsPendingTranscriptionMetadataAcrossReloads]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStorePersistsSessionsAcrossReloads]' started.
+2026-04-12 20:06:50.172539-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.172Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.174133-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.174Z [INFO] [session-library] session_store_loaded - Loaded session history from primary storage. session_count=1
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStorePersistsSessionsAcrossReloads]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRecoversFromBackupWhenPrimaryFileIsCorrupt]' started.
+2026-04-12 20:06:50.176051-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.176Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.178372-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.178Z [WARNING] [session-library] session_store_decode_failed - Session history could not be decoded from disk. file=sessions.json
+2026-04-12 20:06:50.179801-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.180Z [WARNING] [session-library] session_store_recovered_from_backup - Recovered session history from the backup store after the primary store failed to load. session_count=1
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRecoversFromBackupWhenPrimaryFileIsCorrupt]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRemovesSessionsAndPersistsDeletion]' started.
+2026-04-12 20:06:50.181764-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.182Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.184960-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.185Z [INFO] [session-library] sessions_deleted - Removed sessions from local history. remaining_sessions=1 removed_count=1
+2026-04-12 20:06:50.185628-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.185Z [INFO] [session-library] session_store_loaded - Loaded session history from primary storage. session_count=1
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRemovesSessionsAndPersistsDeletion]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRollsBackInMemoryAddWhenPersistFails]' started.
+2026-04-12 20:06:50.187973-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.188Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.189842-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.190Z [ERROR] [session-library] session_save_failed - Saving session history failed. session_id=3DDA0607-A8FA-4B0B-8582-CB5EA6BEE239
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRollsBackInMemoryAddWhenPersistFails]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRollsBackRemovalWhenPersistFails]' started.
+2026-04-12 20:06:50.192864-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.193Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 20:06:50.196070-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.196Z [ERROR] [session-library] session_delete_failed - Removing sessions from local history failed. requested_count=1
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreRollsBackRemovalWhenPersistFails]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreTracksPendingTranscriptionSessionsForRecoverySurfacing]' started.
+2026-04-12 20:06:50.199314-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.199Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreTracksPendingTranscriptionSessionsForRecoverySurfacing]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreUpdatesLookupAndLibraryEntriesTogether]' started.
+2026-04-12 20:06:50.203119-0400 BugNarrator[64124:1112862] [session-library] 2026-04-13T00:06:50.203Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+Test Case '-[BugNarratorTests.TranscriptStoreTests testTranscriptStoreUpdatesLookupAndLibraryEntriesTogether]' passed (0.004 seconds).
+Test Suite 'TranscriptStoreTests' passed at 2026-04-12 20:06:50.206.
+	 Executed 9 tests, with 0 failures (0 unexpected) in 4.699 (4.702) seconds
+Test Suite 'TranscriptionClientTests' started at 2026-04-12 20:06:50.206.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testMakeURLRequestIncludesMultipartFieldsAndAuthorization]' started.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testMakeURLRequestIncludesMultipartFieldsAndAuthorization]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeMapsAPIErrorResponse]' started.
+2026-04-12 20:06:50.211338-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:50.211Z [INFO] [transcription] transcription_requested - Uploading audio to OpenAI for transcription. file_name=BugNarrator-TranscriptionTests-api-error.m4a has_language_hint=no has_prompt=no model=whisper-1
+2026-04-12 20:06:50.212073-0400 BugNarrator[64124:1112871] [transcription] 2026-04-13T00:06:50.212Z [WARNING] [transcription] transcription_rejected - OpenAI rejected the transcription request. status_code=401
+2026-04-12 20:06:50.212461-0400 BugNarrator[64124:1112871] [transcription] 2026-04-13T00:06:50.212Z [ERROR] [transcription] transcription_failed - The OpenAI API key was rejected. Open Settings, replace it, and try again.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeMapsAPIErrorResponse]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeMapsNetworkTimeout]' started.
+2026-04-12 20:06:50.215047-0400 BugNarrator[64124:1112871] [transcription] 2026-04-13T00:06:50.215Z [INFO] [transcription] transcription_requested - Uploading audio to OpenAI for transcription. file_name=BugNarrator-TranscriptionTests-timeout.m4a has_language_hint=no has_prompt=no model=whisper-1
+2026-04-12 20:06:50.215527-0400 BugNarrator[64124:1112882] [Default] Task <D9830766-01FE-4E68-8884-5343ECE33F41>.<1> finished with error [-1001] Error Domain=NSURLErrorDomain Code=-1001 "(null)" UserInfo={_NSURLErrorRelatedURLSessionTaskErrorKey=(
+    "LocalDataTask <D9830766-01FE-4E68-8884-5343ECE33F41>.<1>"
+), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <D9830766-01FE-4E68-8884-5343ECE33F41>.<1>}
+2026-04-12 20:06:50.216871-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.217Z [ERROR] [transcription] transcription_failed - The operation couldn’t be completed. (NSURLErrorDomain error -1001.)
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeMapsNetworkTimeout]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeRejectsEmptyAudioFileBeforeMakingNetworkCall]' started.
+2026-04-12 20:06:50.219139-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:50.219Z [ERROR] [transcription] transcription_audio_empty - The recorded audio file was empty before upload. file_name=BugNarrator-TranscriptionTests-empty.m4a
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeRejectsEmptyAudioFileBeforeMakingNetworkCall]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeRejectsEmptyTranscriptPayload]' started.
+2026-04-12 20:06:50.222045-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.222Z [INFO] [transcription] transcription_requested - Uploading audio to OpenAI for transcription. file_name=BugNarrator-TranscriptionTests-empty-transcript.m4a has_language_hint=no has_prompt=no model=whisper-1
+2026-04-12 20:06:50.223439-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.223Z [WARNING] [transcription] transcription_empty - OpenAI returned an empty transcript.
+2026-04-12 20:06:50.223720-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.224Z [ERROR] [transcription] transcription_failed - The transcription finished but returned empty text.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testTranscribeRejectsEmptyTranscriptPayload]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testValidateAPIKeyMakesBearerRequest]' started.
+2026-04-12 20:06:50.225550-0400 BugNarrator[64124:1112871] [transcription] 2026-04-13T00:06:50.225Z [INFO] [transcription] openai_key_validation_requested - Validating the OpenAI API key.
+2026-04-12 20:06:50.226449-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.226Z [INFO] [transcription] openai_key_validation_succeeded - The OpenAI API key was accepted.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testValidateAPIKeyMakesBearerRequest]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.TranscriptionClientTests testValidateAPIKeyMapsRevokedKeyResponse]' started.
+2026-04-12 20:06:50.229381-0400 BugNarrator[64124:1112882] [transcription] 2026-04-13T00:06:50.229Z [INFO] [transcription] openai_key_validation_requested - Validating the OpenAI API key.
+2026-04-12 20:06:50.230307-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:50.230Z [WARNING] [transcription] openai_key_validation_rejected - The OpenAI API key validation request was rejected. status_code=401
+2026-04-12 20:06:50.230559-0400 BugNarrator[64124:1112886] [transcription] 2026-04-13T00:06:50.230Z [ERROR] [transcription] openai_key_validation_failed - The OpenAI API key is no longer valid. Open Settings, remove it, and add a new key.
+Test Case '-[BugNarratorTests.TranscriptionClientTests testValidateAPIKeyMapsRevokedKeyResponse]' passed (0.013 seconds).
+Test Suite 'TranscriptionClientTests' passed at 2026-04-12 20:06:50.241.
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.033 (0.035) seconds
+Test Suite 'BugNarratorTests.xctest' passed at 2026-04-12 20:06:50.241.
+	 Executed 180 tests, with 0 failures (0 unexpected) in 9.746 (9.821) seconds
+Test Suite 'All tests' passed at 2026-04-12 20:06:50.241.
+	 Executed 180 tests, with 0 failures (0 unexpected) in 9.746 (9.822) seconds
+
+Test session results, code coverage, and logs:
+	/Users/deffenda/Library/Developer/Xcode/DerivedData/BugNarrator-czxvfnybddlunubhpbjguokkpsac/Logs/Test/Test-BugNarrator-2026.04.12_20-06-38--0400.xcresult
+
+** TEST SUCCEEDED **
+
+Testing started

--- a/scripts/accessibility_regression_check.sh
+++ b/scripts/accessibility_regression_check.sh
@@ -49,8 +49,8 @@ check_literal \
   'session-library filter selected-state announcement'
 check_literal \
   "$ROOT_DIR/Sources/BugNarrator/Views/TranscriptView.swift" \
-  '.accessibilityValue(selectedDetailTab == tab ? "Selected" : "Not selected")' \
-  'review tab selected-state announcement'
+  '.accessibilityAddTraits(.isHeader)' \
+  'review workspace section heading announcement'
 check_literal \
   "$ROOT_DIR/Sources/BugNarrator/Views/TranscriptView.swift" \
   'Select issue ' \

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-04-12T23:58:43Z",
-  "code_changes_present": false,
+  "last_updated": "2026-04-13T00:07:30Z",
+  "code_changes_present": true,
   "claims": {
     "implementation": "complete",
     "validation": "complete",
@@ -10,30 +10,32 @@
   "evidence": {
     "build": {
       "status": "passed",
-      "updated_at": "2026-04-12T19:11:53.000Z",
+      "updated_at": "2026-04-13T00:07:30Z",
+      "reason": "",
       "paths": [
-        "artifacts/standards-adoption/build.log"
+        "artifacts/n1-recording-flow-hardening/xcodebuild-test.log"
       ]
     },
     "test": {
       "status": "passed",
-      "updated_at": "2026-04-12T19:11:53.000Z",
+      "updated_at": "2026-04-13T00:07:30Z",
+      "reason": "",
       "paths": [
-        "artifacts/standards-adoption/validate.log"
+        "artifacts/n1-recording-flow-hardening/xcodebuild-test.log"
       ]
     },
     "run": {
-      "status": "passed",
-      "updated_at": "2026-04-12T19:11:53.000Z",
-      "paths": [
-        "artifacts/standards-adoption/run.log"
-      ]
+      "metadata_only": true,
+      "status": "not_run",
+      "reason": "No interactive app run was performed in this Codex slice; local coverage came from runtime guardrails plus the full macOS test suite.",
+      "updated_at": "2026-04-13T00:07:30Z",
+      "paths": []
     },
     "deploy": {
       "metadata_only": true,
       "status": "not_required",
-      "reason": "Current roadmap phase remains build-scoped and no deployment was executed in this standards-adoption slice.",
-      "updated_at": "2026-04-12T19:11:53.000Z",
+      "reason": "Current roadmap phase remains build-scoped and no deployment was executed in the N1 review slice.",
+      "updated_at": "2026-04-13T00:07:30Z",
       "paths": []
     }
   }

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,4 +1,4 @@
 # Controller State
 
-current_state: ready_for_codex
+current_state: ready_for_review
 current_task: N1

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -3,12 +3,13 @@
 task_id: N1
 description: End-to-end recording flow hardening — bulletproof record → transcribe → extract → export with auto-save and unified review
 scope: Sources/BugNarrator/
-status: pending
+status: ready_for_review
 execution_status: idle
-execution_branch: codex/N1-end-to-end-recording-flow-hardening
+execution_branch:
 execution_started_at:
 execution_heartbeat_at:
 execution_lease_expires_at:
 execution_host_id:
 execution_worker_id:
-review_failure_count: 0
+review_failure_count: 1
+last_review_failure_signature: 99a8810ca3d010fc9117a496e178ac1b6602b7bd|checks:macos-validation|threads:PRRT_kwDORnPu2856aHnC,PRRT_kwDORnPu2856aHnL,PRRT_kwDORnPu2856aHnN

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -5,7 +5,7 @@ description: End-to-end recording flow hardening — bulletproof record → tran
 scope: Sources/BugNarrator/
 status: pending
 execution_status: idle
-execution_branch:
+execution_branch: codex/N1-end-to-end-recording-flow-hardening
 execution_started_at:
 execution_heartbeat_at:
 execution_lease_expires_at:

--- a/state/handoff.json
+++ b/state/handoff.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-04-12T23:58:43Z",
-  "summary": "Replanned: THE bug narration tool \u2014 9 tasks (N1-N9)",
-  "next_action": "Codex implements N1",
+  "last_updated": "2026-04-13T00:07:30Z",
+  "summary": "N1 is implemented on codex/N1-end-to-end-recording-flow-hardening with forced session persistence, staged progress text, a 10-second extraction timeout, and a unified review workspace.",
+  "next_action": "Open or review the PR for N1 and collect GitHub CI plus code review feedback.",
   "discovered_issues": []
 }

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -25,3 +25,10 @@ VALIDATED:
 
 NEXT:
 - Review the unified transcript workspace and the forced auto-save behavior in PR review.
+
+## 2026-04-13 Review Remediation
+
+- Synced the issue-extraction timeout failure copy to the configured timeout budget and rounded subsecond values up to a stable tenths display.
+- Computed transcription progress step totals from `autoExtractIssues` so non-extraction runs no longer claim a missing third step.
+- Marked the stacked review workspace section titles as accessibility headers and updated the regression script for the no-tabs layout.
+- Returned `state/current_task.md` to `ready_for_review` after fixing the CI and review findings on PR #14.

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,5 +1,27 @@
 # Implementation Notes
 
-task_id: T1
-status: idle
-summary: Standards adoption bootstrap has not started an implementation slice in this workflow file yet.
+task_id: N1
+status: ready_for_review
+
+CHANGED:
+- Sources/BugNarrator/AppState.swift
+- Sources/BugNarrator/Services/IssueExtractionService.swift
+- Sources/BugNarrator/Views/SettingsView.swift
+- Sources/BugNarrator/Views/TranscriptView.swift
+- Tests/BugNarratorTests/AppStateTests.swift
+- Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+- Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
+
+DID:
+- Forced completed recording sessions to persist locally on stop, even if the legacy auto-save preference is disabled.
+- Added staged progress text for stop and retry flows so transcription, local save, and extraction progress are visible as text.
+- Enforced a 10-second issue-extraction timeout with a clear retry/faster-model error.
+- Reworked the review pane into one stacked workspace so summary, extracted issues, screenshots, and transcript are visible in a single view.
+- Updated workflow settings copy to reflect required local session persistence.
+
+VALIDATED:
+- ./scripts/validate.sh 314d332a132e94f9076d7da5c512d031f598a7ff
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test
+
+NEXT:
+- Review the unified transcript workspace and the forced auto-save behavior in PR review.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -187,12 +187,13 @@
       "updated_at": "2026-04-12T19:11:53.000Z"
     }
   ],
-  "last_updated": "2026-04-12T23:58:43Z",
+  "last_updated": "2026-04-13T00:07:30Z",
   "tasks": [
     {
       "id": "N1",
-      "status": "pending",
-      "title": "End-to-end recording flow hardening"
+      "status": "ready_for_review",
+      "title": "End-to-end recording flow hardening",
+      "updated_at": "2026-04-13T00:07:30Z"
     }
   ]
 }

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -7,3 +7,9 @@ summary: Runtime guardrails and the full BugNarrator macOS test suite passed for
 artifacts:
 - artifacts/n1-recording-flow-hardening/validate.log
 - artifacts/n1-recording-flow-hardening/xcodebuild-test.log
+
+## 2026-04-13 Review Remediation Validation
+
+- ./scripts/accessibility_regression_check.sh -> PASS
+- ./scripts/validate.sh -> PASS
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/AppStateTests test -> PASS

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,5 +1,9 @@
 # Validation Report
 
-task_id: T1
-result: pending
-summary: Waiting for the current standards adoption slice to finish local validation.
+task_id: N1
+result: passed
+summary: Runtime guardrails and the full BugNarrator macOS test suite passed for the N1 recording-flow hardening slice.
+
+artifacts:
+- artifacts/n1-recording-flow-hardening/validate.log
+- artifacts/n1-recording-flow-hardening/xcodebuild-test.log


### PR DESCRIPTION
## Summary
- force finished recording sessions to persist locally on stop and surface staged progress text through transcription/save/extraction
- enforce a 10-second issue extraction timeout and update settings copy to reflect required session persistence
- replace the tabbed review pane with one stacked workspace that keeps summary, issues, screenshots, and transcript together

## Validation
- ./scripts/validate.sh 314d332a132e94f9076d7da5c512d031f598a7ff
- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test