### PR TITLE
N3: Enhanced issue classification — severity, component, deduplication hint

### DIFF
--- a/Sources/BugNarrator/Models/ExtractedIssue.swift
+++ b/Sources/BugNarrator/Models/ExtractedIssue.swift
@@ -9,6 +9,15 @@ enum ExtractedIssueCategory: String, Codable, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+enum ExtractedIssueSeverity: String, Codable, CaseIterable, Identifiable {
+    case critical = "Critical"
+    case high = "High"
+    case medium = "Medium"
+    case low = "Low"
+
+    var id: String { rawValue }
+}
+
 struct IssueReproductionStep: Identifiable, Codable, Equatable {
     let id: UUID
     var instruction: String
@@ -46,8 +55,11 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
     let id: UUID
     var title: String
     var category: ExtractedIssueCategory
+    var severity: ExtractedIssueSeverity
+    var component: String?
     var summary: String
     var evidenceExcerpt: String
+    var deduplicationHint: String
     var timestamp: TimeInterval?
     var relatedScreenshotIDs: [UUID]
     var confidence: Double?
@@ -61,8 +73,11 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         id: UUID = UUID(),
         title: String,
         category: ExtractedIssueCategory,
+        severity: ExtractedIssueSeverity = .medium,
+        component: String? = nil,
         summary: String,
         evidenceExcerpt: String,
+        deduplicationHint: String? = nil,
         timestamp: TimeInterval?,
         relatedScreenshotIDs: [UUID] = [],
         confidence: Double? = nil,
@@ -75,8 +90,16 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         self.id = id
         self.title = title
         self.category = category
+        self.severity = severity
+        self.component = component?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         self.summary = summary
         self.evidenceExcerpt = evidenceExcerpt
+        self.deduplicationHint = Self.normalizedDeduplicationHint(
+            deduplicationHint,
+            title: title,
+            summary: summary,
+            evidenceExcerpt: evidenceExcerpt
+        )
         self.timestamp = timestamp
         self.relatedScreenshotIDs = relatedScreenshotIDs
         self.confidence = confidence
@@ -92,8 +115,16 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         id = try container.decode(UUID.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         category = try container.decode(ExtractedIssueCategory.self, forKey: .category)
+        severity = try container.decodeIfPresent(ExtractedIssueSeverity.self, forKey: .severity) ?? .medium
+        component = try container.decodeIfPresent(String.self, forKey: .component)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         summary = try container.decode(String.self, forKey: .summary)
         evidenceExcerpt = try container.decode(String.self, forKey: .evidenceExcerpt)
+        deduplicationHint = Self.normalizedDeduplicationHint(
+            try container.decodeIfPresent(String.self, forKey: .deduplicationHint),
+            title: title,
+            summary: summary,
+            evidenceExcerpt: evidenceExcerpt
+        )
         timestamp = try container.decodeIfPresent(TimeInterval.self, forKey: .timestamp)
         relatedScreenshotIDs = try container.decodeIfPresent([UUID].self, forKey: .relatedScreenshotIDs) ?? []
         confidence = try container.decodeIfPresent(Double.self, forKey: .confidence)
@@ -109,8 +140,11 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         try container.encode(id, forKey: .id)
         try container.encode(title, forKey: .title)
         try container.encode(category, forKey: .category)
+        try container.encode(severity, forKey: .severity)
+        try container.encodeIfPresent(component, forKey: .component)
         try container.encode(summary, forKey: .summary)
         try container.encode(evidenceExcerpt, forKey: .evidenceExcerpt)
+        try container.encode(deduplicationHint, forKey: .deduplicationHint)
         try container.encodeIfPresent(timestamp, forKey: .timestamp)
         try container.encode(relatedScreenshotIDs, forKey: .relatedScreenshotIDs)
         try container.encodeIfPresent(confidence, forKey: .confidence)
@@ -125,8 +159,11 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         case id
         case title
         case category
+        case severity
+        case component
         case summary
         case evidenceExcerpt
+        case deduplicationHint
         case timestamp
         case relatedScreenshotIDs
         case confidence
@@ -151,6 +188,47 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         }
 
         return "\(Int((confidence * 100).rounded()))%"
+    }
+
+    static func makeDeduplicationHint(title: String, summary: String, evidenceExcerpt: String) -> String {
+        let normalized = [
+            title,
+            summary,
+            evidenceExcerpt
+        ]
+        .joined(separator: "\n")
+        .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        .lowercased()
+        .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !normalized.isEmpty else {
+            return "issue-0000000000000000"
+        }
+
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        let prime: UInt64 = 1_099_511_628_211
+
+        for byte in normalized.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+
+        return String(format: "issue-%016llx", hash)
+    }
+
+    private static func normalizedDeduplicationHint(
+        _ value: String?,
+        title: String,
+        summary: String,
+        evidenceExcerpt: String
+    ) -> String {
+        if let trimmedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !trimmedValue.isEmpty {
+            return trimmedValue
+        }
+
+        return makeDeduplicationHint(title: title, summary: summary, evidenceExcerpt: evidenceExcerpt)
     }
 }
 
