### PR TITLE
N2: add AI-generated reproduction steps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * 1'  # Weekly on Monday at 4 AM UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.language == 'swift' && 'macos-latest' || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, swift, python, javascript-typescript, csharp]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,69 @@
-# AGENTS.md — BugNarrator
+# Agent Rules
 
-This file configures AI coding agents (Codex, etc.) for the BugNarrator repo.
+Read `ai/bootstrap.md` first — it is the authoritative workflow entry point.
+
+## Pipeline (deterministic, cron-driven)
+
+```
+Claude plans → writes ai/ → sets ready_for_codex
+Codex implements → opens PR → sets ready_for_review  
+CI passes → PR auto-merges (watch-open-prs)
+watch-open-prs → advances state to ready_for_codex (next task)
+```
+
+State flow: `ready_for_codex` → `ready_for_review` → (merge) → `ready_for_codex` | `done`  
+Failure: `review_failed_fix_required` → fix → `ready_for_review`  
+Needs planning: `ready_for_claude` → Claude updates ai/ → `ready_for_codex`
+
+## Role boundaries
+
+**Claude** — plans tasks, writes `ai/` files, sets `ready_for_codex`. Never writes production code.  
+**Codex** — implements the current task only, runs local validation, opens/updates PR. Never re-plans.  
+**watch-open-prs** — merges green PRs, advances state automatically. Codex never merges its own PR.  
+**No agent-to-agent communication.** Coordination happens only through repo files and PR/CI state.
+
+## State file ownership (critical)
+
+Codex writes: `state/current_task.md`, `state/controller.md`, `state/tasks.json`, `state/artifacts.json`, `state/implementation_notes.md`, `state/validation_report.md`, `state/handoff.json`  
+Claude writes: `ai/` files, `docs/roadmap/state.json`, `ai.config.json`  
+**Always commit state changes immediately** — automated readers use `git show origin/main:<file>` and will not see uncommitted local changes.
+
+## Execution lease
+
+Codex acquires a 90-minute lease before starting work:
+
+- `execution_status: in_progress` + `execution_lease_expires_at` in the future → another instance is running, **STOP**
+- `execution_status: in_progress` + lease expired → clear all lease fields, commit `fix: clear stale lease [task_id]`, push, then start
+- Always clear the lease (set `execution_status: idle`, blank all lease fields) before setting `ready_for_review`
+
+## Git safety
+
+- Stage specific files only — never `git add -A` or `git add .`
+- Never commit directly to `main` — use feature branches and PRs
+- Run `git diff --cached --stat` before every commit to verify what is staged
+- Never commit secrets, node_modules, __pycache__, .env, or generated artifacts
+- Use `--force-with-lease` for own branch pushes only; never force-push `main`
+
+## Before setting ready_for_review
+
+1. All repo-local validation must pass (see `ai/bootstrap.md` for the exact commands)
+2. `node tools/validators/enforce-runtime-guardrails.js --repo . --config ai.config.json` must pass
+3. `state/artifacts.json` must reflect actual evidence (real file paths, correct statuses)
+4. Lease must be cleared (`execution_status: idle`)
+
+## Scope rules
+
+- Work on the current task only — do not change files outside the declared scope in `ai/tasks.md`
+- Never modify `ai/plan.md`, `ai/tasks.md`, `ai/acceptance.md`
+- Document any necessary out-of-scope changes in `state/implementation_notes.md`
+- If the task is ambiguous or blocked: set `ready_for_claude`, document reason, clear lease, stop
+
+
+---
+
+## Repo-specific rules
+
+his file configures AI coding agents (Codex, etc.) for the BugNarrator repo.
 
 ## What This Repo Is
 

