### PR TITLE
N3-H1: Deduplication hash locale stability and extraction inference optimization

### DIFF
--- a/Sources/BugNarrator/Models/ExtractedIssue.swift
+++ b/Sources/BugNarrator/Models/ExtractedIssue.swift
@@ -52,6 +52,8 @@ struct IssueReproductionStep: Identifiable, Codable, Equatable {
 }
 
 struct ExtractedIssue: Identifiable, Codable, Equatable {
+    private static let deduplicationNormalizationLocale = Locale(identifier: "en_US_POSIX")
+
     let id: UUID
     var title: String
     var category: ExtractedIssueCategory
@@ -197,8 +199,8 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
             evidenceExcerpt
         ]
         .joined(separator: "\n")
-        .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
-        .lowercased()
+        .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: deduplicationNormalizationLocale)
+        .lowercased(with: deduplicationNormalizationLocale)
         .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
         .trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -460,6 +460,45 @@ private struct IssueExtractionPayload {
 }
 
 private struct IssuePayload {
+    private static let criticalSeveritySignals = [
+        "crash",
+        "crashes",
+        "data loss",
+        "completely broken",
+        "blocked",
+        "blocker",
+        "cannot continue",
+        "can't continue",
+        "unable to continue",
+        "won't open",
+        "blank screen"
+    ]
+
+    private static let lowSeveritySignals = [
+        "minor",
+        "small",
+        "cosmetic",
+        "visual glitch",
+        "visual issue",
+        "spacing",
+        "alignment",
+        "typo",
+        "copy issue"
+    ]
+
+    private static let highSeveritySignals = [
+        "broken",
+        "doesn't work",
+        "does not work",
+        "not respond",
+        "fails",
+        "failure",
+        "unable to",
+        "cannot",
+        "can't",
+        "stuck"
+    ]
+
     let title: String
     let category: String
     let severity: String?
@@ -680,51 +719,15 @@ private struct IssuePayload {
         .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
         .lowercased()
 
-        let criticalSignals = [
-            "crash",
-            "crashes",
-            "data loss",
-            "completely broken",
-            "blocked",
-            "blocker",
-            "cannot continue",
-            "can't continue",
-            "unable to continue",
-            "won't open",
-            "blank screen"
-        ]
-        if criticalSignals.contains(where: combinedText.contains) {
+        if Self.criticalSeveritySignals.contains(where: combinedText.contains) {
             return .critical
         }
 
-        let lowSignals = [
-            "minor",
-            "small",
-            "cosmetic",
-            "visual glitch",
-            "visual issue",
-            "spacing",
-            "alignment",
-            "typo",
-            "copy issue"
-        ]
-        if lowSignals.contains(where: combinedText.contains) {
+        if Self.lowSeveritySignals.contains(where: combinedText.contains) {
             return .low
         }
 
-        let highSignals = [
-            "broken",
-            "doesn't work",
-            "does not work",
-            "not respond",
-            "fails",
-            "failure",
-            "unable to",
-            "cannot",
-            "can't",
-            "stuck"
-        ]
-        if highSignals.contains(where: combinedText.contains) {
+        if Self.highSeveritySignals.contains(where: combinedText.contains) {
             return .high
         }
 

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -167,6 +167,34 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertTrue(result.issues.first?.deduplicationHint.hasPrefix("issue-") == true)
     }
 
+    func testDeduplicationHintUsesFixedLocaleNormalization() {
+        let title = "ISTANBUL ISSUE"
+        let summary = "I expected the icon to stay visible."
+        let evidenceExcerpt = "The icon disappears immediately."
+
+        let hint = ExtractedIssue.makeDeduplicationHint(
+            title: title,
+            summary: summary,
+            evidenceExcerpt: evidenceExcerpt
+        )
+
+        let posixHash = makeExpectedDeduplicationHint(
+            title: title,
+            summary: summary,
+            evidenceExcerpt: evidenceExcerpt,
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+        let turkishHash = makeExpectedDeduplicationHint(
+            title: title,
+            summary: summary,
+            evidenceExcerpt: evidenceExcerpt,
+            locale: Locale(identifier: "tr_TR")
+        )
+
+        XCTAssertEqual(hint, posixHash)
+        XCTAssertNotEqual(posixHash, turkishHash)
+    }
+
     func testExtractIssuesReturnsClearErrorForMalformedStructuredPayload() async throws {
         let session = makeReviewSession()
         let malformedContent = """
@@ -262,5 +290,33 @@ final class IssueExtractionServiceTests: XCTestCase {
                 ]
             ]
         )
+    }
+
+    private func makeExpectedDeduplicationHint(
+        title: String,
+        summary: String,
+        evidenceExcerpt: String,
+        locale: Locale
+    ) -> String {
+        let normalized = [
+            title,
+            summary,
+            evidenceExcerpt
+        ]
+        .joined(separator: "\n")
+        .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: locale)
+        .lowercased(with: locale)
+        .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        let prime: UInt64 = 1_099_511_628_211
+
+        for byte in normalized.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+
+        return String(format: "issue-%016llx", hash)
     }
 }

--- a/artifacts/n3-h1-hardening/validate.log
+++ b/artifacts/n3-h1-hardening/validate.log
@@ -1,0 +1,5 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 3 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Config loaded from ai.config.json

--- a/artifacts/n3-h1-hardening/xcodebuild-test.log
+++ b/artifacts/n3-h1-hardening/xcodebuild-test.log
@@ -1,0 +1,111 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test "-only-testing:BugNarratorTests/IssueExtractionServiceTests" "-only-testing:BugNarratorTests/GitHubExportProviderTests" "-only-testing:BugNarratorTests/JiraExportProviderTests"
+
+Build settings from command line:
+    CODE_SIGNING_ALLOWED = NO
+
+2026-04-13 05:06:39.754 xcodebuild[85624:2306293] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, arch:x86_64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, name:Any Mac }
+ComputePackagePrebuildTargetDependencyGraph
+
+Prepare packages
+
+CreateBuildRequest
+
+SendProjectDescription
+
+CreateBuildOperation
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'BugNarratorTests' in project 'BugNarrator'
+        ➜ Explicit dependency on target 'BugNarrator' in project 'BugNarrator'
+    Target 'BugNarrator' in project 'BugNarrator' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /tmp/bugnarrator-n3h1-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+    cd /Users/deffenda/Code/bug-narrator/BugNarrator.xcodeproj
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /tmp/bugnarrator-n3h1-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+2026-04-13 05:06:40.915148-0400 BugNarrator[85680:2306525] [settings] 2026-04-13T09:06:40.914Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-13 05:06:40.915758-0400 BugNarrator[85680:2306525] [session-library] 2026-04-13T09:06:40.916Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-13 05:06:40.920213-0400 BugNarrator[85680:2306525] [settings] 2026-04-13T09:06:40.920Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-13 05:06:40.931270-0400 BugNarrator[85680:2306525] [permissions] 2026-04-13T09:06:40.931Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/private/tmp/bugnarrator-n3h1-tests/Build/Products/Debug/BugNarrator.app is_local_testing_build=no microphone_status=notDetermined screen_capture_status=notDetermined
+2026-04-13 05:06:40.931535-0400 BugNarrator[85680:2306525] [session-library] 2026-04-13T09:06:40.931Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Suite 'Selected tests' started at 2026-04-13 05:06:41.109.
+Test Suite 'BugNarratorTests.xctest' started at 2026-04-13 05:06:41.109.
+Test Suite 'GitHubExportProviderTests' started at 2026-04-13 05:06:41.110.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' started.
+2026-04-13 05:06:41.111447-0400 BugNarrator[85680:2306542] [export] 2026-04-13T09:06:41.111Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=1 repository=acme/bugnarrator session_id=6E5F3F89-65AD-4259-B60F-F3FBCBDA8FEF
+2026-04-13 05:06:41.114557-0400 BugNarrator[85680:2306561] [export] 2026-04-13T09:06:41.114Z [ERROR] [export] github_export_failed - Export failed: GitHub could not find acme/bugnarrator. Check the owner, repository name, and token permissions. source_issue_id=8FF307A1-5CDF-409E-A91E-7D181D4AA528 successful_count=0
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' passed (0.014 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 05:06:41.124833-0400 BugNarrator[85680:2306542] [export] 2026-04-13T09:06:41.125Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=2 repository=acme/bugnarrator session_id=A56D3562-9343-437C-B0A5-48AF574F840D
+2026-04-13 05:06:41.125805-0400 BugNarrator[85680:2306535] [export] 2026-04-13T09:06:41.126Z [INFO] [export] github_issue_exported - Exported one issue to GitHub. remote_identifier=#101 source_issue_id=2FDE282C-11D7-4EBA-8E7C-AF9273FF9449
+2026-04-13 05:06:41.126518-0400 BugNarrator[85680:2306542] [export] 2026-04-13T09:06:41.126Z [ERROR] [export] github_export_failed - Export failed: GitHub rejected the issue payload: Validation Failed source_issue_id=D48ADC3C-B99B-4C21-B8EC-FB178615987B successful_count=1
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' started.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' passed (0.002 seconds).
+Test Suite 'GitHubExportProviderTests' passed at 2026-04-13 05:06:41.129.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.018 (0.020) seconds
+Test Suite 'IssueExtractionServiceTests' started at 2026-04-13 05:06:41.129.
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testDeduplicationHintUsesFixedLocaleNormalization]' started.
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testDeduplicationHintUsesFixedLocaleNormalization]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing]' started.
+2026-04-13 05:06:41.131440-0400 BugNarrator[85680:2306536] [transcription] 2026-04-13T09:06:41.131Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=6E647D74-D143-441D-9980-3EC5089A94E0
+2026-04-13 05:06:41.133969-0400 BugNarrator[85680:2306535] [transcription] 2026-04-13T09:06:41.134Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=6E647D74-D143-441D-9980-3EC5089A94E0
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing]' passed (0.004 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' started.
+2026-04-13 05:06:41.135575-0400 BugNarrator[85680:2306535] [transcription] 2026-04-13T09:06:41.135Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=B6F6C3C9-F71B-438D-8EC6-E204C6C20620
+2026-04-13 05:06:41.136823-0400 BugNarrator[85680:2306535] [transcription] 2026-04-13T09:06:41.137Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=B6F6C3C9-F71B-438D-8EC6-E204C6C20620
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' started.
+2026-04-13 05:06:41.138249-0400 BugNarrator[85680:2306535] [transcription] 2026-04-13T09:06:41.138Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=53C0A06A-C220-4181-9E7A-9439AF2B6B5A
+2026-04-13 05:06:41.139155-0400 BugNarrator[85680:2306542] [transcription] 2026-04-13T09:06:41.139Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings. session_id=53C0A06A-C220-4181-9E7A-9439AF2B6B5A
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsClearErrorForMalformedStructuredPayload]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' started.
+2026-04-13 05:06:41.140524-0400 BugNarrator[85680:2306535] [transcription] 2026-04-13T09:06:41.140Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=DE6ADF47-3897-4565-A137-7CECD10E8B88
+2026-04-13 05:06:41.141298-0400 BugNarrator[85680:2306542] [transcription] 2026-04-13T09:06:41.141Z [INFO] [transcription] issue_extraction_request_succeeded - OpenAI returned extracted review issues. issue_count=1 session_id=DE6ADF47-3897-4565-A137-7CECD10E8B88
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesReturnsStructuredDraftIssues]' passed (0.002 seconds).
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' started.
+2026-04-13 05:06:41.142761-0400 BugNarrator[85680:2306542] [transcription] 2026-04-13T09:06:41.143Z [INFO] [transcription] issue_extraction_request_started - Sending the transcript to OpenAI for issue extraction. marker_count=1 model=gpt-4.1-mini screenshot_count=1 session_id=B5217976-750A-4102-9C8E-041B71AC010F
+2026-04-13 05:06:41.403307-0400 BugNarrator[85680:2306542] [transcription] 2026-04-13T09:06:41.403Z [ERROR] [transcription] issue_extraction_request_failed - Issue extraction failed: Issue extraction took longer than 0.3 seconds. Retry the extraction or choose a faster model in Settings. session_id=B5217976-750A-4102-9C8E-041B71AC010F
+Test Case '-[BugNarratorTests.IssueExtractionServiceTests testExtractIssuesTimesOutAfterConfiguredBudget]' passed (0.263 seconds).
+Test Suite 'IssueExtractionServiceTests' passed at 2026-04-13 05:06:41.405.
+	 Executed 6 tests, with 0 failures (0 unexpected) in 0.274 (0.276) seconds
+Test Suite 'JiraExportProviderTests' started at 2026-04-13 05:06:41.405.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' started.
+2026-04-13 05:06:41.408662-0400 BugNarrator[85680:2306561] [export] 2026-04-13T09:06:41.408Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=1 project_key=FM session_id=571CB0F6-9803-48BE-833D-0B1B83C38763
+2026-04-13 05:06:41.452246-0400 BugNarrator[85680:2306535] [export] 2026-04-13T09:06:41.451Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=09E9BBEE-05BB-476C-9E69-50A827F8D079 successful_count=0
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' passed (0.048 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 05:06:41.457970-0400 BugNarrator[85680:2306542] [export] 2026-04-13T09:06:41.457Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=2 project_key=FM session_id=F6E72755-0C6E-4860-A7DF-A0E7A0CFBB6A
+2026-04-13 05:06:41.460664-0400 BugNarrator[85680:2306561] [export] 2026-04-13T09:06:41.460Z [INFO] [export] jira_issue_exported - Exported one issue to Jira. remote_identifier=FM-101 source_issue_id=80930C08-1C20-425D-9C97-961D7D5FBA46
+2026-04-13 05:06:41.462777-0400 BugNarrator[85680:2306561] [export] 2026-04-13T09:06:41.462Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=4D7D1065-2CB8-41D6-8AB7-4B4758AA2278 successful_count=1
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.010 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' started.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' passed (0.002 seconds).
+Test Suite 'JiraExportProviderTests' passed at 2026-04-13 05:06:41.467.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.060 (0.061) seconds
+Test Suite 'BugNarratorTests.xctest' passed at 2026-04-13 05:06:41.467.
+	 Executed 12 tests, with 0 failures (0 unexpected) in 0.352 (0.358) seconds
+Test Suite 'Selected tests' passed at 2026-04-13 05:06:41.467.
+	 Executed 12 tests, with 0 failures (0 unexpected) in 0.352 (0.358) seconds
+2026-04-13 05:06:41.748 xcodebuild[85624:2306293] [MT] IDETestOperationsObserverDebug: 1.332 elapsed -- Testing started completed.
+2026-04-13 05:06:41.748 xcodebuild[85624:2306293] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2026-04-13 05:06:41.748 xcodebuild[85624:2306293] [MT] IDETestOperationsObserverDebug: 1.332 sec, +1.332 sec -- end
+
+Test session results, code coverage, and logs:
+	/tmp/bugnarrator-n3h1-tests/Logs/Test/Test-BugNarrator-2026.04.13_05-06-39--0400.xcresult
+
+** TEST SUCCEEDED **
+
+Testing started

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,24 +1,29 @@
 {
-  "last_updated": "2026-04-13T09:00:00Z",
-  "code_changes_present": false,
+  "last_updated": "2026-04-13T09:07:09Z",
+  "code_changes_present": true,
   "claims": {
-    "implementation": "not_started",
-    "validation": "not_started",
+    "implementation": "complete",
+    "validation": "complete",
     "deployment": "not_started"
   },
   "external_inputs": [],
   "evidence": {
     "build": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T09:00:00Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T09:07:09Z",
+      "reason": "Targeted xcodebuild validation completed for N3-H1.",
+      "paths": [
+        "artifacts/n3-h1-hardening/xcodebuild-test.log"
+      ]
     },
     "test": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T09:00:00Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T09:07:09Z",
+      "reason": "Runtime guardrails and targeted extraction/export tests passed for N3-H1.",
+      "paths": [
+        "artifacts/n3-h1-hardening/validate.log",
+        "artifacts/n3-h1-hardening/xcodebuild-test.log"
+      ]
     },
     "run": {
       "status": "not_run",

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,4 +1,4 @@
 # Controller State
 
-current_state: ready_for_codex
+current_state: ready_for_review
 current_task: N3-H1

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -5,13 +5,13 @@ description: Deduplication hash locale stability and extraction inference optimi
 scope: Sources/BugNarrator/Services/IssueExtractionService.swift, Sources/BugNarrator/Models/ExtractedIssue.swift
 status: pending
 current_state: ready_for_codex
-execution_status: idle
-execution_branch:
-execution_started_at:
-execution_heartbeat_at:
-execution_lease_expires_at:
-execution_host_id:
-execution_worker_id:
+execution_status: in_progress
+execution_branch: codex/N3-H1-dedup-hash-luntime
+execution_started_at: 2026-04-13T09:02:40Z
+execution_heartbeat_at: 2026-04-13T09:02:40Z
+execution_lease_expires_at: 2026-04-13T10:32:40Z
+execution_host_id: ABD-Mac-Studio
+execution_worker_id: codex-bug-narrator
 review_failure_count: 0
 depends_on: N3 (done, merged to main)
 acceptance_criteria_reference: /ai/acceptance.md#N3-H1

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -3,15 +3,15 @@
 task_id: N3-H1
 description: Deduplication hash locale stability and extraction inference optimization
 scope: Sources/BugNarrator/Services/IssueExtractionService.swift, Sources/BugNarrator/Models/ExtractedIssue.swift
-status: pending
-current_state: ready_for_codex
-execution_status: in_progress
-execution_branch: codex/N3-H1-dedup-hash-luntime
-execution_started_at: 2026-04-13T09:02:40Z
-execution_heartbeat_at: 2026-04-13T09:02:40Z
-execution_lease_expires_at: 2026-04-13T10:32:40Z
-execution_host_id: ABD-Mac-Studio
-execution_worker_id: codex-bug-narrator
+status: done
+current_state: ready_for_review
+execution_status: idle
+execution_branch:
+execution_started_at:
+execution_heartbeat_at:
+execution_lease_expires_at:
+execution_host_id:
+execution_worker_id:
 review_failure_count: 0
 depends_on: N3 (done, merged to main)
 acceptance_criteria_reference: /ai/acceptance.md#N3-H1

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,29 +1,29 @@
 # Implementation Notes
 
-task_id: N3
+task_id: N3-H1
 status: ready_for_review
+
+completed_task_ids:
+- N3-H1
 
 CHANGED:
 - Sources/BugNarrator/Models/ExtractedIssue.swift
-- Sources/BugNarrator/Models/TranscriptSession.swift
-- Sources/BugNarrator/Services/GitHubExportProvider.swift
 - Sources/BugNarrator/Services/IssueExtractionService.swift
-- Sources/BugNarrator/Services/JiraExportProvider.swift
-- Sources/BugNarrator/Views/TranscriptView.swift
-- Tests/BugNarratorTests/GitHubExportProviderTests.swift
 - Tests/BugNarratorTests/IssueExtractionServiceTests.swift
-- Tests/BugNarratorTests/JiraExportProviderTests.swift
+- state/artifacts.json
+- state/controller.md
+- state/current_task.md
+- state/tasks.json
+- state/validation_report.md
 
 DID:
-- Added severity, suggested component, and stable deduplication-hint fields to extracted issues, with persistence defaults for older saved sessions.
-- Extended issue extraction so OpenAI can return severity/component metadata, while local fallbacks infer severity from narration content, reuse section titles as component context, and generate deduplication hashes when hints are missing.
-- Rendered editable severity, component, and deduplication fields in the review workspace alongside the existing issue editor.
-- Included the new classification metadata in review markdown plus GitHub and Jira export payloads.
-- Added targeted tests that cover structured parsing, fallback inference, and export formatting for the new classification metadata.
+- Pinned deduplication-hint normalization to `en_US_POSIX` so identical issue text hashes consistently across machines and user locales.
+- Moved the severity keyword lists in `IssueExtractionService` to static constants so extraction inference reuses them instead of allocating on every parse.
+- Added a regression test that exercises locale-sensitive casing and verifies the deduplication hash matches fixed-locale normalization.
 
 VALIDATED:
 - ./scripts/validate.sh
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/TranscriptExporterTests -only-testing:BugNarratorTests/ReviewWorkspaceTests
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
 
 NEXT:
-- Ready for PR review on the N3 issue-classification slice.
+- Ready for PR review on the N3-H1 hardening slice.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-13T09:00:00Z",
+  "last_updated": "2026-04-13T09:07:09Z",
   "tasks": [
     {
       "id": "N1",
@@ -21,8 +21,9 @@
     },
     {
       "id": "N3-H1",
-      "status": "pending",
-      "title": "Deduplication hash locale stability and extraction inference optimization"
+      "status": "done",
+      "title": "Deduplication hash locale stability and extraction inference optimization",
+      "completed_at": "2026-04-13T09:07:09Z"
     }
   ]
 }

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,13 +1,13 @@
 # Validation Report
 
-task_id: N3
+task_id: N3-H1
 result: passed
-summary: Runtime guardrails plus the targeted BugNarrator extraction/export/review macOS tests passed for the N3 issue-classification slice.
+summary: Runtime guardrails plus the targeted BugNarrator extraction/export macOS tests passed for the N3-H1 locale-stability and inference-optimization slice.
 
 artifacts:
-- artifacts/n3-issue-classification/validate.log
-- artifacts/n3-issue-classification/xcodebuild-test.log
+- artifacts/n3-h1-hardening/validate.log
+- artifacts/n3-h1-hardening/xcodebuild-test.log
 
 commands:
 - ./scripts/validate.sh -> PASS
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/TranscriptExporterTests -only-testing:BugNarratorTests/ReviewWorkspaceTests -> PASS
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -> PASS


### PR DESCRIPTION
## Summary
- pin deduplication-hint normalization to `en_US_POSIX` so hashes stay stable across user locales
- move severity keyword arrays in `IssueExtractionService` to static constants reused across inference calls
- add a regression test for locale-sensitive dedup normalization and attach branch-local validation evidence

## Validation
- `./scripts/validate.sh`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests`