@@ -233,5 +311,11 @@ struct JiraExportConfiguration: Equatable {
 
     var isComplete: Bool {
         !email.isEmpty && !apiToken.isEmpty && !projectKey.isEmpty && !issueType.isEmpty
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -426,6 +426,10 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
             lines.append("- **\(item.title)**: \(item.summary)")
 
             var contextParts: [String] = []
+            contextParts.append("severity \(item.severity.rawValue)")
+            if let component = item.component, !component.isEmpty {
+                contextParts.append(component)
+            }
             if let sectionTitle = item.sectionTitle, !sectionTitle.isEmpty {
                 contextParts.append(sectionTitle)
             }
@@ -443,6 +447,7 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
                 lines.append("  Context: \(contextParts.joined(separator: "  •  "))")
             }
             lines.append("  Evidence: \(item.evidenceExcerpt)")
+            lines.append("  Dedup hint: \(item.deduplicationHint)")
 
             let relatedScreenshots = screenshots(for: item)
             if !relatedScreenshots.isEmpty {

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -134,6 +134,15 @@ actor GitHubExportProvider {
             lines.append("- Transcript time: `\(timestampLabel)`")
         }
 
+        lines.append("- Severity: \(issue.severity.rawValue)")
+
+        if let component = issue.component?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !component.isEmpty {
+            lines.append("- Component: \(component)")
+        }
+
+        lines.append("- Deduplication hint: `\(issue.deduplicationHint)`")
+
         if let sectionTitle = issue.sectionTitle, !sectionTitle.isEmpty {
             lines.append("- Transcript section: \(sectionTitle)")
         }

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -185,10 +185,13 @@ actor IssueExtractionService: IssueExtracting {
                         You convert spoken software review notes into structured, reviewable draft issues.
                         Use only information explicitly present in the transcript, markers, and screenshot references.
                         Return strict JSON with keys summary, guidanceNote, issues.
-                        Each issue must contain title, category, summary, evidenceExcerpt, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview, reproductionSteps.
+                        Each issue must contain title, category, severity, component, summary, evidenceExcerpt, deduplicationHint, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview, reproductionSteps.
                         Each reproduction step must contain instruction, expectedResult, actualResult, timestamp, relatedScreenshotFileName.
                         Generate numbered reproduction steps that follow the narration timeline and tie each step to the most relevant screenshot reference when one exists.
                         Valid categories are exactly: Bug, UX Issue, Enhancement, Question / Follow-up.
+                        Valid severities are exactly: Critical, High, Medium, Low.
+                        Infer severity from the narration tone and impact. Infer component from the most specific app area available in the transcript or screenshot context.
+                        DeduplicationHint should be a short stable hash-like string derived from the issue description.
                         Prefer conservative output. If evidence is weak, set requiresReview to true and use a lower confidence.
                         """
                     ),
@@ -459,8 +462,11 @@ private struct IssueExtractionPayload {
 private struct IssuePayload {
     let title: String
     let category: String
+    let severity: String?
+    let component: String?
     let summary: String
     let evidenceExcerpt: String
+    let deduplicationHint: String?
     let timestamp: String?
     let sectionTitle: String?
     let relatedScreenshotFileNames: [String]?
@@ -483,8 +489,20 @@ private struct IssuePayload {
 
         self.title = title
         self.category = category
+        self.severity = Self.firstString(
+            in: dictionary,
+            keys: ["severity", "priority", "impact"]
+        )?.trimmedForExtraction
+        self.component = Self.firstString(
+            in: dictionary,
+            keys: ["component", "area", "affectedComponent", "affected_component", "surface", "scope"]
+        )?.trimmedForExtraction
         self.summary = summary
         self.evidenceExcerpt = evidenceExcerpt
+        self.deduplicationHint = Self.firstString(
+            in: dictionary,
+            keys: ["deduplicationHint", "dedupHint", "dedup_hint", "duplicateHint", "duplicate_hint"]
+        )?.trimmedForExtraction
         self.timestamp = Self.firstString(in: dictionary, keys: ["timestamp", "time", "timecode"])?.trimmedForExtraction
         self.sectionTitle = Self.firstString(in: dictionary, keys: ["sectionTitle", "section", "sectionName"])?.trimmedForExtraction
         self.relatedScreenshotFileNames = Self.firstStringArray(
@@ -521,8 +539,11 @@ private struct IssuePayload {
         return ExtractedIssue(
             title: title.trimmingCharacters(in: .whitespacesAndNewlines),
             category: Self.parseCategory(category),
+            severity: Self.parseSeverity(severity, title: title, summary: summary, evidenceExcerpt: evidenceExcerpt),
+            component: normalizedComponent,
             summary: summary.trimmingCharacters(in: .whitespacesAndNewlines),
             evidenceExcerpt: evidenceExcerpt.trimmingCharacters(in: .whitespacesAndNewlines),
+            deduplicationHint: deduplicationHint?.trimmingCharacters(in: .whitespacesAndNewlines),
             timestamp: parsedTimestamp,
             relatedScreenshotIDs: screenshotIDs,
             confidence: confidence,
@@ -531,6 +552,20 @@ private struct IssuePayload {
             sectionTitle: sectionTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
             reproductionSteps: reproductionSteps
         )
+    }
+
+    private var normalizedComponent: String? {
+        if let component = component?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !component.isEmpty {
+            return component
+        }
+
+        if let sectionTitle = sectionTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !sectionTitle.isEmpty {
+            return sectionTitle
+        }
+
+        return nil
     }
 
     fileprivate static func firstString(in dictionary: [String: Any], keys: [String]) -> String? {
@@ -611,6 +646,89 @@ private struct IssuePayload {
         default:
             return .followUp
         }
+    }
+
+    fileprivate static func parseSeverity(
+        _ value: String?,
+        title: String,
+        summary: String,
+        evidenceExcerpt: String
+    ) -> ExtractedIssueSeverity {
+        if let value {
+            let normalizedValue = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+            switch normalizedValue {
+            case "critical", "blocker", "sev1", "p0":
+                return .critical
+            case "high", "major", "sev2", "p1":
+                return .high
+            case "medium", "moderate", "normal", "sev3", "p2":
+                return .medium
+            case "low", "minor", "cosmetic", "sev4", "p3":
+                return .low
+            default:
+                break
+            }
+        }
+
+        let combinedText = [
+            title,
+            summary,
+            evidenceExcerpt
+        ]
+        .joined(separator: " ")
+        .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+        .lowercased()
+
+        let criticalSignals = [
+            "crash",
+            "crashes",
+            "data loss",
+            "completely broken",
+            "blocked",
+            "blocker",
+            "cannot continue",
+            "can't continue",
+            "unable to continue",
+            "won't open",
+            "blank screen"
+        ]
+        if criticalSignals.contains(where: combinedText.contains) {
+            return .critical
+        }
+
+        let lowSignals = [
+            "minor",
+            "small",
+            "cosmetic",
+            "visual glitch",
+            "visual issue",
+            "spacing",
+            "alignment",
+            "typo",
+            "copy issue"
+        ]
+        if lowSignals.contains(where: combinedText.contains) {
+            return .low
+        }
+
+        let highSignals = [
+            "broken",
+            "doesn't work",
+            "does not work",
+            "not respond",
+            "fails",
+            "failure",
+            "unable to",
+            "cannot",
+            "can't",
+            "stuck"
+        ]
+        if highSignals.contains(where: combinedText.contains) {
+            return .high
+        }
+
+        return .medium
     }
 
     fileprivate static func parseTimestamp(_ value: String?) -> TimeInterval? {

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -133,6 +133,12 @@ actor JiraExportProvider {
         if let timestampLabel = issue.timestampLabel {
             metadataLines.append("Transcript time: \(timestampLabel)")
         }
+        metadataLines.append("Severity: \(issue.severity.rawValue)")
+        if let component = issue.component?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !component.isEmpty {
+            metadataLines.append("Component: \(component)")
+        }
+        metadataLines.append("Deduplication hint: \(issue.deduplicationHint)")
         if let sectionTitle = issue.sectionTitle, !sectionTitle.isEmpty {
             metadataLines.append("Transcript section: \(sectionTitle)")
         }

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -6,6 +6,11 @@ func normalizedOptionalReproductionStepText(_ value: String) -> String? {
     return trimmedValue.isEmpty ? nil : trimmedValue
 }
 
+func normalizedOptionalIssueText(_ value: String) -> String? {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedValue.isEmpty ? nil : trimmedValue
+}
+
 struct TranscriptView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var transcriptStore: TranscriptStore
@@ -1221,7 +1226,10 @@ struct TranscriptView: View {
         VStack(alignment: .leading, spacing: 10) {
             if availableWidth < 520 {
                 VStack(alignment: .leading, spacing: 8) {
-                    issueCategoryPicker(issue: issue, session: session)
+                    HStack(spacing: 8) {
+                        issueCategoryPicker(issue: issue, session: session)
+                        issueSeverityPicker(issue: issue, session: session)
+                    }
 
                     TextField(
                         "Issue title",
@@ -1235,6 +1243,7 @@ struct TranscriptView: View {
             } else {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
                     issueCategoryPicker(issue: issue, session: session)
+                    issueSeverityPicker(issue: issue, session: session)
 
                     Text("—")
                         .foregroundStyle(.secondary)
@@ -1250,6 +1259,24 @@ struct TranscriptView: View {
 
                     issueReviewBadge(issue: issue, session: session)
                 }
+            }
+
+            HStack(alignment: .center, spacing: 10) {
+                Text("Component")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                TextField(
+                    "Settings > Accounts",
+                    text: issueOptionalTextBinding(
+                        sessionID: session.id,
+                        issueID: issue.id,
+                        keyPath: \.component,
+                        fallback: issue.component
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Suggested component for \(issue.title)")
             }
 
             if let timestampLabel = extractedIssue(sessionID: session.id, issueID: issue.id)?.timestampLabel ?? issue.timestampLabel {
@@ -1275,6 +1302,24 @@ struct TranscriptView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
+            }
+
+            HStack(alignment: .center, spacing: 10) {
+                Text("Dedup Hint")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                TextField(
+                    "Stable duplicate hint",
+                    text: issueDeduplicationHintBinding(
+                        sessionID: session.id,
+                        issueID: issue.id,
+                        fallback: issue.deduplicationHint
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .accessibilityLabel("Deduplication hint for \(issue.title)")
             }
 
             let liveIssue = extractedIssue(sessionID: session.id, issueID: issue.id) ?? issue
@@ -1405,6 +1450,21 @@ struct TranscriptView: View {
         .pickerStyle(.menu)
         .accessibilityLabel("Issue category for \(issue.title)")
         .accessibilityValue((extractedIssue(sessionID: session.id, issueID: issue.id)?.category ?? issue.category).rawValue)
+    }
+
+    private func issueSeverityPicker(issue: ExtractedIssue, session: TranscriptSession) -> some View {
+        Picker(
+            "",
+            selection: issueBinding(sessionID: session.id, issueID: issue.id, keyPath: \.severity, fallback: issue.severity)
+        ) {
+            ForEach(ExtractedIssueSeverity.allCases) { severity in
+                Text(severity.rawValue).tag(severity)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .accessibilityLabel("Issue severity for \(issue.title)")
+        .accessibilityValue((extractedIssue(sessionID: session.id, issueID: issue.id)?.severity ?? issue.severity).rawValue)
     }
 
     @ViewBuilder
@@ -1540,6 +1600,53 @@ struct TranscriptView: View {
                 }
 
                 updatedIssue.reproductionSteps[stepIndex][keyPath: keyPath] = normalizedOptionalReproductionStepText(newValue)
+                appState.updateExtractedIssue(updatedIssue, in: sessionID)
+            }
+        )
+    }
+
+    private func issueOptionalTextBinding(
+        sessionID: UUID,
+        issueID: UUID,
+        keyPath: WritableKeyPath<ExtractedIssue, String?>,
+        fallback: String?
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                extractedIssue(sessionID: sessionID, issueID: issueID)?[keyPath: keyPath] ?? fallback ?? ""
+            },
+            set: { newValue in
+                guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID) else {
+                    return
+                }
+
+                updatedIssue[keyPath: keyPath] = normalizedOptionalIssueText(newValue)
+                appState.updateExtractedIssue(updatedIssue, in: sessionID)
+            }
+        )
+    }
+
+    private func issueDeduplicationHintBinding(
+        sessionID: UUID,
+        issueID: UUID,
+        fallback: String
+    ) -> Binding<String> {
+        Binding(
+            get: {
+                extractedIssue(sessionID: sessionID, issueID: issueID)?.deduplicationHint ?? fallback
+            },
+            set: { newValue in
+                guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID) else {
+                    return
+                }
+
+                updatedIssue.deduplicationHint =
+                    normalizedOptionalIssueText(newValue) ??
+                    ExtractedIssue.makeDeduplicationHint(
+                        title: updatedIssue.title,
+                        summary: updatedIssue.summary,
+                        evidenceExcerpt: updatedIssue.evidenceExcerpt
+                    )
                 appState.updateExtractedIssue(updatedIssue, in: sessionID)
             }
         )

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -13,8 +13,11 @@ final class GitHubExportProviderTests: XCTestCase {
         let issue = ExtractedIssue(
             title: "Login button is disabled",
             category: .bug,
+            severity: .high,
+            component: "Login Page",
             summary: "The login button stays disabled after valid input.",
             evidenceExcerpt: "The login button never re-enabled after typing a valid email.",
+            deduplicationHint: "issue-login-disabled",
             timestamp: 14,
             relatedScreenshotIDs: [],
             requiresReview: true,
@@ -57,6 +60,9 @@ final class GitHubExportProviderTests: XCTestCase {
         XCTAssertEqual(payload.title, "Login button is disabled")
         XCTAssertEqual(payload.labels, ["bug", "triage"])
         XCTAssertTrue(payload.body.contains("Transcript time"))
+        XCTAssertTrue(payload.body.contains("Severity: High"))
+        XCTAssertTrue(payload.body.contains("Component: Login Page"))
+        XCTAssertTrue(payload.body.contains("Deduplication hint: `issue-login-disabled`"))
         XCTAssertTrue(payload.body.contains("Review needed: Yes"))
         XCTAssertTrue(payload.body.contains("## Reproduction Steps"))
         XCTAssertTrue(payload.body.contains("Expected: The login button enables."))

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -19,8 +19,11 @@ final class IssueExtractionServiceTests: XCTestCase {
             {
               "title": "Save button clips in the modal",
               "category": "Bug",
+              "severity": "High",
+              "component": "Settings > Save Modal",
               "summary": "The save button appears clipped in the modal layout.",
               "evidenceExcerpt": "The save button is clipped",
+              "deduplicationHint": "issue-save-modal-clipped",
               "timestamp": "00:08",
               "sectionTitle": "Save flow",
               "relatedScreenshotFileNames": ["review-shot.png"],
@@ -54,7 +57,10 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.guidanceNote, "Review these before export.")
         XCTAssertEqual(result.issues.count, 1)
         XCTAssertEqual(result.issues.first?.category, .bug)
+        XCTAssertEqual(result.issues.first?.severity, .high)
+        XCTAssertEqual(result.issues.first?.component, "Settings > Save Modal")
         XCTAssertEqual(result.issues.first?.relatedScreenshotIDs, [try XCTUnwrap(session.screenshots.first?.id)])
+        XCTAssertEqual(result.issues.first?.deduplicationHint, "issue-save-modal-clipped")
         XCTAssertEqual(result.issues.first?.timestamp, 8)
         XCTAssertEqual(result.issues.first?.reproductionSteps.count, 1)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.instruction, "Open the save modal.")
@@ -123,11 +129,42 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.issues.count, 1)
         XCTAssertEqual(result.issues.first?.title, "Save button clips in the modal")
         XCTAssertEqual(result.issues.first?.category, .bug)
+        XCTAssertEqual(result.issues.first?.severity, .medium)
+        XCTAssertEqual(result.issues.first?.component, "Save flow")
         XCTAssertEqual(result.issues.first?.relatedScreenshotIDs, [session.screenshots.first?.id].compactMap { $0 })
+        XCTAssertTrue(result.issues.first?.deduplicationHint.hasPrefix("issue-") == true)
         XCTAssertEqual(result.issues.first?.timestamp, 8)
         XCTAssertEqual(result.issues.first?.reproductionSteps.count, 1)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.timestamp, 8)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.screenshotID, session.screenshots.first?.id)
+    }
+
+    func testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing() async throws {
+        let session = makeReviewSession()
+        let content = """
+        {
+          "summary": "One draft issue was extracted.",
+          "issues": [
+            {
+              "title": "Submit button does not respond",
+              "category": "Bug",
+              "summary": "The submit button does not respond after entering valid input.",
+              "evidenceExcerpt": "This is completely broken because the submit button never responds.",
+              "timestamp": "00:08"
+            }
+          ]
+        }
+        """
+
+        MockURLProtocol.requestHandler = { request in
+            (self.successResponse(for: request), self.makeChatCompletionData(content: content))
+        }
+
+        let service = IssueExtractionService(session: makeMockURLSession())
+        let result = try await service.extractIssues(from: session, apiKey: "fixture-openai-key", model: "gpt-4.1-mini")
+
+        XCTAssertEqual(result.issues.first?.severity, .critical)
+        XCTAssertTrue(result.issues.first?.deduplicationHint.hasPrefix("issue-") == true)
     }
 
     func testExtractIssuesReturnsClearErrorForMalformedStructuredPayload() async throws {

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -13,8 +13,11 @@ final class JiraExportProviderTests: XCTestCase {
         let issue = ExtractedIssue(
             title: "Modal lacks close affordance",
             category: .uxIssue,
+            severity: .medium,
+            component: "Settings Modal",
             summary: "The modal has no visible close affordance.",
             evidenceExcerpt: "I cannot tell how to dismiss the modal.",
+            deduplicationHint: "issue-modal-close-affordance",
             timestamp: 22,
             requiresReview: true,
             reproductionSteps: [
@@ -63,6 +66,9 @@ final class JiraExportProviderTests: XCTestCase {
         XCTAssertEqual(fields["summary"] as? String, "Modal lacks close affordance")
         let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         let payloadString = try XCTUnwrap(String(data: payloadData, encoding: .utf8))
+        XCTAssertTrue(payloadString.contains("Severity: Medium"))
+        XCTAssertTrue(payloadString.contains("Component: Settings Modal"))
+        XCTAssertTrue(payloadString.contains("Deduplication hint: issue-modal-close-affordance"))
         XCTAssertTrue(payloadString.contains("Reproduction steps"))
         XCTAssertTrue(payloadString.contains("Expected: A close affordance is visible immediately."))
         XCTAssertTrue(payloadString.contains("Actual: No close affordance appears in the modal chrome."))

--- a/artifacts/n3-issue-classification/validate.log
+++ b/artifacts/n3-issue-classification/validate.log
@@ -1,0 +1,5 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 9 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Config loaded from ai.config.json

--- a/artifacts/n3-issue-classification/xcodebuild-test.log
+++ b/artifacts/n3-issue-classification/xcodebuild-test.log
@@ -1,0 +1,166 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test "-only-testing:BugNarratorTests/IssueExtractionServiceTests" "-only-testing:BugNarratorTests/GitHubExportProviderTests" "-only-testing:BugNarratorTests/JiraExportProviderTests" "-only-testing:BugNarratorTests/TranscriptExporterTests" "-only-testing:BugNarratorTests/ReviewWorkspaceTests"
+
+Build settings from command line:
+    CODE_SIGNING_ALLOWED = NO
+
+2026-04-13 04:09:00.862 xcodebuild[57025:2183900] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, arch:x86_64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, name:Any Mac }
+ComputePackagePrebuildTargetDependencyGraph
+
+Prepare packages
+
+CreateBuildRequest
+
+SendProjectDescription
+
+CreateBuildOperation
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'BugNarratorTests' in project 'BugNarrator'
+        ➜ Explicit dependency on target 'BugNarrator' in project 'BugNarrator'
+    Target 'BugNarrator' in project 'BugNarrator' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -x c -c /dev/null
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
+
+ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details
+
+Build description signature: 7f5e936c9a66d6a108c8f87d33cc4ca3
+Build description path: /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/XCBuildData/7f5e936c9a66d6a108c8f87d33cc4ca3.xcbuilddata
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /tmp/bugnarrator-n3-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+    cd /Users/deffenda/Code/bug-narrator/BugNarrator.xcodeproj
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /tmp/bugnarrator-n3-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+CopySwiftLibs /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/MacOS/BugNarrator.debug.dylib --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Library/SystemExtensions --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+ProcessInfoPlistFile /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Info.plist /Users/deffenda/Code/bug-narrator/Resources/Info.plist (in target 'BugNarrator' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-infoPlistUtility /Users/deffenda/Code/bug-narrator/Resources/Info.plist -producttype com.apple.product-type.application -genpkginfo /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarrator.build/assetcatalog_generated_info.plist -o /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/Info.plist
+
+CopySwiftLibs /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-swiftStdLibTool --copy --verbose --scan-executable /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/MacOS/BugNarratorTests --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/PlugIns --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Library/SystemExtensions --scan-folder /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span
+Ignoring --strip-bitcode because --sign was not passed
+
+ProcessInfoPlistFile /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist (in target 'BugNarratorTests' from project 'BugNarrator')
+    cd /Users/deffenda/Code/bug-narrator
+    builtin-infoPlistUtility /tmp/bugnarrator-n3-tests/Build/Intermediates.noindex/BugNarrator.build/Debug/BugNarratorTests.build/empty-BugNarratorTests.plist -producttype com.apple.product-type.bundle.unit-test -expandbuildsettings -platform macosx -o /tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app/Contents/PlugIns/BugNarratorTests.xctest/Contents/Info.plist
+
+2026-04-13 04:09:07.698211-0400 BugNarrator[57197:2184594] [settings] 2026-04-13T08:09:07.696Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-13 04:09:07.698880-0400 BugNarrator[57197:2184594] [session-library] 2026-04-13T08:09:07.699Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-13 04:09:07.704006-0400 BugNarrator[57197:2184594] [settings] 2026-04-13T08:09:07.704Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-13 04:09:07.716440-0400 BugNarrator[57197:2184594] [permissions] 2026-04-13T08:09:07.716Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/private/tmp/bugnarrator-n3-tests/Build/Products/Debug/BugNarrator.app is_local_testing_build=no microphone_status=notDetermined screen_capture_status=notDetermined
+2026-04-13 04:09:07.716715-0400 BugNarrator[57197:2184594] [session-library] 2026-04-13T08:09:07.717Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Suite 'Selected tests' started at 2026-04-13 04:09:07.955.
+Test Suite 'BugNarratorTests.xctest' started at 2026-04-13 04:09:07.956.
+Test Suite 'GitHubExportProviderTests' started at 2026-04-13 04:09:07.956.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' started.
+2026-04-13 04:09:07.958096-0400 BugNarrator[57197:2184687] [export] 2026-04-13T08:09:07.958Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=1 repository=acme/bugnarrator session_id=D2311027-FFCF-4AAE-AD16-A2A871C0E0F5
+2026-04-13 04:09:07.964811-0400 BugNarrator[57197:2184673] [export] 2026-04-13T08:09:07.965Z [ERROR] [export] github_export_failed - Export failed: GitHub could not find acme/bugnarrator. Check the owner, repository name, and token permissions. source_issue_id=5530F4A5-0E14-4203-A1C3-E1523E9586FB successful_count=0
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 04:09:07.966919-0400 BugNarrator[57197:2184710] [export] 2026-04-13T08:09:07.967Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=2 repository=acme/bugnarrator session_id=22B2916D-9493-4299-94F6-88DFFBD3BA60
+2026-04-13 04:09:07.967886-0400 BugNarrator[57197:2184673] [export] 2026-04-13T08:09:07.968Z [INFO] [export] github_issue_exported - Exported one issue to GitHub. remote_identifier=#101 source_issue_id=E2344E49-637E-4ACE-AD0B-628578663917
+2026-04-13 04:09:07.968460-0400 BugNarrator[57197:2184673] [export] 2026-04-13T08:09:07.968Z [ERROR] [export] github_export_failed - Export failed: GitHub rejected the issue payload: Validation Failed source_issue_id=D3ABAAA0-D7A9-469A-A2FD-741D93C8F744 successful_count=1
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.008 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' started.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' passed (0.009 seconds).
+Test Suite 'GitHubExportProviderTests' passed at 2026-04-13 04:09:07.983.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.026 (0.027) seconds
+Test Suite 'IssueExtractionServiceTests' started at 2026-04-13 04:09:07.983.
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing]' started.
+2026-04-13 04:09:07.984605-0400 BugNarrator[57197:2184664] [transcription] 2026-04-13T08:09:07.984Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=34D29A17-C7A3-4ACF-AF66-AD011056853C
+2026-04-13 04:09:07.987444-0400 BugNarrator[57197:2184710] [transcription] 2026-04-13T08:09:07.987Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=34D29A17-C7A3-4ACF-AF66-AD011056853C
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' started.
+2026-04-13 04:09:07.989322-0400 BugNarrator[57197:2184710] [transcription] 2026-04-13T08:09:07.989Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=65441DC3-1ABB-4E6A-AB83-D86A5D06BAD0
+2026-04-13 04:09:07.990822-0400 BugNarrator[57197:2184710] [transcription] 2026-04-13T08:09:07.991Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=65441DC3-1ABB-4E6A-AB83-D86A5D06BAD0
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' started.
+2026-04-13 04:09:07.992601-0400 BugNarrator[57197:2184710] [transcription] 2026-04-13T08:09:07.992Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=CD020A68-B448-433D-BC43-7FA6D58CB8BE
+2026-04-13 04:09:07.993691-0400 BugNarrator[57197:2184713] [transcription] 2026-04-13T08:09:07.993Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings. session_id=CD020A68-B448-433D-BC43-7FA6D58CB8BE
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' started.
+2026-04-13 04:09:07.995409-0400 BugNarrator[57197:2184664] [transcription] 2026-04-13T08:09:07.995Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=9890A835-39BA-492A-86E7-DB43014A7289
+2026-04-13 04:09:07.996555-0400 BugNarrator[57197:2184664] [transcription] 2026-04-13T08:09:07.996Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=9890A835-39BA-492A-86E7-DB43014A7289
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' started.
+2026-04-13 04:09:07.998315-0400 BugNarrator[57197:2184713] [transcription] 2026-04-13T08:09:07.998Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=507D519C-7E29-40AC-9876-33CA557E5BE0
+2026-04-13 04:09:08.275930-0400 BugNarrator[57197:2184713] [transcription] 2026-04-13T08:09:08.276Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: Issue extraction took longer than 0.3 seconds. Retry the extraction or choose a faster model in Settings. session_id=507D519C-7E29-40AC-9876-33CA557E5BE0
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' passed (0.283 seconds).
+Test Suite 'IssueExtractionServiceTests' passed at 2026-04-13 04:09:08.280.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.295 (0.297) seconds
+Test Suite 'JiraExportProviderTests' started at 2026-04-13 04:09:08.280.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' started.
+2026-04-13 04:09:08.281845-0400 BugNarrator[57197:2184664] [export] 2026-04-13T08:09:08.282Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=1 project_key=FM session_id=31986BF5-9205-4860-A46D-D22F72CAC696
+2026-04-13 04:09:08.311923-0400 BugNarrator[57197:2184687] [export] 2026-04-13T08:09:08.311Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=D85F6B7C-1062-4B46-8834-B01CD4B7BFD7 successful_count=0
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' passed (0.033 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 04:09:08.318296-0400 BugNarrator[57197:2184664] [export] 2026-04-13T08:09:08.318Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=2 project_key=FM session_id=FF22E748-811A-4237-BA3C-C4820F635891
+2026-04-13 04:09:08.320729-0400 BugNarrator[57197:2184687] [export] 2026-04-13T08:09:08.320Z [INFO] [export] jira_issue_exported - Exported one issue to Jira. remote_identifier=FM-101 source_issue_id=077F37B2-A202-4ACD-BF52-2DF9FC85E43D
+2026-04-13 04:09:08.322972-0400 BugNarrator[57197:2184710] [export] 2026-04-13T08:09:08.322Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=0B9C6ABD-86A2-4B34-B20A-5FDEBF854E69 successful_count=1
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.009 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' started.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' passed (0.002 seconds).
+Test Suite 'JiraExportProviderTests' passed at 2026-04-13 04:09:08.327.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.045 (0.047) seconds
+Test Suite 'ReviewWorkspaceTests' started at 2026-04-13 04:09:08.328.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testAvailableTabsIncludeSummaryOnlyWhenSessionHasSummaryContent]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testAvailableTabsIncludeSummaryOnlyWhenSessionHasSummaryContent]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testClampedTabFallsBackToSummaryWhenReviewSummaryIsAvailable]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testClampedTabFallsBackToSummaryWhenReviewSummaryIsAvailable]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testNormalizedOptionalReproductionStepTextTrimsPaddingAndDropsBlankValues]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testNormalizedOptionalReproductionStepTextTrimsPaddingAndDropsBlankValues]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testPendingTranscriptionSessionUsesRecoveryTimelineEntry]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testPendingTranscriptionSessionUsesRecoveryTimelineEntry]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testSelectedIssueSummaryCountsOnlySelectedIssues]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testSelectedIssueSummaryCountsOnlySelectedIssues]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesCombineScreenshotAndLinkedMarkerAtSameTimestamp]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesCombineScreenshotAndLinkedMarkerAtSameTimestamp]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesKeepLegacyMarkerWithoutScreenshot]' started.
+Test Case '-[BugNarratorTests.ReviewWorkspaceTests testTimelineEntriesKeepLegacyMarkerWithoutScreenshot]' passed (0.001 seconds).
+Test Suite 'ReviewWorkspaceTests' passed at 2026-04-13 04:09:08.334.
+	 Executed 7 tests, with 0 failures (0 unexpected) in 0.005 (0.007) seconds
+Test Suite 'TranscriptExporterTests' started at 2026-04-13 04:09:08.334.
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleCreatesExpectedFilesAndCopiesScreenshots]' started.
+2026-04-13 04:09:08.337304-0400 BugNarrator[57197:2184594] [export] 2026-04-13T08:09:08.337Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=1 missing_screenshot_count=0 screenshot_count=1 session_id=5E086353-468A-469B-9523-DFE83DB3F4D4
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleCreatesExpectedFilesAndCopiesScreenshots]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames]' started.
+2026-04-13 04:09:08.342193-0400 BugNarrator[57197:2184594] [export] 2026-04-13T08:09:08.342Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=2 missing_screenshot_count=0 screenshot_count=2 session_id=91BB50C9-99A9-4AAC-8BCC-3AAB86276567
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames]' passed (0.005 seconds).
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleSkipsMissingScreenshotFilesButStillCreatesScreenshotsDirectory]' started.
+2026-04-13 04:09:08.345851-0400 BugNarrator[57197:2184594] [export] 2026-04-13T08:09:08.346Z [INFO] [export] session_bundle_exported - Exported a local session bundle. copied_screenshot_count=0 missing_screenshot_count=1 screenshot_count=1 session_id=598176B4-CBE1-4967-AA51-E958067A450F
+Test Case '-[BugNarratorTests.TranscriptExporterTests testWriteBundleSkipsMissingScreenshotFilesButStillCreatesScreenshotsDirectory]' passed (0.003 seconds).
+Test Suite 'TranscriptExporterTests' passed at 2026-04-13 04:09:08.347.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.012 (0.013) seconds
+Test Suite 'BugNarratorTests.xctest' passed at 2026-04-13 04:09:08.347.
+	 Executed 21 tests, with 0 failures (0 unexpected) in 0.383 (0.392) seconds
+Test Suite 'Selected tests' passed at 2026-04-13 04:09:08.348.
+	 Executed 21 tests, with 0 failures (0 unexpected) in 0.383 (0.392) seconds
+2026-04-13 04:09:08.627 xcodebuild[57025:2183900] [MT] IDETestOperationsObserverDebug: 2.782 elapsed -- Testing started completed.
+2026-04-13 04:09:08.627 xcodebuild[57025:2183900] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2026-04-13 04:09:08.627 xcodebuild[57025:2183900] [MT] IDETestOperationsObserverDebug: 2.782 sec, +2.782 sec -- end
+
+Test session results, code coverage, and logs:
+	/tmp/bugnarrator-n3-tests/Logs/Test/Test-BugNarrator-2026.04.13_04-09-00--0400.xcresult
+
+** TEST SUCCEEDED **
+
+Testing started

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-04-13T08:00:00Z",
-  "code_changes_present": false,
+  "last_updated": "2026-04-13T08:08:10Z",
+  "code_changes_present": true,
   "claims": {
     "implementation": "complete",
     "validation": "complete",
@@ -9,16 +9,21 @@
   "external_inputs": [],
   "evidence": {
     "build": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T08:00:00Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T08:08:10Z",
+      "reason": "Targeted macOS xcodebuild test run compiled the N3 classification slice successfully.",
+      "paths": [
+        "artifacts/n3-issue-classification/xcodebuild-test.log"
+      ]
     },
     "test": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T08:00:00Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T08:08:10Z",
+      "reason": "Runtime guardrails and targeted extraction/export/review tests passed for N3.",
+      "paths": [
+        "artifacts/n3-issue-classification/validate.log",
+        "artifacts/n3-issue-classification/xcodebuild-test.log"
+      ]
     },
     "run": {
       "status": "not_run",

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,4 +1,4 @@
 # Controller State
 
-current_state: ready_for_codex
+current_state: ready_for_review
 current_task: N3

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -3,12 +3,13 @@
 task_id: N3
 description: Enhanced issue classification — severity, component, deduplication hint
 scope: Sources/BugNarrator/
-status: pending
+current_state: ready_for_review
+status: done
 execution_status: idle
-execution_branch: codex/N3-enhanced-issue-classification
-execution_started_at: 2026-04-13T08:02:53Z
-execution_heartbeat_at: 2026-04-13T08:02:53Z
-execution_lease_expires_at: 2026-04-13T09:32:53Z
+execution_branch:
+execution_started_at:
+execution_heartbeat_at:
+execution_lease_expires_at:
 execution_host_id:
 execution_worker_id:
 review_failure_count: 0

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -5,10 +5,10 @@ description: Enhanced issue classification — severity, component, deduplicatio
 scope: Sources/BugNarrator/
 status: pending
 execution_status: idle
-execution_branch:
-execution_started_at:
-execution_heartbeat_at:
-execution_lease_expires_at:
+execution_branch: codex/N3-enhanced-issue-classification
+execution_started_at: 2026-04-13T08:02:53Z
+execution_heartbeat_at: 2026-04-13T08:02:53Z
+execution_lease_expires_at: 2026-04-13T09:32:53Z
 execution_host_id:
 execution_worker_id:
 review_failure_count: 0

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,10 +1,11 @@
 # Implementation Notes
 
-task_id: N2
+task_id: N3
 status: ready_for_review
 
 CHANGED:
 - Sources/BugNarrator/Models/ExtractedIssue.swift
+- Sources/BugNarrator/Models/TranscriptSession.swift
 - Sources/BugNarrator/Services/GitHubExportProvider.swift
 - Sources/BugNarrator/Services/IssueExtractionService.swift
 - Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -14,16 +15,15 @@ CHANGED:
 - Tests/BugNarratorTests/JiraExportProviderTests.swift
 
 DID:
-- Added structured reproduction-step data to extracted issues, with per-step instruction, expected result, actual result, timestamp, and screenshot reference persistence.
-- Extended the issue-extraction prompt/parser so OpenAI returns reproduction steps tied to narration timecodes and screenshot file names, with issue-level reference fallback when a step omits one.
-- Rendered reproduction steps in the review workspace with editable action, expected, and actual fields plus visible timestamp and screenshot references.
-- Included reproduction steps and step references in both GitHub and Jira export payloads so the generated issue tracker tickets carry the same reviewable repro details.
-- Normalized optional reproduction-step edits so expected and actual text is trimmed before persistence, preventing accidental whitespace from leaking into exports.
+- Added severity, suggested component, and stable deduplication-hint fields to extracted issues, with persistence defaults for older saved sessions.
+- Extended issue extraction so OpenAI can return severity/component metadata, while local fallbacks infer severity from narration content, reuse section titles as component context, and generate deduplication hashes when hints are missing.
+- Rendered editable severity, component, and deduplication fields in the review workspace alongside the existing issue editor.
+- Included the new classification metadata in review markdown plus GitHub and Jira export payloads.
+- Added targeted tests that cover structured parsing, fallback inference, and export formatting for the new classification metadata.
 
 VALIDATED:
 - ./scripts/validate.sh
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -only-testing:BugNarratorTests/ReviewWorkspaceTests test
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/TranscriptExporterTests -only-testing:BugNarratorTests/ReviewWorkspaceTests
 
 NEXT:
-- Confirm the PR review thread about reproduction-step whitespace is resolved by the pushed branch update.
+- Ready for PR review on the N3 issue-classification slice.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-13T08:00:00Z",
+  "last_updated": "2026-04-13T08:08:10Z",
   "tasks": [
     {
       "id": "N1",
@@ -15,8 +15,9 @@
     },
     {
       "id": "N3",
-      "status": "pending",
-      "title": "Enhanced issue classification — severity, component, deduplication hint"
+      "status": "done",
+      "title": "Enhanced issue classification — severity, component, deduplication hint",
+      "completed_at": "2026-04-13T08:08:10Z"
     }
   ]
 }

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,13 +1,13 @@
 # Validation Report
 
-task_id: N2
+task_id: N3
 result: passed
-summary: Runtime guardrails and the targeted BugNarrator extraction/export macOS tests passed for the N2 reproduction-step slice.
+summary: Runtime guardrails plus the targeted BugNarrator extraction/export/review macOS tests passed for the N3 issue-classification slice.
 
 artifacts:
-- artifacts/n2-reproduction-steps/validate.log
-- artifacts/n2-reproduction-steps/xcodebuild-test.log
+- artifacts/n3-issue-classification/validate.log
+- artifacts/n3-issue-classification/xcodebuild-test.log
 
 commands:
 - ./scripts/validate.sh -> PASS
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n2-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -> PASS
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/TranscriptExporterTests -only-testing:BugNarratorTests/ReviewWorkspaceTests -> PASS


### PR DESCRIPTION
## Summary
- add severity, component, and deduplication hint metadata to extracted issues
- expose editable classification fields in the review workspace and include them in markdown/export payloads
- cover parsing, fallback inference, and export formatting with targeted tests

## Validation
- ./scripts/validate.sh
- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/TranscriptExporterTests -only-testing:BugNarratorTests/ReviewWorkspaceTests