--- a/Sources/BugNarrator/Models/ExtractedIssue.swift
+++ b/Sources/BugNarrator/Models/ExtractedIssue.swift
@@ -9,6 +9,39 @@ enum ExtractedIssueCategory: String, Codable, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+struct IssueReproductionStep: Identifiable, Codable, Equatable {
+    let id: UUID
+    var instruction: String
+    var expectedResult: String?
+    var actualResult: String?
+    var timestamp: TimeInterval?
+    var screenshotID: UUID?
+
+    init(
+        id: UUID = UUID(),
+        instruction: String,
+        expectedResult: String? = nil,
+        actualResult: String? = nil,
+        timestamp: TimeInterval? = nil,
+        screenshotID: UUID? = nil
+    ) {
+        self.id = id
+        self.instruction = instruction
+        self.expectedResult = expectedResult
+        self.actualResult = actualResult
+        self.timestamp = timestamp
+        self.screenshotID = screenshotID
+    }
+
+    var timestampLabel: String? {
+        guard let timestamp else {
+            return nil
+        }
+
+        return ElapsedTimeFormatter.string(from: timestamp)
+    }
+}
+
 struct ExtractedIssue: Identifiable, Codable, Equatable {
     let id: UUID
     var title: String
@@ -21,6 +54,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
     var requiresReview: Bool
     var isSelectedForExport: Bool
     var sectionTitle: String?
+    var reproductionSteps: [IssueReproductionStep]
     var note: String?
 
     init(
@@ -35,6 +69,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         requiresReview: Bool = true,
         isSelectedForExport: Bool = true,
         sectionTitle: String? = nil,
+        reproductionSteps: [IssueReproductionStep] = [],
         note: String? = nil
     ) {
         self.id = id
@@ -48,7 +83,58 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         self.requiresReview = requiresReview
         self.isSelectedForExport = isSelectedForExport
         self.sectionTitle = sectionTitle
+        self.reproductionSteps = reproductionSteps
         self.note = note
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        category = try container.decode(ExtractedIssueCategory.self, forKey: .category)
+        summary = try container.decode(String.self, forKey: .summary)
+        evidenceExcerpt = try container.decode(String.self, forKey: .evidenceExcerpt)
+        timestamp = try container.decodeIfPresent(TimeInterval.self, forKey: .timestamp)
+        relatedScreenshotIDs = try container.decodeIfPresent([UUID].self, forKey: .relatedScreenshotIDs) ?? []
+        confidence = try container.decodeIfPresent(Double.self, forKey: .confidence)
+        requiresReview = try container.decodeIfPresent(Bool.self, forKey: .requiresReview) ?? true
+        isSelectedForExport = try container.decodeIfPresent(Bool.self, forKey: .isSelectedForExport) ?? true
+        sectionTitle = try container.decodeIfPresent(String.self, forKey: .sectionTitle)
+        reproductionSteps = try container.decodeIfPresent([IssueReproductionStep].self, forKey: .reproductionSteps) ?? []
+        note = try container.decodeIfPresent(String.self, forKey: .note)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(category, forKey: .category)
+        try container.encode(summary, forKey: .summary)
+        try container.encode(evidenceExcerpt, forKey: .evidenceExcerpt)
+        try container.encodeIfPresent(timestamp, forKey: .timestamp)
+        try container.encode(relatedScreenshotIDs, forKey: .relatedScreenshotIDs)
+        try container.encodeIfPresent(confidence, forKey: .confidence)
+        try container.encode(requiresReview, forKey: .requiresReview)
+        try container.encode(isSelectedForExport, forKey: .isSelectedForExport)
+        try container.encodeIfPresent(sectionTitle, forKey: .sectionTitle)
+        try container.encode(reproductionSteps, forKey: .reproductionSteps)
+        try container.encodeIfPresent(note, forKey: .note)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case category
+        case summary
+        case evidenceExcerpt
+        case timestamp
+        case relatedScreenshotIDs
+        case confidence
+        case requiresReview
+        case isSelectedForExport
+        case sectionTitle
+        case reproductionSteps
+        case note
     }
 
     var timestampLabel: String? {

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -146,6 +146,29 @@ actor GitHubExportProvider {
             lines.append("- Review needed: Yes")
         }
 
+        if !issue.reproductionSteps.isEmpty {
+            lines.append("")
+            lines.append("## Reproduction Steps")
+
+            for (index, step) in issue.reproductionSteps.enumerated() {
+                lines.append("\(index + 1). \(step.instruction)")
+
+                if let expectedResult = step.expectedResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !expectedResult.isEmpty {
+                    lines.append("   - Expected: \(expectedResult)")
+                }
+
+                if let actualResult = step.actualResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !actualResult.isEmpty {
+                    lines.append("   - Actual: \(actualResult)")
+                }
+
+                if let reference = reproductionStepReference(step, session: session) {
+                    lines.append("   - Reference: \(reference)")
+                }
+            }
+        }
+
         let screenshots = session.screenshots(for: issue)
         if !screenshots.isEmpty {
             lines.append("")
@@ -160,6 +183,21 @@ actor GitHubExportProvider {
         lines.append("Exported from BugNarrator. Review against the raw transcript before triage.")
 
         return lines.joined(separator: "\n")
+    }
+
+    private func reproductionStepReference(_ step: IssueReproductionStep, session: TranscriptSession) -> String? {
+        var parts: [String] = []
+
+        if let timestampLabel = step.timestampLabel {
+            parts.append("Transcript `\(timestampLabel)`")
+        }
+
+        if let screenshotID = step.screenshotID,
+           let screenshot = session.screenshot(with: screenshotID) {
+            parts.append("Screenshot `\(screenshot.fileName)` (`\(screenshot.timeLabel)`)")
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: "  •  ")
     }
 
     private func mapGitHubError(

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -185,7 +185,9 @@ actor IssueExtractionService: IssueExtracting {
                         You convert spoken software review notes into structured, reviewable draft issues.
                         Use only information explicitly present in the transcript, markers, and screenshot references.
                         Return strict JSON with keys summary, guidanceNote, issues.
-                        Each issue must contain title, category, summary, evidenceExcerpt, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview.
+                        Each issue must contain title, category, summary, evidenceExcerpt, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview, reproductionSteps.
+                        Each reproduction step must contain instruction, expectedResult, actualResult, timestamp, relatedScreenshotFileName.
+                        Generate numbered reproduction steps that follow the narration timeline and tie each step to the most relevant screenshot reference when one exists.
                         Valid categories are exactly: Bug, UX Issue, Enhancement, Question / Follow-up.
                         Prefer conservative output. If evidence is weak, set requiresReview to true and use a lower confidence.
                         """
@@ -433,7 +435,7 @@ private struct IssueExtractionPayload {
         return String(content[startIndex...endIndex])
     }
 
-    private static func firstString(in dictionary: [String: Any], keys: [String]) -> String? {
+    fileprivate static func firstString(in dictionary: [String: Any], keys: [String]) -> String? {
         for key in keys {
             if let value = dictionary[key] as? String {
                 return value
@@ -464,6 +466,7 @@ private struct IssuePayload {
     let relatedScreenshotFileNames: [String]?
     let confidence: Double?
     let requiresReview: Bool?
+    let reproductionSteps: [IssueReproductionStepPayload]
 
     init?(dictionary: [String: Any]) {
         let title = Self.firstString(in: dictionary, keys: ["title", "issueTitle", "name"])?.trimmedForExtraction
@@ -490,28 +493,47 @@ private struct IssuePayload {
         )
         self.confidence = Self.firstDouble(in: dictionary, keys: ["confidence", "score"])
         self.requiresReview = Self.firstBool(in: dictionary, keys: ["requiresReview", "requires_review", "needsReview"])
+        self.reproductionSteps = Self.firstArray(
+            in: dictionary,
+            keys: ["reproductionSteps", "stepsToReproduce", "steps_to_reproduce", "reproSteps", "steps"]
+        )?.compactMap { stepObject in
+            guard let stepDictionary = stepObject as? [String: Any] else {
+                return nil
+            }
+
+            return IssueReproductionStepPayload(dictionary: stepDictionary)
+        } ?? []
     }
 
     func makeExtractedIssue(screenshotIndex: [String: UUID]) -> ExtractedIssue {
         let screenshotIDs = (relatedScreenshotFileNames ?? []).compactMap { fileName in
             screenshotIndex[fileName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
         }
+        let parsedTimestamp = Self.parseTimestamp(timestamp)
+        let reproductionSteps = reproductionSteps.map {
+            $0.makeIssueReproductionStep(
+                screenshotIndex: screenshotIndex,
+                fallbackTimestamp: parsedTimestamp,
+                fallbackScreenshotID: screenshotIDs.first
+            )
+        }
 
         return ExtractedIssue(
             title: title.trimmingCharacters(in: .whitespacesAndNewlines),
-            category: parseCategory(category),
+            category: Self.parseCategory(category),
             summary: summary.trimmingCharacters(in: .whitespacesAndNewlines),
             evidenceExcerpt: evidenceExcerpt.trimmingCharacters(in: .whitespacesAndNewlines),
-            timestamp: parseTimestamp(timestamp),
+            timestamp: parsedTimestamp,
             relatedScreenshotIDs: screenshotIDs,
             confidence: confidence,
             requiresReview: requiresReview ?? true,
             isSelectedForExport: true,
-            sectionTitle: sectionTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+            sectionTitle: sectionTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+            reproductionSteps: reproductionSteps
         )
     }
 
-    private static func firstString(in dictionary: [String: Any], keys: [String]) -> String? {
+    fileprivate static func firstString(in dictionary: [String: Any], keys: [String]) -> String? {
         for key in keys {
             if let value = dictionary[key] as? String {
                 return value
@@ -521,7 +543,17 @@ private struct IssuePayload {
         return nil
     }
 
-    private static func firstStringArray(in dictionary: [String: Any], keys: [String]) -> [String]? {
+    fileprivate static func firstArray(in dictionary: [String: Any], keys: [String]) -> [Any]? {
+        for key in keys {
+            if let value = dictionary[key] as? [Any] {
+                return value
+            }
+        }
+
+        return nil
+    }
+
+    fileprivate static func firstStringArray(in dictionary: [String: Any], keys: [String]) -> [String]? {
         for key in keys {
             if let values = dictionary[key] as? [String] {
                 return values
@@ -566,7 +598,7 @@ private struct IssuePayload {
         return nil
     }
 
-    private func parseCategory(_ value: String) -> ExtractedIssueCategory {
+    fileprivate static func parseCategory(_ value: String) -> ExtractedIssueCategory {
         let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         switch normalizedValue {
@@ -581,7 +613,7 @@ private struct IssuePayload {
         }
     }
 
-    private func parseTimestamp(_ value: String?) -> TimeInterval? {
+    fileprivate static func parseTimestamp(_ value: String?) -> TimeInterval? {
         guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty else {
             return nil
@@ -600,6 +632,66 @@ private struct IssuePayload {
     }
 }
 
+private struct IssueReproductionStepPayload {
+    let instruction: String
+    let expectedResult: String?
+    let actualResult: String?
+    let timestamp: String?
+    let relatedScreenshotFileName: String?
+
+    init?(dictionary: [String: Any]) {
+        let instruction = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["instruction", "step", "action", "description"]
+        )?.trimmedForExtraction
+
+        guard let instruction, !instruction.isEmpty else {
+            return nil
+        }
+
+        self.instruction = instruction
+        self.expectedResult = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["expectedResult", "expected", "expected_result"]
+        )?.trimmedForExtraction.nilIfEmpty
+        self.actualResult = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["actualResult", "actual", "actual_result"]
+        )?.trimmedForExtraction.nilIfEmpty
+        self.timestamp = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["timestamp", "time", "timecode"]
+        )?.trimmedForExtraction
+        self.relatedScreenshotFileName =
+            IssuePayload.firstString(
+                in: dictionary,
+                keys: ["relatedScreenshotFileName", "screenshotFileName", "screenshot", "related_screenshot_file_name"]
+            )?.trimmedForExtraction ??
+            IssuePayload.firstStringArray(
+                in: dictionary,
+                keys: ["relatedScreenshotFileNames", "screenshotFileNames", "screenshots"]
+            )?.first?.trimmedForExtraction
+    }
+
+    func makeIssueReproductionStep(
+        screenshotIndex: [String: UUID],
+        fallbackTimestamp: TimeInterval?,
+        fallbackScreenshotID: UUID?
+    ) -> IssueReproductionStep {
+        let screenshotID = relatedScreenshotFileName.flatMap {
+            screenshotIndex[$0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
+        } ?? fallbackScreenshotID
+
+        return IssueReproductionStep(
+            instruction: instruction,
+            expectedResult: expectedResult,
+            actualResult: actualResult,
+            timestamp: IssuePayload.parseTimestamp(timestamp) ?? fallbackTimestamp,
+            screenshotID: screenshotID
+        )
+    }
+}
+
 private enum IssueExtractionParseError: Error {
     case invalidPayload(String)
 }
@@ -607,5 +699,9 @@ private enum IssueExtractionParseError: Error {
 private extension String {
     var trimmedForExtraction: String {
         trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -147,6 +147,14 @@ actor JiraExportProvider {
             content.append(.bulletList(items: metadataLines))
         }
 
+        if !issue.reproductionSteps.isEmpty {
+            let stepLines = issue.reproductionSteps.enumerated().map { index, step in
+                formattedReproductionStep(step, index: index, session: session)
+            }
+            content.append(.paragraph(text: "Reproduction steps"))
+            content.append(.bulletList(items: stepLines))
+        }
+
         let screenshots = session.screenshots(for: issue)
         if !screenshots.isEmpty {
             let screenshotLines = screenshots.map {
@@ -158,6 +166,39 @@ actor JiraExportProvider {
 
         content.append(.paragraph(text: "Exported from BugNarrator. Review against the raw transcript before triage."))
         return JiraDocument(content: content)
+    }
+
+    private func formattedReproductionStep(
+        _ step: IssueReproductionStep,
+        index: Int,
+        session: TranscriptSession
+    ) -> String {
+        var parts = ["\(index + 1). \(step.instruction)"]
+
+        if let expectedResult = step.expectedResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !expectedResult.isEmpty {
+            parts.append("Expected: \(expectedResult)")
+        }
+
+        if let actualResult = step.actualResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !actualResult.isEmpty {
+            parts.append("Actual: \(actualResult)")
+        }
+
+        var references: [String] = []
+        if let timestampLabel = step.timestampLabel {
+            references.append("Transcript \(timestampLabel)")
+        }
+        if let screenshotID = step.screenshotID,
+           let screenshot = session.screenshot(with: screenshotID) {
+            references.append("Screenshot \(screenshot.fileName) (\(screenshot.timeLabel))")
+        }
+
+        if !references.isEmpty {
+            parts.append("Reference: \(references.joined(separator: " • "))")
+        }
+
+        return parts.joined(separator: " | ")
     }
 
     private func mapJiraError(

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -1,6 +1,11 @@
 import AppKit
 import SwiftUI
 
+func normalizedOptionalReproductionStepText(_ value: String) -> String? {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedValue.isEmpty ? nil : trimmedValue
+}
+
 struct TranscriptView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var transcriptStore: TranscriptStore
@@ -1534,8 +1539,7 @@ struct TranscriptView: View {
                     return
                 }
 
-                let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                updatedIssue.reproductionSteps[stepIndex][keyPath: keyPath] = trimmedValue.isEmpty ? nil : newValue
+                updatedIssue.reproductionSteps[stepIndex][keyPath: keyPath] = normalizedOptionalReproductionStepText(newValue)
                 appState.updateExtractedIssue(updatedIssue, in: sessionID)
             }
         )

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -1272,6 +1272,11 @@ struct TranscriptView: View {
                     .textSelection(.enabled)
             }
 
+            let liveIssue = extractedIssue(sessionID: session.id, issueID: issue.id) ?? issue
+            if !liveIssue.reproductionSteps.isEmpty {
+                reproductionStepsSection(issue: liveIssue, session: session)
+            }
+
             let relatedScreenshots = (extractedIssue(sessionID: session.id, issueID: issue.id) ?? issue).relatedScreenshotIDs
                 .compactMap(session.screenshot(with:))
             if !relatedScreenshots.isEmpty {
@@ -1290,6 +1295,96 @@ struct TranscriptView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func reproductionStepsSection(issue: ExtractedIssue, session: TranscriptSession) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Reproduction Steps")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            ForEach(Array(issue.reproductionSteps.enumerated()), id: \.element.id) { index, step in
+                reproductionStepEditor(
+                    step: step,
+                    stepIndex: index,
+                    issueID: issue.id,
+                    session: session
+                )
+            }
+        }
+    }
+
+    private func reproductionStepEditor(
+        step: IssueReproductionStep,
+        stepIndex: Int,
+        issueID: UUID,
+        session: TranscriptSession
+    ) -> some View {
+        let liveStep = reproductionStep(sessionID: session.id, issueID: issueID, stepID: step.id) ?? step
+        let referencedScreenshot = liveStep.screenshotID.flatMap(session.screenshot(with:))
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 8) {
+                Text("Step \(stepIndex + 1)")
+                    .font(.body.weight(.semibold))
+
+                if let timestampLabel = liveStep.timestampLabel {
+                    metadataChip(label: timestampLabel, systemImage: "clock")
+                }
+
+                if let referencedScreenshot {
+                    metadataChip(label: referencedScreenshot.fileName, systemImage: "photo")
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            fieldEditor(
+                title: "Action",
+                text: reproductionStepInstructionBinding(
+                    sessionID: session.id,
+                    issueID: issueID,
+                    stepID: step.id,
+                    fallback: liveStep.instruction
+                ),
+                minHeight: 56
+            )
+
+            fieldEditor(
+                title: "Expected",
+                text: reproductionStepOptionalTextBinding(
+                    sessionID: session.id,
+                    issueID: issueID,
+                    stepID: step.id,
+                    keyPath: \.expectedResult,
+                    fallback: liveStep.expectedResult
+                ),
+                minHeight: 44
+            )
+
+            fieldEditor(
+                title: "Actual",
+                text: reproductionStepOptionalTextBinding(
+                    sessionID: session.id,
+                    issueID: issueID,
+                    stepID: step.id,
+                    keyPath: \.actualResult,
+                    fallback: liveStep.actualResult
+                ),
+                minHeight: 44
+            )
+
+            if let referencedScreenshot {
+                Button("Open Referenced Screenshot") {
+                    appState.openScreenshot(referencedScreenshot)
+                }
+                .buttonStyle(.link)
+                .accessibilityLabel("Open referenced screenshot \(referencedScreenshot.fileName) for step \(stepIndex + 1)")
+            }
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.24), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private func issueCategoryPicker(issue: ExtractedIssue, session: TranscriptSession) -> some View {
@@ -1365,6 +1460,12 @@ struct TranscriptView: View {
         return sourceSession?.issueExtraction?.issues.first(where: { $0.id == issueID })
     }
 
+    private func reproductionStep(sessionID: UUID, issueID: UUID, stepID: UUID) -> IssueReproductionStep? {
+        extractedIssue(sessionID: sessionID, issueID: issueID)?
+            .reproductionSteps
+            .first(where: { $0.id == stepID })
+    }
+
     private func liveSession(with sessionID: UUID) -> TranscriptSession? {
         if appState.currentTranscript?.id == sessionID {
             return appState.currentTranscript
@@ -1389,6 +1490,52 @@ struct TranscriptView: View {
                 }
 
                 updatedIssue[keyPath: keyPath] = newValue
+                appState.updateExtractedIssue(updatedIssue, in: sessionID)
+            }
+        )
+    }
+
+    private func reproductionStepInstructionBinding(
+        sessionID: UUID,
+        issueID: UUID,
+        stepID: UUID,
+        fallback: String
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                reproductionStep(sessionID: sessionID, issueID: issueID, stepID: stepID)?.instruction ?? fallback
+            },
+            set: { newValue in
+                guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID),
+                      let stepIndex = updatedIssue.reproductionSteps.firstIndex(where: { $0.id == stepID }) else {
+                    return
+                }
+
+                updatedIssue.reproductionSteps[stepIndex].instruction = newValue
+                appState.updateExtractedIssue(updatedIssue, in: sessionID)
+            }
+        )
+    }
+
+    private func reproductionStepOptionalTextBinding(
+        sessionID: UUID,
+        issueID: UUID,
+        stepID: UUID,
+        keyPath: WritableKeyPath<IssueReproductionStep, String?>,
+        fallback: String?
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                reproductionStep(sessionID: sessionID, issueID: issueID, stepID: stepID)?[keyPath: keyPath] ?? fallback ?? ""
+            },
+            set: { newValue in
+                guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID),
+                      let stepIndex = updatedIssue.reproductionSteps.firstIndex(where: { $0.id == stepID }) else {
+                    return
+                }
+
+                let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                updatedIssue.reproductionSteps[stepIndex][keyPath: keyPath] = trimmedValue.isEmpty ? nil : newValue
                 appState.updateExtractedIssue(updatedIssue, in: sessionID)
             }
         )

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -17,7 +17,15 @@ final class GitHubExportProviderTests: XCTestCase {
             evidenceExcerpt: "The login button never re-enabled after typing a valid email.",
             timestamp: 14,
             relatedScreenshotIDs: [],
-            requiresReview: true
+            requiresReview: true,
+            reproductionSteps: [
+                IssueReproductionStep(
+                    instruction: "Enter a valid email and password.",
+                    expectedResult: "The login button enables.",
+                    actualResult: "The login button stays disabled.",
+                    timestamp: 14
+                )
+            ]
         )
         let session = TranscriptSession(
             createdAt: Date(),
@@ -44,12 +52,15 @@ final class GitHubExportProviderTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer fixture-github-token")
         XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "BugNarrator")
 
-        let body = try XCTUnwrap(request.httpBody)
+        let body: Data = try XCTUnwrap(request.httpBody)
         let payload = try JSONDecoder().decode(GitHubIssueRequestPayload.self, from: body)
         XCTAssertEqual(payload.title, "Login button is disabled")
         XCTAssertEqual(payload.labels, ["bug", "triage"])
         XCTAssertTrue(payload.body.contains("Transcript time"))
         XCTAssertTrue(payload.body.contains("Review needed: Yes"))
+        XCTAssertTrue(payload.body.contains("## Reproduction Steps"))
+        XCTAssertTrue(payload.body.contains("Expected: The login button enables."))
+        XCTAssertTrue(payload.body.contains("Actual: The login button stays disabled."))
     }
 
     func testExportMapsRepositoryNotFound() async throws {

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -24,6 +24,15 @@ final class IssueExtractionServiceTests: XCTestCase {
               "timestamp": "00:08",
               "sectionTitle": "Save flow",
               "relatedScreenshotFileNames": ["review-shot.png"],
+              "reproductionSteps": [
+                {
+                  "instruction": "Open the save modal.",
+                  "expectedResult": "The primary action fits within the modal bounds.",
+                  "actualResult": "The save button is clipped on the right edge.",
+                  "timestamp": "00:08",
+                  "relatedScreenshotFileName": "review-shot.png"
+                }
+              ],
               "confidence": 0.74,
               "requiresReview": true
             }
@@ -47,6 +56,12 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.issues.first?.category, .bug)
         XCTAssertEqual(result.issues.first?.relatedScreenshotIDs, [try XCTUnwrap(session.screenshots.first?.id)])
         XCTAssertEqual(result.issues.first?.timestamp, 8)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.count, 1)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.instruction, "Open the save modal.")
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.expectedResult, "The primary action fits within the modal bounds.")
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.actualResult, "The save button is clipped on the right edge.")
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.timestamp, 8)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.screenshotID, session.screenshots.first?.id)
     }
 
     func testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys() async throws {
@@ -66,6 +81,13 @@ final class IssueExtractionServiceTests: XCTestCase {
               "timecode": "00:08",
               "section": "Save flow",
               "screenshotFileNames": ["review-shot.png"],
+              "stepsToReproduce": [
+                {
+                  "step": "Open the save modal.",
+                  "expected": "The save button is fully visible.",
+                  "actual": "The save button clips against the modal frame."
+                }
+              ],
               "score": 0.74,
               "needsReview": true
             }
@@ -103,6 +125,9 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.issues.first?.category, .bug)
         XCTAssertEqual(result.issues.first?.relatedScreenshotIDs, [session.screenshots.first?.id].compactMap { $0 })
         XCTAssertEqual(result.issues.first?.timestamp, 8)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.count, 1)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.timestamp, 8)
+        XCTAssertEqual(result.issues.first?.reproductionSteps.first?.screenshotID, session.screenshots.first?.id)
     }
 
     func testExtractIssuesReturnsClearErrorForMalformedStructuredPayload() async throws {

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -16,7 +16,15 @@ final class JiraExportProviderTests: XCTestCase {
             summary: "The modal has no visible close affordance.",
             evidenceExcerpt: "I cannot tell how to dismiss the modal.",
             timestamp: 22,
-            requiresReview: true
+            requiresReview: true,
+            reproductionSteps: [
+                IssueReproductionStep(
+                    instruction: "Open the modal from settings.",
+                    expectedResult: "A close affordance is visible immediately.",
+                    actualResult: "No close affordance appears in the modal chrome.",
+                    timestamp: 22
+                )
+            ]
         )
         let session = TranscriptSession(
             createdAt: Date(),
@@ -44,15 +52,20 @@ final class JiraExportProviderTests: XCTestCase {
         XCTAssertTrue(request.value(forHTTPHeaderField: "Authorization")?.hasPrefix("Basic ") == true)
         XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "BugNarrator")
 
-        let body = try XCTUnwrap(request.httpBody)
-        let payload = try JSONSerialization.jsonObject(with: body) as? [String: Any]
-        let fields = try XCTUnwrap(payload?["fields"] as? [String: Any])
+        let body: Data = try XCTUnwrap(request.httpBody)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let fields = try XCTUnwrap(payload["fields"] as? [String: Any])
         let project = try XCTUnwrap(fields["project"] as? [String: Any])
         let issueType = try XCTUnwrap(fields["issuetype"] as? [String: Any])
 
         XCTAssertEqual(project["key"] as? String, "FM")
         XCTAssertEqual(issueType["name"] as? String, "Task")
         XCTAssertEqual(fields["summary"] as? String, "Modal lacks close affordance")
+        let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let payloadString = try XCTUnwrap(String(data: payloadData, encoding: .utf8))
+        XCTAssertTrue(payloadString.contains("Reproduction steps"))
+        XCTAssertTrue(payloadString.contains("Expected: A close affordance is visible immediately."))
+        XCTAssertTrue(payloadString.contains("Actual: No close affordance appears in the modal chrome."))
     }
 
     func testExportMapsValidationFailure() async throws {

--- a/Tests/BugNarratorTests/ReviewWorkspaceTests.swift
+++ b/Tests/BugNarratorTests/ReviewWorkspaceTests.swift
@@ -3,6 +3,14 @@ import XCTest
 @testable import BugNarrator
 
 final class ReviewWorkspaceTests: XCTestCase {
+    func testNormalizedOptionalReproductionStepTextTrimsPaddingAndDropsBlankValues() {
+        XCTAssertEqual(
+            normalizedOptionalReproductionStepText("  Click Save  \n"),
+            "Click Save"
+        )
+        XCTAssertNil(normalizedOptionalReproductionStepText("  \n  "))
+    }
+
     func testAvailableTabsIncludeSummaryOnlyWhenSessionHasSummaryContent() {
         let baseSession = makeSession(summary: "", extraction: nil)
         let summarySession = makeSession(summary: "One summary line.", extraction: nil)

--- a/ai/bootstrap.md
+++ b/ai/bootstrap.md
@@ -125,7 +125,7 @@ Single-tool rule:
 
 Budget rules:
 
-- Codex: implement at most 1 task per repo per run; after opening a PR, stop
+- Codex: implement up to 3 sequential tasks per run (batch mode); opens one PR per batch
 - review gate: CI checks (free) + Copilot review (primary) are the merge gate; Gemini is optional
 - auto-merge: PRs that pass all required CI checks with no blocking review comments are merged automatically
 
@@ -135,7 +135,7 @@ The following cron automations run on your local machine (no GitHub Actions cost
 
 | Time (every hour) | Automation | What it does |
 |---|---|---|
-| :00 | `codex-{repo}` | Implements next task if `ready_for_codex` |
+| :00 | `codex-{repo}` | Implements up to 3 tasks (batch) if `ready_for_codex` |
 | :30 | `post-push-reviewer` | Reviews newly-opened PRs (advisory checks) |
 | :45 | `watch-open-prs` | Merges green PRs, advances state to `ready_for_codex` |
 | :55 | `fix-stuck-repos` | Fixes repos with `review_failure_count >= 2` |

--- a/ai/bootstrap.md
+++ b/ai/bootstrap.md
@@ -128,3 +128,32 @@ Budget rules:
 - Codex: implement at most 1 task per repo per run; after opening a PR, stop
 - review gate: CI checks (free) + Copilot review (primary) are the merge gate; Gemini is optional
 - auto-merge: PRs that pass all required CI checks with no blocking review comments are merged automatically
+
+## Pipeline automation
+
+The following cron automations run on your local machine (no GitHub Actions cost):
+
+| Time (every hour) | Automation | What it does |
+|---|---|---|
+| :00 | `codex-{repo}` | Implements next task if `ready_for_codex` |
+| :30 | `post-push-reviewer` | Reviews newly-opened PRs (advisory checks) |
+| :45 | `watch-open-prs` | Merges green PRs, advances state to `ready_for_codex` |
+| :55 | `fix-stuck-repos` | Fixes repos with `review_failure_count >= 2` |
+
+After a PR merges, `watch-open-prs` automatically advances state to `ready_for_codex` for the next pending task. **Claude intervention is only needed when:**
+- A task is marked `requires_claude_review: true` in `ai/tasks.md`
+- The controller reaches `ready_for_claude` after a planning failure
+- `state/controller.md` reaches `blocked`
+
+## Self-healing behaviours
+
+These happen automatically — you don't need to intervene:
+
+- **Stale lease** (`execution_status: in_progress`, lease expired): Codex or fix-stuck-repos clears it and retries
+- **Fingerprint unchanged + lease expired**: Codex clears the stale lease and starts fresh
+- **State inconsistency** (tasks.json vs roadmap): `watch-open-prs` auto-fixes before advancing
+- **Merge conflicts on PR branch**: automation rebases with `-X theirs` for state files
+
+## State file ownership
+
+Read `AGENTS.md` for the full list. Key rule: **always commit state file changes immediately** — automations read from `origin/main` via `git show` and will not see uncommitted local changes.

--- a/artifacts/n2-reproduction-steps/validate.log
+++ b/artifacts/n2-reproduction-steps/validate.log
@@ -1,0 +1,5 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 8 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Config loaded from ai.config.json

--- a/artifacts/n2-reproduction-steps/xcodebuild-test.log
+++ b/artifacts/n2-reproduction-steps/xcodebuild-test.log
@@ -1,0 +1,504 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test "-only-testing:BugNarratorTests/IssueExtractionServiceTests" "-only-testing:BugNarratorTests/GitHubExportProviderTests" "-only-testing:BugNarratorTests/JiraExportProviderTests"
+
+Build settings from command line:
+    CODE_SIGNING_ALLOWED = NO
+
+2026-04-12 21:33:58.769 xcodebuild[35895:1350508] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, arch:x86_64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, name:Any Mac }
+ComputePackagePrebuildTargetDependencyGraph
+
+Prepare packages
+
+CreateBuildRequest
+
+SendProjectDescription
+
+CreateBuildOperation
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'BugNarratorTests' in project 'BugNarrator'
+        ➜ Explicit dependency on target 'BugNarrator' in project 'BugNarrator'
+    Target 'BugNarrator' in project 'BugNarrator' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+    cd /Users/deffenda/Code/bug-narrator/BugNarrator.xcodeproj
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+SwiftDriver BugNarrator normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-SwiftDriver -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarrator -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.SwiftFileList -DDEBUG -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+SwiftCompile normal arm64 Compiling\ TranscriptView.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Views/TranscriptView.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Views/TranscriptView.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptSection.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Models/TranscriptSection.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Models/TranscriptSection.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftEmitModule normal arm64 Emitting\ module\ for\ BugNarrator (in target 'BugNarrator' from project 'BugNarrator')
+
+EmitSwiftModule normal arm64 (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptSection.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 Compiling\ GitHubExportProvider.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/GitHubExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/GitHubExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ MenuBarView.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Views/MenuBarView.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Views/MenuBarView.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ BugNarratorApp.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/BugNarratorApp.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/BugNarratorApp.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ AppState.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/AppState.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/AppState.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ IssueExtractionService.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/IssueExtractionService.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/IssueExtractionService.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ DebugBundleExporter.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/DebugBundleExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/DebugBundleExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptSession.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Models/TranscriptSession.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Models/TranscriptSession.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ SessionLibrary.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/SessionLibrary.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/SessionLibrary.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ ReviewWorkspace.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/ReviewWorkspace.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/ReviewWorkspace.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptSectionBuilder.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptSectionBuilder.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptSectionBuilder.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ JiraExportProvider.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/JiraExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/JiraExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptExporter.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ AppBootstrap.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/AppBootstrap.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Utilities/AppBootstrap.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ ExportService.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/ExportService.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/ExportService.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptStore.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptStore.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/Services/TranscriptStore.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ WindowCoordinator.swift /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/WindowCoordinator.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Sources/BugNarrator/WindowCoordinator.swift (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftDriverJobDiscovery normal arm64 Compiling ExportService.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling AppBootstrap.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling BugNarratorApp.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptSectionBuilder.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling ReviewWorkspace.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptStore.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling SessionLibrary.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling GitHubExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling JiraExportProvider.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling WindowCoordinator.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptSession.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling IssueExtractionService.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Emitting module for BugNarrator (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriver\ Compilation\ Requirements BugNarrator normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-Swift-Compilation-Requirements -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarrator -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.SwiftFileList -DDEBUG -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+Copy /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.swiftmodule/arm64-apple-macos.abi.json /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.abi.json (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks -rename /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.abi.json /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.swiftmodule/arm64-apple-macos.abi.json
+
+SwiftDriver BugNarratorTests normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-SwiftDriver -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarratorTests -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.SwiftFileList -DDEBUG -plugin-path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -Isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+SwiftDriverJobDiscovery normal arm64 Compiling DebugBundleExporter.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling AppState.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling MenuBarView.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftCompile normal arm64 Compiling\ AppStateTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/AppStateTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/AppStateTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ GitHubExportProviderTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/GitHubExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/GitHubExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ AppBootstrapTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/AppBootstrapTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/AppBootstrapTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ DiagnosticsLoggerTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ DebugBundleExporterTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/DebugBundleExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/DebugBundleExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ IssueExtractionServiceTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/IssueExtractionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/IssueExtractionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ MicrophonePermissionServiceTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/MicrophonePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/MicrophonePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ JiraExportProviderTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/JiraExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/JiraExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ SessionLibraryTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/SessionLibraryTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/SessionLibraryTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ SettingsStoreTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/SettingsStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/SettingsStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptStoreTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ ScreenshotCaptureServiceTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TestSupport.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TestSupport.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TestSupport.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptionClientTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptionClientTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptionClientTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftEmitModule normal arm64 Emitting\ module\ for\ BugNarratorTests (in target 'BugNarratorTests' from project 'BugNarrator')
+
+EmitSwiftModule normal arm64 (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ TranscriptExporterTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/TranscriptExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ ReviewWorkspaceTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ReviewWorkspaceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ReviewWorkspaceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftCompile normal arm64 Compiling\ ScreenCapturePermissionServiceTests.swift /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ScreenCapturePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftCompile normal arm64 /Users/deffenda/Code/bug-narrator/Tests/BugNarratorTests/ScreenCapturePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    
+
+SwiftDriverJobDiscovery normal arm64 Compiling ScreenCapturePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling ReviewWorkspaceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling AppBootstrapTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling DebugBundleExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling DiagnosticsLoggerTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling MicrophonePermissionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptExporterTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Emitting module for BugNarratorTests (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriver\ Compilation\ Requirements BugNarratorTests normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-Swift-Compilation-Requirements -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarratorTests -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.SwiftFileList -DDEBUG -plugin-path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -Isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+Copy /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarratorTests.swiftmodule/arm64-apple-macos.abi.json /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.abi.json (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks -rename /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.abi.json /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarratorTests.swiftmodule/arm64-apple-macos.abi.json
+
+Copy /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarratorTests.swiftmodule/Project/arm64-apple-macos.swiftsourceinfo /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftsourceinfo (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-copy -exclude .DS_Store -exclude CVS -exclude .svn -exclude .git -exclude .hg -resolve-src-symlinks -rename /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftsourceinfo /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarratorTests.swiftmodule/Project/arm64-apple-macos.swiftsourceinfo
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling IssueExtractionServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling GitHubExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptionClientTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling JiraExportProviderTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling ScreenshotCaptureServiceTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling SessionLibraryTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling SettingsStoreTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling TestSupport.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriverJobDiscovery normal arm64 Compiling AppStateTests.swift (in target 'BugNarratorTests' from project 'BugNarrator')
+
+SwiftDriver\ Compilation BugNarratorTests normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-Swift-Compilation -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarratorTests -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.SwiftFileList -DDEBUG -plugin-path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins/testing -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -Isystem /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+SwiftDriverJobDiscovery normal arm64 Compiling TranscriptView.swift (in target 'BugNarrator' from project 'BugNarrator')
+
+SwiftDriver\ Compilation BugNarrator normal arm64 com.apple.xcode.tools.swift.compiler (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-Swift-Compilation -- /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -module-name BugNarrator -Onone @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.SwiftFileList -DDEBUG -enable-experimental-feature DebugDescriptionMacro -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -target arm64-apple-macos14.0 -g -module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -Xfrontend -serialize-debugging-options -profile-coverage-mapping -profile-generate -enable-testing -index-store-path /tmp/bugnarrator-n2-tests/Index.noindex/DataStore -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -swift-version 6 -I /tmp/bugnarrator-n2-tests/Build/Products/Debug -F /tmp/bugnarrator-n2-tests/Build/Products/Debug -c -j20 -enable-batch-mode -incremental -Xcc -ivfsstatcache -Xcc /tmp/bugnarrator-n2-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache -output-file-map /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-OutputFileMap.json -use-frontend-parseable-output -save-temps -no-color-diagnostics -explicit-module-build -module-cache-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -clang-scanner-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -sdk-module-cache-path /tmp/bugnarrator-n2-tests/ModuleCache.noindex -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.swiftmodule -validate-clang-modules-once -clang-build-session-file /tmp/bugnarrator-n2-tests/ModuleCache.noindex/Session.modulevalidation -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/swift-overrides.hmap -emit-const-values -Xfrontend -const-gather-protocols-file -Xfrontend /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_const_extract_protocols.json -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-generated-files.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-own-target-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-all-target-headers.hmap -Xcc -iquote -Xcc /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-project-headers.hmap -Xcc -I/tmp/bugnarrator-n2-tests/Build/Products/Debug/include -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources-normal/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources/arm64 -Xcc -I/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/DerivedSources -Xcc -DDEBUG\=1 -emit-objc-header -emit-objc-header-path /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-Swift.h -working-directory /Users/deffenda/Code/bug-narrator -experimental-emit-module-separately -disable-cmo
+
+Ld /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib normal (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -Xlinker -reproducible -target arm64-apple-macos14.0 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -O0 -L/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug -L/tmp/bugnarrator-n2-tests/Build/Products/Debug -F/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug -F/tmp/bugnarrator-n2-tests/Build/Products/Debug -filelist /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.LinkFileList -install_name @rpath/BugNarrator.debug.dylib -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -object_path_lto -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_lto.o -rdynamic -Xlinker -no_deduplicate -Xlinker -debug_variant -Xlinker -dependency_info -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_dependency_info.dat -fobjc-link-runtime -fprofile-instr-generate -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/usr/lib/swift -Xlinker -add_ast_path -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.swiftmodule @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator-linker-args.resp -Xlinker -alias -Xlinker _main -Xlinker ___debug_main_executable_dylib_entry_point -o /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib
+
+ConstructStubExecutorLinkFileList /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-ExecutorLinkFileList-normal-arm64.txt (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    construct-stub-executor-link-file-list /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libPreviewsJITStubExecutor_no_swift_entry_point.a /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libPreviewsJITStubExecutor.a --output /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-ExecutorLinkFileList-normal-arm64.txt
+note: Using stub executor library with Swift entry point. (in target 'BugNarrator' from project 'BugNarrator')
+
+Ld /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator normal (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -Xlinker -reproducible -target arm64-apple-macos14.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -O0 -L/tmp/bugnarrator-n2-tests/Build/Products/Debug -F/tmp/bugnarrator-n2-tests/Build/Products/Debug -Xlinker -rpath -Xlinker @executable_path -Xlinker -rpath -Xlinker @executable_path/../Frameworks -rdynamic -Xlinker -no_deduplicate -Xlinker -debug_variant -e ___debug_blank_executor_main -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __debug_dylib -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-DebugDylibPath-normal-arm64.txt -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __debug_instlnm -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-DebugDylibInstallName-normal-arm64.txt -Xlinker -filelist -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator-ExecutorLinkFileList-normal-arm64.txt /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib -o /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator
+
+ExtractAppIntentsMetadata (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/appintentsmetadataprocessor --toolchain-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --module-name BugNarrator --sdk-root /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk --xcode-version 17E192 --platform-family macOS --deployment-target 14.0 --bundle-identifier com.abdenterprises.bugnarrator --output /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/Resources --target-triple arm64-apple-macos14.0 --binary-file /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator --dependency-file /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator_dependency_info.dat --stringsdata-file /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/ExtractedAppShortcutsMetadata.stringsdata --source-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.SwiftFileList --metadata-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator.DependencyMetadataFileList --static-metadata-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/BugNarrator.DependencyStaticMetadataFileList --swift-const-vals-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/Objects-normal/arm64/BugNarrator.SwiftConstValuesFileList --compile-time-extraction --deployment-aware-processing --validate-assistant-intents --no-app-shortcuts-localization
+2026-04-12 21:34:04.384 appintentsmetadataprocessor[36091:1351057] Starting appintentsmetadataprocessor export
+2026-04-12 21:34:04.387 appintentsmetadataprocessor[36091:1351057] warning: Metadata extraction skipped. No AppIntents.framework dependency found.
+
+CopySwiftLibs /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/Library/SystemExtensions --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+ProcessInfoPlistFile /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-infoPlistUtility /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist -producttype com.apple.product-type.bundle.unit-test -expandbuildsettings -platform macosx -o /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist
+
+Ld /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests normal (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -Xlinker -reproducible -target arm64-apple-macos14.0 -bundle -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -O0 -L/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug -L/tmp/bugnarrator-n2-tests/Build/Products/Debug -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug -F/tmp/bugnarrator-n2-tests/Build/Products/Debug -iframework /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -filelist /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.LinkFileList -Xlinker -rpath -Xlinker /usr/lib/swift -Xlinker -rpath -Xlinker @loader_path/../Frameworks -Xlinker -rpath -Xlinker @executable_path/../Frameworks -bundle_loader /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator -Xlinker -object_path_lto -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_lto.o -rdynamic -Xlinker -no_deduplicate -Xlinker -debug_variant -Xlinker -dependency_info -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_dependency_info.dat -fobjc-link-runtime -fprofile-instr-generate -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/usr/lib/swift -Xlinker -add_ast_path -Xlinker /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.swiftmodule @/tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests-linker-args.resp -Xlinker -needed_framework -Xlinker XCTest -framework XCTest -Xlinker -needed-lXCTestSwiftSupport -lXCTestSwiftSupport /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib -o /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests
+
+ExtractAppIntentsMetadata (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/appintentsmetadataprocessor --toolchain-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --module-name BugNarratorTests --sdk-root /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk --xcode-version 17E192 --platform-family macOS --deployment-target 14.0 --bundle-identifier com.abdenterprises.bugnarrator.tests --output /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Resources --target-triple arm64-apple-macos14.0 --binary-file /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests --dependency-file /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests_dependency_info.dat --stringsdata-file /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/ExtractedAppShortcutsMetadata.stringsdata --source-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.SwiftFileList --metadata-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests.DependencyMetadataFileList --static-metadata-file-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/BugNarratorTests.DependencyStaticMetadataFileList --swift-const-vals-list /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/Objects-normal/arm64/BugNarratorTests.SwiftConstValuesFileList --compile-time-extraction --deployment-aware-processing --validate-assistant-intents --no-app-shortcuts-localization
+2026-04-12 21:34:04.687 appintentsmetadataprocessor[36094:1351090] Starting appintentsmetadataprocessor export
+2026-04-12 21:34:04.688 appintentsmetadataprocessor[36094:1351090] warning: Metadata extraction skipped. No AppIntents.framework dependency found.
+
+CopySwiftLibs /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/PlugIns --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Library/SystemExtensions --scan-folder /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /tmp/bugnarrator-n2-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+RegisterExecutionPolicyException /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-RegisterExecutionPolicyException /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest
+
+Touch /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /usr/bin/touch -c /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest
+
+RegisterExecutionPolicyException /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-RegisterExecutionPolicyException /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app
+
+Validate /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-validationUtility /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app -no-validate-extension -infoplist-subpath Contents/Info.plist
+
+Touch /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /usr/bin/touch -c /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app
+
+RegisterWithLaunchServices /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app
+
+2026-04-12 21:34:05.668912-0400 BugNarrator[36098:1351159] [settings] 2026-04-13T01:34:05.667Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-12 21:34:05.669852-0400 BugNarrator[36098:1351159] [session-library] 2026-04-13T01:34:05.670Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-12 21:34:05.675706-0400 BugNarrator[36098:1351159] [settings] 2026-04-13T01:34:05.675Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-12 21:34:05.686214-0400 BugNarrator[36098:1351159] [permissions] 2026-04-13T01:34:05.686Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/private/tmp/bugnarrator-n2-tests/Build/Products/Debug/BugNarrator.app is_local_testing_build=no microphone_status=notDetermined screen_capture_status=notDetermined
+2026-04-12 21:34:05.686482-0400 BugNarrator[36098:1351159] [session-library] 2026-04-13T01:34:05.686Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Suite 'Selected tests' started at 2026-04-12 21:34:05.877.
+Test Suite 'BugNarratorTests.xctest' started at 2026-04-12 21:34:05.877.
+Test Suite 'GitHubExportProviderTests' started at 2026-04-12 21:34:05.877.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' started.
+2026-04-12 21:34:05.879874-0400 BugNarrator[36098:1351199] [export] 2026-04-13T01:34:05.880Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=1 repository=acme/bugnarrator session_id=C396136E-B84C-474F-ACE5-90CD82E6E63F
+2026-04-12 21:34:05.883140-0400 BugNarrator[36098:1351198] [export] 2026-04-13T01:34:05.883Z [ERROR] [export] github_export_failed - Export failed: GitHub could not find acme/bugnarrator. Check the owner, repository name, and token permissions. source_issue_id=9CC02639-13BD-4D3B-98AE-D0DDB7DB7700 successful_count=0
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' passed (0.016 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-12 21:34:05.895539-0400 BugNarrator[36098:1351212] [export] 2026-04-13T01:34:05.895Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=2 repository=acme/bugnarrator session_id=C768B74E-842B-4B50-BA6B-169B73BC9C74
+2026-04-12 21:34:05.896586-0400 BugNarrator[36098:1351198] [export] 2026-04-13T01:34:05.896Z [INFO] [export] github_issue_exported - Exported one issue to GitHub. remote_identifier=#101 source_issue_id=F1B7EC0D-5A80-4373-94B2-EE7B3F585239
+2026-04-12 21:34:05.897313-0400 BugNarrator[36098:1351231] [export] 2026-04-13T01:34:05.897Z [ERROR] [export] github_export_failed - Export failed: GitHub rejected the issue payload: Validation Failed source_issue_id=ADE4455F-C420-45C3-AAF2-2C87095D8C4D successful_count=1
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' started.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' passed (0.005 seconds).
+Test Suite 'GitHubExportProviderTests' passed at 2026-04-12 21:34:05.903.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.024 (0.026) seconds
+Test Suite 'IssueExtractionServiceTests' started at 2026-04-12 21:34:05.903.
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' started.
+2026-04-12 21:34:05.904572-0400 BugNarrator[36098:1351198] [transcription] 2026-04-13T01:34:05.904Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=E258559F-7B65-4C3B-8F45-C99DE56FDB42
+2026-04-12 21:34:05.907415-0400 BugNarrator[36098:1351198] [transcription] 2026-04-13T01:34:05.907Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=E258559F-7B65-4C3B-8F45-C99DE56FDB42
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' started.
+2026-04-12 21:34:05.909264-0400 BugNarrator[36098:1351198] [transcription] 2026-04-13T01:34:05.909Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=66DB912F-8284-4FCF-B899-E438B7C78C24
+2026-04-12 21:34:05.910492-0400 BugNarrator[36098:1351231] [transcription] 2026-04-13T01:34:05.910Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings. session_id=66DB912F-8284-4FCF-B899-E438B7C78C24
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' started.
+2026-04-12 21:34:05.912148-0400 BugNarrator[36098:1351198] [transcription] 2026-04-13T01:34:05.912Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=12BC8789-C6A3-4FA2-9F43-3AE1B9C1F0AE
+2026-04-12 21:34:05.913010-0400 BugNarrator[36098:1351212] [transcription] 2026-04-13T01:34:05.913Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=12BC8789-C6A3-4FA2-9F43-3AE1B9C1F0AE
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' started.
+2026-04-12 21:34:05.914591-0400 BugNarrator[36098:1351212] [transcription] 2026-04-13T01:34:05.914Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=8B0FDBEF-D1BC-4B50-845D-92EE0840E522
+2026-04-12 21:34:06.188947-0400 BugNarrator[36098:1351198] [transcription] 2026-04-13T01:34:06.188Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: Issue extraction took longer than 0.3 seconds. Retry the extraction or choose a faster model in Settings. session_id=8B0FDBEF-D1BC-4B50-845D-92EE0840E522
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' passed (0.277 seconds).
+Test Suite 'IssueExtractionServiceTests' passed at 2026-04-12 21:34:06.191.
+	 Executed 4 tests, with 0 failures (0 unexpected) in 0.286 (0.287) seconds
+Test Suite 'JiraExportProviderTests' started at 2026-04-12 21:34:06.191.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' started.
+2026-04-12 21:34:06.194342-0400 BugNarrator[36098:1351212] [export] 2026-04-13T01:34:06.193Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=1 project_key=FM session_id=BB7897B4-F3AD-426B-9690-FDB6D19C01FE
+2026-04-12 21:34:06.221725-0400 BugNarrator[36098:1351212] [export] 2026-04-13T01:34:06.221Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=F244B758-409E-4FE5-8915-2F8422A810DE successful_count=0
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' passed (0.032 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-12 21:34:06.225870-0400 BugNarrator[36098:1351231] [export] 2026-04-13T01:34:06.226Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=2 project_key=FM session_id=32C6EC97-A4F6-40CB-8612-3577DF7E3007
+2026-04-12 21:34:06.226760-0400 BugNarrator[36098:1351212] [export] 2026-04-13T01:34:06.226Z [INFO] [export] jira_issue_exported - Exported one issue to Jira. remote_identifier=FM-101 source_issue_id=6F53D7E1-1C20-41C2-83F7-7733485258D0
+2026-04-12 21:34:06.227542-0400 BugNarrator[36098:1351231] [export] 2026-04-13T01:34:06.227Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=ED7E1B9D-CFA7-4B69-A87A-AE2DB73E8372 successful_count=1
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' started.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' passed (0.001 seconds).
+Test Suite 'JiraExportProviderTests' passed at 2026-04-12 21:34:06.230.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.037 (0.039) seconds
+Test Suite 'BugNarratorTests.xctest' passed at 2026-04-12 21:34:06.230.
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.347 (0.353) seconds
+Test Suite 'Selected tests' passed at 2026-04-12 21:34:06.230.
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.347 (0.353) seconds
+2026-04-12 21:34:06.505 xcodebuild[35895:1350508] [MT] IDETestOperationsObserverDebug: 1.687 elapsed -- Testing started completed.
+2026-04-12 21:34:06.505 xcodebuild[35895:1350508] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2026-04-12 21:34:06.505 xcodebuild[35895:1350508] [MT] IDETestOperationsObserverDebug: 1.687 sec, +1.687 sec -- end
+
+Test session results, code coverage, and logs:
+	/tmp/bugnarrator-n2-tests/Logs/Test/Test-BugNarrator-2026.04.12_21-33-58--0400.xcresult
+
+** TEST SUCCEEDED **
+
+Testing started

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-13T00:07:30Z",
+  "last_updated": "2026-04-13T01:34:16Z",
   "code_changes_present": true,
   "claims": {
     "implementation": "complete",
@@ -10,32 +10,32 @@
   "evidence": {
     "build": {
       "status": "passed",
-      "updated_at": "2026-04-13T00:07:30Z",
+      "updated_at": "2026-04-13T01:34:16Z",
       "reason": "",
       "paths": [
-        "artifacts/n1-recording-flow-hardening/xcodebuild-test.log"
+        "artifacts/n2-reproduction-steps/xcodebuild-test.log"
       ]
     },
     "test": {
       "status": "passed",
-      "updated_at": "2026-04-13T00:07:30Z",
+      "updated_at": "2026-04-13T01:34:16Z",
       "reason": "",
       "paths": [
-        "artifacts/n1-recording-flow-hardening/xcodebuild-test.log"
+        "artifacts/n2-reproduction-steps/xcodebuild-test.log"
       ]
     },
     "run": {
       "metadata_only": true,
       "status": "not_run",
-      "reason": "No interactive app run was performed in this Codex slice; local coverage came from runtime guardrails plus the full macOS test suite.",
-      "updated_at": "2026-04-13T00:07:30Z",
+      "reason": "No interactive app run was performed in this N2 Codex slice; local coverage came from runtime guardrails plus targeted macOS tests.",
+      "updated_at": "2026-04-13T01:34:16Z",
       "paths": []
     },
     "deploy": {
       "metadata_only": true,
       "status": "not_required",
-      "reason": "Current roadmap phase remains build-scoped and no deployment was executed in the N1 review slice.",
-      "updated_at": "2026-04-13T00:07:30Z",
+      "reason": "Current roadmap phase remains build-scoped and no deployment was executed in the N2 review slice.",
+      "updated_at": "2026-04-13T01:34:16Z",
       "paths": []
     }
   }

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,4 +1,4 @@
 # Controller State
 
-current_state: review_failed_fix_required
+current_state: ready_for_review
 current_task: N2

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -3,7 +3,7 @@
 task_id: N2
 description: AI-generated reproduction steps from narration + screenshots
 scope: Sources/BugNarrator/
-status: pending
+status: ready_for_review
 execution_status: idle
 execution_branch:
 execution_started_at:

--- a/state/handoff.json
+++ b/state/handoff.json
@@ -1,23 +1,6 @@
 {
-  "last_updated": "2026-04-13T05:11:00Z",
-  "summary": "N1 is implemented on codex/N1-end-to-end-recording-flow-hardening with forced session persistence, staged progress text, a 10-second extraction timeout, and a unified review workspace.",
-  "next_action": "Open or review the PR for N1 and collect GitHub CI plus code review feedback.",
-  "discovered_issues": [
-    {
-      "issue": "Roadmap active_task_id (N1) does not match current_task.md (N2). The advance-task workflow did not update docs/roadmap/state.json.",
-      "severity": "medium",
-      "action": "Update docs/roadmap/state.json active_task_id to N2 and last_updated.",
-      "owner": "scheduled-audit",
-      "source": "repo-health-audit",
-      "detected_at": "2026-04-13T05:11:00Z"
-    },
-    {
-      "issue": "Handoff next_action still references opening or reviewing the N1 PR, but N1 is already done and merged. Current task is N2.",
-      "severity": "low",
-      "action": "Update handoff summary and next_action to reflect current N2 task state.",
-      "owner": "scheduled-audit",
-      "source": "repo-health-audit",
-      "detected_at": "2026-04-13T05:11:00Z"
-    }
-  ]
+  "last_updated": "2026-04-13T01:34:16Z",
+  "summary": "N2 is ready for review on codex/N2-ai-generated-reproduction-steps-from-narration-screenshots with structured reproduction-step generation, editing, and tracker export support.",
+  "next_action": "Review the N2 PR, focusing on reproduction-step quality in the review UI and exported issue payloads.",
+  "discovered_issues": []
 }

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -18,10 +18,12 @@ DID:
 - Extended the issue-extraction prompt/parser so OpenAI returns reproduction steps tied to narration timecodes and screenshot file names, with issue-level reference fallback when a step omits one.
 - Rendered reproduction steps in the review workspace with editable action, expected, and actual fields plus visible timestamp and screenshot references.
 - Included reproduction steps and step references in both GitHub and Jira export payloads so the generated issue tracker tickets carry the same reviewable repro details.
+- Normalized optional reproduction-step edits so expected and actual text is trimmed before persistence, preventing accidental whitespace from leaking into exports.
 
 VALIDATED:
 - ./scripts/validate.sh
 - xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:BugNarratorTests/ReviewWorkspaceTests test
 
 NEXT:
-- Review the generated reproduction steps in the stacked review workspace and confirm the exported GitHub/Jira issue formatting in PR review.
+- Confirm the PR review thread about reproduction-step whitespace is resolved by the pushed branch update.

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,34 +1,27 @@
 # Implementation Notes
 
-task_id: N1
+task_id: N2
 status: ready_for_review
 
 CHANGED:
-- Sources/BugNarrator/AppState.swift
+- Sources/BugNarrator/Models/ExtractedIssue.swift
+- Sources/BugNarrator/Services/GitHubExportProvider.swift
 - Sources/BugNarrator/Services/IssueExtractionService.swift
-- Sources/BugNarrator/Views/SettingsView.swift
+- Sources/BugNarrator/Services/JiraExportProvider.swift
 - Sources/BugNarrator/Views/TranscriptView.swift
-- Tests/BugNarratorTests/AppStateTests.swift
+- Tests/BugNarratorTests/GitHubExportProviderTests.swift
 - Tests/BugNarratorTests/IssueExtractionServiceTests.swift
-- Tests/BugNarratorTests/MenuBarStatusPresentationTests.swift
+- Tests/BugNarratorTests/JiraExportProviderTests.swift
 
 DID:
-- Forced completed recording sessions to persist locally on stop, even if the legacy auto-save preference is disabled.
-- Added staged progress text for stop and retry flows so transcription, local save, and extraction progress are visible as text.
-- Enforced a 10-second issue-extraction timeout with a clear retry/faster-model error.
-- Reworked the review pane into one stacked workspace so summary, extracted issues, screenshots, and transcript are visible in a single view.
-- Updated workflow settings copy to reflect required local session persistence.
+- Added structured reproduction-step data to extracted issues, with per-step instruction, expected result, actual result, timestamp, and screenshot reference persistence.
+- Extended the issue-extraction prompt/parser so OpenAI returns reproduction steps tied to narration timecodes and screenshot file names, with issue-level reference fallback when a step omits one.
+- Rendered reproduction steps in the review workspace with editable action, expected, and actual fields plus visible timestamp and screenshot references.
+- Included reproduction steps and step references in both GitHub and Jira export payloads so the generated issue tracker tickets carry the same reviewable repro details.
 
 VALIDATED:
-- ./scripts/validate.sh 314d332a132e94f9076d7da5c512d031f598a7ff
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test
+- ./scripts/validate.sh
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
 
 NEXT:
-- Review the unified transcript workspace and the forced auto-save behavior in PR review.
-
-## 2026-04-13 Review Remediation
-
-- Synced the issue-extraction timeout failure copy to the configured timeout budget and rounded subsecond values up to a stable tenths display.
-- Computed transcription progress step totals from `autoExtractIssues` so non-extraction runs no longer claim a missing third step.
-- Marked the stacked review workspace section titles as accessibility headers and updated the regression script for the no-tabs layout.
-- Returned `state/current_task.md` to `ready_for_review` after fixing the CI and review findings on PR #14.
+- Review the generated reproduction steps in the stacked review workspace and confirm the exported GitHub/Jira issue formatting in PR review.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,6 +1,13 @@
 {
-  "updated_on": "2026-04-12",
-  "active": [],
+  "updated_on": "2026-04-13",
+  "active": [
+    {
+      "id": "N2",
+      "status": "in_progress",
+      "title": "AI-generated reproduction steps from narration + screenshots",
+      "updated_at": "2026-04-13T05:03:00Z"
+    }
+  ],
   "completed": [
     {
       "id": "N1",
@@ -9,7 +16,7 @@
       "updated_at": "2026-04-12T07:00:00Z"
     }
   ],
-  "last_updated": "2026-04-12T07:00:00Z",
+  "last_updated": "2026-04-13T05:03:00Z",
   "tasks": [
     {
       "id": "N1",
@@ -19,9 +26,9 @@
     },
     {
       "id": "N2",
-      "status": "pending",
+      "status": "in_progress",
       "title": "AI-generated reproduction steps from narration + screenshots",
-      "updated_at": "2026-04-12T07:00:00Z"
+      "updated_at": "2026-04-13T05:03:00Z"
     }
   ]
 }

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,15 +1,13 @@
 # Validation Report
 
-task_id: N1
+task_id: N2
 result: passed
-summary: Runtime guardrails and the full BugNarrator macOS test suite passed for the N1 recording-flow hardening slice.
+summary: Runtime guardrails and the targeted BugNarrator extraction/export macOS tests passed for the N2 reproduction-step slice.
 
 artifacts:
-- artifacts/n1-recording-flow-hardening/validate.log
-- artifacts/n1-recording-flow-hardening/xcodebuild-test.log
+- artifacts/n2-reproduction-steps/validate.log
+- artifacts/n2-reproduction-steps/xcodebuild-test.log
 
-## 2026-04-13 Review Remediation Validation
-
-- ./scripts/accessibility_regression_check.sh -> PASS
+commands:
 - ./scripts/validate.sh -> PASS
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/AppStateTests test -> PASS
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -> PASS

--- a/tools/validators/enforce-runtime-guardrails.js
+++ b/tools/validators/enforce-runtime-guardrails.js
@@ -16,6 +16,7 @@ const OPTIONAL_STATE_FILES = [
   "state/decisions.json"
 ];
 const REQUIRED_WORKFLOW_FILES = [
+  "AGENTS.md",
   "ai/bootstrap.md",
   "ai/plan.md",
   "ai/tasks.md",
@@ -93,6 +94,7 @@ const DOC_PATTERNS = [
 ];
 
 const STATE_OR_META_PATTERNS = [
+  /^AGENTS\.md$/,
   /^ai\//,
   /^state\//,
   /^docs\/roadmap\//,


### PR DESCRIPTION
## Summary
- add structured reproduction steps to extracted issues, including per-step time and screenshot references
- render editable reproduction steps in the review workspace and carry them into GitHub/Jira exports
- extend extraction/export tests and record N2 validation artifacts/state handoff

## Files
- Sources/BugNarrator/Models/ExtractedIssue.swift
- Sources/BugNarrator/Services/IssueExtractionService.swift
- Sources/BugNarrator/Services/GitHubExportProvider.swift
- Sources/BugNarrator/Services/JiraExportProvider.swift
- Sources/BugNarrator/Views/TranscriptView.swift
- Tests/BugNarratorTests/IssueExtractionServiceTests.swift
- Tests/BugNarratorTests/GitHubExportProviderTests.swift
- Tests/BugNarratorTests/JiraExportProviderTests.swift
- state/current_task.md
- state/controller.md
- state/implementation_notes.md
- state/validation_report.md
- state/artifacts.json
- state/handoff.json

## Validation
- `./scripts/validate.sh`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests`