### PR TITLE
N4: Smart screenshot annotation — auto-highlight relevant UI elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Codex acquires a 90-minute lease before starting work:
 
 ## Before setting ready_for_review
 
+0. Rebase branch onto current main: `git fetch origin main && git rebase origin/main` — prevents DIRTY PR state.
 1. All repo-local validation must pass (see `ai/bootstrap.md` for the exact commands)
 2. `node tools/validators/enforce-runtime-guardrails.js --repo . --config ai.config.json` must pass
 3. `state/artifacts.json` must reflect actual evidence (real file paths, correct statuses)

--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		280973289AE78D9919ECD80C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5346EDB503C6B05C81C368 /* KeychainService.swift */; };
+		28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */; };
 		29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09CA463A8DF59221937A2C7 /* TranscriptView.swift */; };
 		2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */; };
 		2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */; };
@@ -60,6 +61,7 @@
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
 		821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */; };
+		82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */; };
 		8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */; };
 		8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */; };
 		88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */; };
@@ -75,6 +77,7 @@
 		9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EFF170BAD57E66A7CB20AB /* AppState.swift */; };
 		A514C06B61A203200CF118A1 /* AppBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */; };
 		A6AF1CAA204EF971F9417E63 /* TranscriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */; };
+		A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */; };
 		B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */; };
 		B3F726638452CBD7F5A4DC16 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */; };
 		B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A663ED1B160E290FCFAC3AED /* ClipboardService.swift */; };
@@ -151,6 +154,7 @@
 		67770387C5BA986EEB40382E /* SessionLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryTests.swift; sourceTree = "<group>"; };
 		6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSession.swift; sourceTree = "<group>"; };
 		6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
+		6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueScreenshotAnnotationRenderer.swift; sourceTree = "<group>"; };
 		6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcut.swift; sourceTree = "<group>"; };
 		6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoTests.swift; sourceTree = "<group>"; };
 		6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 		84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionServiceTests.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotAnnotationTests.swift; sourceTree = "<group>"; };
 		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
 		9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
 		9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsService.swift; sourceTree = "<group>"; };
@@ -189,6 +194,7 @@
 		CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibrary.swift; sourceTree = "<group>"; };
 		CCCB5C9DAEB3066CA8E30234 /* SingleInstanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceController.swift; sourceTree = "<group>"; };
 		D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorLinks.swift; sourceTree = "<group>"; };
+		DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueScreenshotAnnotationPreview.swift; sourceTree = "<group>"; };
 		DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProviderTests.swift; sourceTree = "<group>"; };
 		DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorApp.swift; sourceTree = "<group>"; };
 		E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -232,6 +238,7 @@
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
+				8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */,
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
 				20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
@@ -293,6 +300,7 @@
 				59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */,
 				5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */,
 				4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */,
+				DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */,
 				820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */,
 				865C5FE84904ECA5F4379637 /* MenuBarView.swift */,
 				0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */,
@@ -345,6 +353,7 @@
 				C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */,
 				33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */,
 				4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */,
+				6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */,
 				9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */,
 				17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */,
 				60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */,
@@ -488,6 +497,7 @@
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
+				28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */,
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
 				6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
@@ -532,6 +542,8 @@
 				3CDB0E66F370246528266E51 /* HotkeyRecorderView.swift in Sources */,
 				8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
+				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,
+				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
 				099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */,

--- a/Sources/BugNarrator/Models/ExtractedIssue.swift
+++ b/Sources/BugNarrator/Models/ExtractedIssue.swift
@@ -51,6 +51,101 @@ struct IssueReproductionStep: Identifiable, Codable, Equatable {
     }
 }
 
+struct IssueScreenshotAnnotation: Identifiable, Codable, Equatable {
+    enum Style: String, Codable {
+        case highlight
+    }
+
+    let id: UUID
+    var screenshotID: UUID
+    var label: String?
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+    var confidence: Double?
+    var style: Style
+
+    init(
+        id: UUID = UUID(),
+        screenshotID: UUID,
+        label: String? = nil,
+        x: Double,
+        y: Double,
+        width: Double,
+        height: Double,
+        confidence: Double? = nil,
+        style: Style = .highlight
+    ) {
+        self.id = id
+        self.screenshotID = screenshotID
+        self.label = label?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        self.x = min(max(x, 0), 1)
+        self.y = min(max(y, 0), 1)
+        self.width = min(max(width, 0.05), 1)
+        self.height = min(max(height, 0.05), 1)
+        self.confidence = confidence
+        self.style = style
+
+        clampRectIntoBounds()
+    }
+
+    var normalizedRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    var confidenceLabel: String? {
+        guard let confidence else {
+            return nil
+        }
+
+        return "\(Int((confidence * 100).rounded()))%"
+    }
+
+    var exportDescription: String {
+        let normalized = normalizedRect
+        let xPercent = Int((normalized.minX * 100).rounded())
+        let yPercent = Int((normalized.minY * 100).rounded())
+        let widthPercent = Int((normalized.width * 100).rounded())
+        let heightPercent = Int((normalized.height * 100).rounded())
+
+        var parts = [
+            label ?? "UI highlight",
+            "x \(xPercent)%",
+            "y \(yPercent)%",
+            "w \(widthPercent)%",
+            "h \(heightPercent)%"
+        ]
+
+        if let confidenceLabel {
+            parts.append("confidence \(confidenceLabel)")
+        }
+
+        return parts.joined(separator: " • ")
+    }
+
+    mutating func move(x deltaX: Double, y deltaY: Double) {
+        x += deltaX
+        y += deltaY
+        clampRectIntoBounds()
+    }
+
+    mutating func updateRect(_ rect: CGRect) {
+        x = min(max(rect.origin.x, 0), 1)
+        y = min(max(rect.origin.y, 0), 1)
+        width = min(max(rect.width, 0.05), 1)
+        height = min(max(rect.height, 0.05), 1)
+        clampRectIntoBounds()
+    }
+
+    private mutating func clampRectIntoBounds() {
+        width = min(max(width, 0.05), 1)
+        height = min(max(height, 0.05), 1)
+        x = min(max(x, 0), max(0, 1 - width))
+        y = min(max(y, 0), max(0, 1 - height))
+    }
+}
+
 struct ExtractedIssue: Identifiable, Codable, Equatable {
     private static let deduplicationNormalizationLocale = Locale(identifier: "en_US_POSIX")
 
@@ -69,6 +164,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
     var isSelectedForExport: Bool
     var sectionTitle: String?
     var reproductionSteps: [IssueReproductionStep]
+    var screenshotAnnotations: [IssueScreenshotAnnotation]
     var note: String?
 
     init(
@@ -87,6 +183,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         isSelectedForExport: Bool = true,
         sectionTitle: String? = nil,
         reproductionSteps: [IssueReproductionStep] = [],
+        screenshotAnnotations: [IssueScreenshotAnnotation] = [],
         note: String? = nil
     ) {
         self.id = id
@@ -109,6 +206,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         self.isSelectedForExport = isSelectedForExport
         self.sectionTitle = sectionTitle
         self.reproductionSteps = reproductionSteps
+        self.screenshotAnnotations = screenshotAnnotations
         self.note = note
     }
 
@@ -134,6 +232,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         isSelectedForExport = try container.decodeIfPresent(Bool.self, forKey: .isSelectedForExport) ?? true
         sectionTitle = try container.decodeIfPresent(String.self, forKey: .sectionTitle)
         reproductionSteps = try container.decodeIfPresent([IssueReproductionStep].self, forKey: .reproductionSteps) ?? []
+        screenshotAnnotations = try container.decodeIfPresent([IssueScreenshotAnnotation].self, forKey: .screenshotAnnotations) ?? []
         note = try container.decodeIfPresent(String.self, forKey: .note)
     }
 
@@ -154,6 +253,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         try container.encode(isSelectedForExport, forKey: .isSelectedForExport)
         try container.encodeIfPresent(sectionTitle, forKey: .sectionTitle)
         try container.encode(reproductionSteps, forKey: .reproductionSteps)
+        try container.encode(screenshotAnnotations, forKey: .screenshotAnnotations)
         try container.encodeIfPresent(note, forKey: .note)
     }
 
@@ -173,6 +273,7 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         case isSelectedForExport
         case sectionTitle
         case reproductionSteps
+        case screenshotAnnotations
         case note
     }
 
@@ -190,6 +291,10 @@ struct ExtractedIssue: Identifiable, Codable, Equatable {
         }
 
         return "\(Int((confidence * 100).rounded()))%"
+    }
+
+    func screenshotAnnotations(for screenshotID: UUID) -> [IssueScreenshotAnnotation] {
+        screenshotAnnotations.filter { $0.screenshotID == screenshotID }
     }
 
     static func makeDeduplicationHint(title: String, summary: String, evidenceExcerpt: String) -> String {

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 actor GitHubExportProvider {
     private let session: URLSession
     private let logger = DiagnosticsLogger(category: .export)
+    private let annotationRenderer = IssueScreenshotAnnotationRenderer()
 
     init(session: URLSession? = nil) {
         if let session {
@@ -113,14 +114,14 @@ actor GitHubExportProvider {
         request.httpBody = try JSONEncoder().encode(
             GitHubIssueRequest(
                 title: issue.title,
-                body: makeIssueBody(issue: issue, session: reviewSession),
+                body: try makeIssueBody(issue: issue, session: reviewSession),
                 labels: configuration.labels.isEmpty ? nil : configuration.labels
             )
         )
         return request
     }
 
-    private func makeIssueBody(issue: ExtractedIssue, session: TranscriptSession) -> String {
+    private func makeIssueBody(issue: ExtractedIssue, session: TranscriptSession) throws -> String {
         var lines: [String] = [
             "## Summary",
             issue.summary,
@@ -178,6 +179,13 @@ actor GitHubExportProvider {
             }
         }
 
+        let annotationLines = try annotatedScreenshotLines(issue: issue, session: session)
+        if !annotationLines.isEmpty {
+            lines.append("")
+            lines.append("## Annotated Screenshots")
+            lines.append(contentsOf: annotationLines)
+        }
+
         let screenshots = session.screenshots(for: issue)
         if !screenshots.isEmpty {
             lines.append("")
@@ -207,6 +215,38 @@ actor GitHubExportProvider {
         }
 
         return parts.isEmpty ? nil : parts.joined(separator: "  •  ")
+    }
+
+    private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
+        let screenshots = session.screenshots(for: issue).filter {
+            !issue.screenshotAnnotations(for: $0.id).isEmpty
+        }
+
+        guard !screenshots.isEmpty else {
+            return []
+        }
+
+        let annotationDirectoryURL = session.artifactsDirectoryURL?.appendingPathComponent(
+            "annotated-exports",
+            isDirectory: true
+        )
+
+        return try screenshots.map { screenshot in
+            let renderedAsset = try annotationDirectoryURL.flatMap {
+                try annotationRenderer.writeAnnotatedScreenshot(
+                    for: issue,
+                    screenshot: screenshot,
+                    to: $0
+                )
+            }
+            let summaries = issue.screenshotAnnotations(for: screenshot.id).map(\.exportDescription).joined(separator: "; ")
+
+            if let renderedAsset {
+                return "- \(renderedAsset.fileName) from `\(screenshot.fileName)` (`\(screenshot.timeLabel)`) — \(summaries)"
+            }
+
+            return "- \(screenshot.fileName) (`\(screenshot.timeLabel)`) — \(summaries)"
+        }
     }
 
     private func mapGitHubError(

--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -181,21 +181,26 @@ actor IssueExtractionService: IssueExtracting {
                 messages: [
                     .init(
                         role: "system",
-                        content: """
+                        content: .text("""
                         You convert spoken software review notes into structured, reviewable draft issues.
                         Use only information explicitly present in the transcript, markers, and screenshot references.
                         Return strict JSON with keys summary, guidanceNote, issues.
-                        Each issue must contain title, category, severity, component, summary, evidenceExcerpt, deduplicationHint, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview, reproductionSteps.
+                        Each issue must contain title, category, severity, component, summary, evidenceExcerpt, deduplicationHint, timestamp, sectionTitle, relatedScreenshotFileNames, confidence, requiresReview, reproductionSteps, screenshotAnnotations.
                         Each reproduction step must contain instruction, expectedResult, actualResult, timestamp, relatedScreenshotFileName.
+                        Each screenshot annotation must contain relatedScreenshotFileName, label, x, y, width, height, confidence, style.
                         Generate numbered reproduction steps that follow the narration timeline and tie each step to the most relevant screenshot reference when one exists.
+                        When the narration clearly points to a specific UI control or region, return one or more screenshotAnnotations that use normalized 0-1 coordinates relative to the screenshot image.
+                        Use a top-left origin for x and y.
+                        Only include screenshotAnnotations when the narration or evidence clearly references a specific UI element. Otherwise return an empty array.
+                        Valid annotation styles are exactly: highlight.
                         Valid categories are exactly: Bug, UX Issue, Enhancement, Question / Follow-up.
                         Valid severities are exactly: Critical, High, Medium, Low.
                         Infer severity from the narration tone and impact. Infer component from the most specific app area available in the transcript or screenshot context.
                         DeduplicationHint should be a short stable hash-like string derived from the issue description.
                         Prefer conservative output. If evidence is weak, set requiresReview to true and use a lower confidence.
-                        """
+                        """)
                     ),
-                    .init(role: "user", content: makePrompt(for: reviewSession))
+                    .init(role: "user", content: .parts(makeUserMessageParts(for: reviewSession)))
                 ]
             )
         )
@@ -206,6 +211,47 @@ actor IssueExtractionService: IssueExtracting {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = body
         return request
+    }
+
+    private static func makeUserMessageParts(for session: TranscriptSession) -> [ChatMessageInputPart] {
+        var parts: [ChatMessageInputPart] = [.text(makePrompt(for: session))]
+
+        for screenshot in session.screenshots {
+            parts.append(.text("Screenshot reference: \(screenshot.fileName) at \(screenshot.timeLabel)."))
+
+            guard let imagePart = makeScreenshotContentPart(for: screenshot) else {
+                continue
+            }
+
+            parts.append(imagePart)
+        }
+
+        return parts
+    }
+
+    private static func makeScreenshotContentPart(for screenshot: SessionScreenshot) -> ChatMessageInputPart? {
+        guard let imageData = try? Data(contentsOf: screenshot.fileURL),
+              let mimeType = mimeType(for: screenshot.fileURL) else {
+            return nil
+        }
+
+        let dataURL = "data:\(mimeType);base64,\(imageData.base64EncodedString())"
+        return .imageURL(dataURL)
+    }
+
+    private static func mimeType(for fileURL: URL) -> String? {
+        switch fileURL.pathExtension.lowercased() {
+        case "png":
+            return "image/png"
+        case "jpg", "jpeg":
+            return "image/jpeg"
+        case "heic":
+            return "image/heic"
+        case "webp":
+            return "image/webp"
+        default:
+            return nil
+        }
     }
 
     private static func performRequest(
@@ -274,7 +320,51 @@ private struct ResponseFormat: Encodable {
 
 private struct ChatMessage: Encodable {
     let role: String
-    let content: String
+    let content: ChatMessageContent
+}
+
+private enum ChatMessageContent: Encodable {
+    case text(String)
+    case parts([ChatMessageInputPart])
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .text(let value):
+            try container.encode(value)
+        case .parts(let parts):
+            try container.encode(parts)
+        }
+    }
+}
+
+private enum ChatMessageInputPart: Encodable {
+    case text(String)
+    case imageURL(String)
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .text(let value):
+            try container.encode("text", forKey: .type)
+            try container.encode(value, forKey: .text)
+        case .imageURL(let value):
+            try container.encode("image_url", forKey: .type)
+            try container.encode(ImageURLPayload(url: value), forKey: .imageURL)
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case imageURL = "image_url"
+    }
+}
+
+private struct ImageURLPayload: Encodable {
+    let url: String
 }
 
 private struct ChatCompletionResponse: Decodable {
@@ -512,6 +602,7 @@ private struct IssuePayload {
     let confidence: Double?
     let requiresReview: Bool?
     let reproductionSteps: [IssueReproductionStepPayload]
+    let screenshotAnnotations: [IssueScreenshotAnnotationPayload]
 
     init?(dictionary: [String: Any]) {
         let title = Self.firstString(in: dictionary, keys: ["title", "issueTitle", "name"])?.trimmedForExtraction
@@ -560,6 +651,16 @@ private struct IssuePayload {
 
             return IssueReproductionStepPayload(dictionary: stepDictionary)
         } ?? []
+        self.screenshotAnnotations = Self.firstArray(
+            in: dictionary,
+            keys: ["screenshotAnnotations", "annotations", "screenshot_annotations", "uiAnnotations"]
+        )?.compactMap { annotationObject in
+            guard let annotationDictionary = annotationObject as? [String: Any] else {
+                return nil
+            }
+
+            return IssueScreenshotAnnotationPayload(dictionary: annotationDictionary)
+        } ?? []
     }
 
     func makeExtractedIssue(screenshotIndex: [String: UUID]) -> ExtractedIssue {
@@ -571,6 +672,12 @@ private struct IssuePayload {
             $0.makeIssueReproductionStep(
                 screenshotIndex: screenshotIndex,
                 fallbackTimestamp: parsedTimestamp,
+                fallbackScreenshotID: screenshotIDs.first
+            )
+        }
+        let annotations = screenshotAnnotations.compactMap {
+            $0.makeIssueScreenshotAnnotation(
+                screenshotIndex: screenshotIndex,
                 fallbackScreenshotID: screenshotIDs.first
             )
         }
@@ -589,7 +696,8 @@ private struct IssuePayload {
             requiresReview: requiresReview ?? true,
             isSelectedForExport: true,
             sectionTitle: sectionTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-            reproductionSteps: reproductionSteps
+            reproductionSteps: reproductionSteps,
+            screenshotAnnotations: annotations
         )
     }
 
@@ -810,6 +918,96 @@ private struct IssueReproductionStepPayload {
             timestamp: IssuePayload.parseTimestamp(timestamp) ?? fallbackTimestamp,
             screenshotID: screenshotID
         )
+    }
+}
+
+private struct IssueScreenshotAnnotationPayload {
+    private static let xKeys = ["x", "left", "originX", "origin_x", "minX"]
+    private static let yKeys = ["y", "top", "originY", "origin_y", "minY"]
+    private static let widthKeys = ["width", "w"]
+    private static let heightKeys = ["height", "h"]
+
+    let relatedScreenshotFileName: String?
+    let label: String?
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+    let confidence: Double?
+    let style: String?
+
+    init?(dictionary: [String: Any]) {
+        guard let x = Self.firstDouble(in: dictionary, keys: Self.xKeys),
+              let y = Self.firstDouble(in: dictionary, keys: Self.yKeys),
+              let width = Self.firstDouble(in: dictionary, keys: Self.widthKeys),
+              let height = Self.firstDouble(in: dictionary, keys: Self.heightKeys) else {
+            return nil
+        }
+
+        self.relatedScreenshotFileName = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["relatedScreenshotFileName", "screenshot", "screenshotFileName", "fileName", "related_screenshot_file_name"]
+        )?.trimmedForExtraction
+        self.label = IssuePayload.firstString(
+            in: dictionary,
+            keys: ["label", "title", "target", "description"]
+        )?.trimmedForExtraction.nilIfEmpty
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+        self.confidence = Self.firstDouble(in: dictionary, keys: ["confidence", "score"])
+        self.style = IssuePayload.firstString(in: dictionary, keys: ["style", "kind"])?.trimmedForExtraction
+    }
+
+    func makeIssueScreenshotAnnotation(
+        screenshotIndex: [String: UUID],
+        fallbackScreenshotID: UUID?
+    ) -> IssueScreenshotAnnotation? {
+        let screenshotID = relatedScreenshotFileName.flatMap {
+            screenshotIndex[$0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()]
+        } ?? fallbackScreenshotID
+
+        guard let screenshotID else {
+            return nil
+        }
+
+        let annotationStyle: IssueScreenshotAnnotation.Style
+        switch style?.lowercased() {
+        case nil, "", "highlight", "box", "outline":
+            annotationStyle = .highlight
+        default:
+            annotationStyle = .highlight
+        }
+
+        return IssueScreenshotAnnotation(
+            screenshotID: screenshotID,
+            label: label,
+            x: x,
+            y: y,
+            width: width,
+            height: height,
+            confidence: confidence,
+            style: annotationStyle
+        )
+    }
+
+    private static func firstDouble(in dictionary: [String: Any], keys: [String]) -> Double? {
+        for key in keys {
+            if let value = dictionary[key] as? Double {
+                return value
+            }
+
+            if let value = dictionary[key] as? NSNumber {
+                return value.doubleValue
+            }
+
+            if let value = dictionary[key] as? String, let doubleValue = Double(value) {
+                return doubleValue
+            }
+        }
+
+        return nil
     }
 }
 

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 actor JiraExportProvider {
     private let session: URLSession
     private let logger = DiagnosticsLogger(category: .export)
+    private let annotationRenderer = IssueScreenshotAnnotationRenderer()
 
     init(session: URLSession? = nil) {
         if let session {
@@ -111,7 +112,7 @@ actor JiraExportProvider {
                     project: .init(key: configuration.projectKey),
                     summary: issue.title,
                     issueType: .init(name: configuration.issueType),
-                    description: makeDescription(issue: issue, session: reviewSession)
+                    description: try makeDescription(issue: issue, session: reviewSession)
                 )
             )
         )
@@ -123,7 +124,7 @@ actor JiraExportProvider {
         return Data(rawValue.utf8).base64EncodedString()
     }
 
-    private func makeDescription(issue: ExtractedIssue, session: TranscriptSession) -> JiraDocument {
+    private func makeDescription(issue: ExtractedIssue, session: TranscriptSession) throws -> JiraDocument {
         var content: [JiraBlock] = [
             .paragraph(text: "Summary: \(issue.summary)"),
             .paragraph(text: "Evidence: \(issue.evidenceExcerpt)")
@@ -159,6 +160,12 @@ actor JiraExportProvider {
             }
             content.append(.paragraph(text: "Reproduction steps"))
             content.append(.bulletList(items: stepLines))
+        }
+
+        let annotationLines = try annotatedScreenshotLines(issue: issue, session: session)
+        if !annotationLines.isEmpty {
+            content.append(.paragraph(text: "Annotated screenshots"))
+            content.append(.bulletList(items: annotationLines))
         }
 
         let screenshots = session.screenshots(for: issue)
@@ -205,6 +212,38 @@ actor JiraExportProvider {
         }
 
         return parts.joined(separator: " | ")
+    }
+
+    private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
+        let screenshots = session.screenshots(for: issue).filter {
+            !issue.screenshotAnnotations(for: $0.id).isEmpty
+        }
+
+        guard !screenshots.isEmpty else {
+            return []
+        }
+
+        let annotationDirectoryURL = session.artifactsDirectoryURL?.appendingPathComponent(
+            "annotated-exports",
+            isDirectory: true
+        )
+
+        return try screenshots.map { screenshot in
+            let renderedAsset = try annotationDirectoryURL.flatMap {
+                try annotationRenderer.writeAnnotatedScreenshot(
+                    for: issue,
+                    screenshot: screenshot,
+                    to: $0
+                )
+            }
+            let summaries = issue.screenshotAnnotations(for: screenshot.id).map(\.exportDescription).joined(separator: "; ")
+
+            if let renderedAsset {
+                return "\(renderedAsset.fileName) from \(screenshot.fileName) (\(screenshot.timeLabel)) - \(summaries)"
+            }
+
+            return "\(screenshot.fileName) (\(screenshot.timeLabel)) - \(summaries)"
+        }
     }
 
     private func mapJiraError(

--- a/Sources/BugNarrator/Utilities/IssueScreenshotAnnotationRenderer.swift
+++ b/Sources/BugNarrator/Utilities/IssueScreenshotAnnotationRenderer.swift
@@ -1,0 +1,143 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+struct RenderedIssueScreenshotAsset: Equatable {
+    let fileURL: URL
+
+    var fileName: String {
+        fileURL.lastPathComponent
+    }
+}
+
+struct IssueScreenshotAnnotationRenderer {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func writeAnnotatedScreenshot(
+        for issue: ExtractedIssue,
+        screenshot: SessionScreenshot,
+        to directoryURL: URL
+    ) throws -> RenderedIssueScreenshotAsset? {
+        let annotations = issue.screenshotAnnotations(for: screenshot.id)
+        guard !annotations.isEmpty else {
+            return nil
+        }
+
+        guard let source = CGImageSourceCreateWithURL(screenshot.fileURL as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            return nil
+        }
+
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let width = image.width
+        let height = image.height
+        guard let colorSpace = image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return nil
+        }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        for annotation in annotations {
+            draw(annotation: annotation, in: context, imageWidth: width, imageHeight: height)
+        }
+
+        guard let renderedImage = context.makeImage() else {
+            return nil
+        }
+
+        let destinationURL = uniqueDestinationURL(
+            in: directoryURL,
+            fileName: annotatedFileName(for: screenshot, issueID: issue.id)
+        )
+
+        guard let destination = CGImageDestinationCreateWithURL(
+            destinationURL as CFURL,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+
+        CGImageDestinationAddImage(destination, renderedImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+
+        return RenderedIssueScreenshotAsset(fileURL: destinationURL)
+    }
+
+    private func annotatedFileName(for screenshot: SessionScreenshot, issueID: UUID) -> String {
+        let baseURL = URL(fileURLWithPath: screenshot.fileName)
+        let baseName = baseURL.deletingPathExtension().lastPathComponent
+        let issuePrefix = issueID.uuidString.split(separator: "-").first.map(String.init) ?? issueID.uuidString
+        return "\(baseName)-annotated-\(issuePrefix).png"
+    }
+
+    private func uniqueDestinationURL(in directoryURL: URL, fileName: String) -> URL {
+        let baseURL = URL(fileURLWithPath: fileName)
+        let baseName = baseURL.deletingPathExtension().lastPathComponent
+        let fileExtension = baseURL.pathExtension.isEmpty ? "png" : baseURL.pathExtension
+        var candidateURL = directoryURL.appendingPathComponent(fileName)
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: candidateURL.path) {
+            candidateURL = directoryURL.appendingPathComponent("\(baseName)-\(suffix).\(fileExtension)")
+            suffix += 1
+        }
+
+        return candidateURL
+    }
+
+    private func draw(
+        annotation: IssueScreenshotAnnotation,
+        in context: CGContext,
+        imageWidth: Int,
+        imageHeight: Int
+    ) {
+        let normalizedRect = annotation.normalizedRect
+        let rect = CGRect(
+            x: normalizedRect.origin.x * CGFloat(imageWidth),
+            y: (1 - normalizedRect.origin.y - normalizedRect.height) * CGFloat(imageHeight),
+            width: normalizedRect.width * CGFloat(imageWidth),
+            height: normalizedRect.height * CGFloat(imageHeight)
+        )
+
+        let strokeColor = CGColor(red: 0.98, green: 0.33, blue: 0.21, alpha: 0.95)
+        let fillColor = CGColor(red: 0.98, green: 0.33, blue: 0.21, alpha: 0.16)
+
+        context.saveGState()
+        context.setStrokeColor(strokeColor)
+        context.setFillColor(fillColor)
+        context.setLineWidth(max(4, min(rect.width, rect.height) * 0.04))
+        context.addRect(rect)
+        context.drawPath(using: .fillStroke)
+
+        let anchor = CGPoint(x: rect.minX, y: rect.maxY)
+        let arrowLength = max(18, min(CGFloat(imageWidth), CGFloat(imageHeight)) * 0.05)
+        context.move(to: CGPoint(x: anchor.x - arrowLength, y: anchor.y + arrowLength))
+        context.addLine(to: anchor)
+        context.addLine(to: CGPoint(x: anchor.x + arrowLength * 0.45, y: anchor.y + arrowLength))
+        context.strokePath()
+        context.restoreGState()
+    }
+}

--- a/Sources/BugNarrator/Views/IssueScreenshotAnnotationPreview.swift
+++ b/Sources/BugNarrator/Views/IssueScreenshotAnnotationPreview.swift
@@ -1,0 +1,154 @@
+import AppKit
+import SwiftUI
+
+struct IssueScreenshotAnnotationPreview: View {
+    let screenshot: SessionScreenshot
+    let annotations: [IssueScreenshotAnnotation]
+    let onUpdate: (IssueScreenshotAnnotation) -> Void
+    let onRemove: (IssueScreenshotAnnotation) -> Void
+
+    @State private var activeAnnotationID: UUID?
+    @State private var dragTranslation: CGSize = .zero
+
+    private let maxPreviewHeight: CGFloat = 220
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let image = ScreenshotPreviewCache.shared.previewImage(for: screenshot.fileURL, maxPixelSize: 960) {
+                GeometryReader { proxy in
+                    let imageFrame = aspectFitFrame(for: image.size, in: proxy.size)
+
+                    ZStack(alignment: .topLeading) {
+                        Image(nsImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                        ForEach(annotations) { annotation in
+                            annotationOverlay(
+                                annotation: annotation,
+                                imageFrame: imageFrame
+                            )
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: maxPreviewHeight)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                )
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Annotated screenshot preview for \(screenshot.fileName)")
+            } else {
+                Text("Annotated preview unavailable for \(screenshot.fileName).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(alignment: .center, spacing: 8) {
+                Text(screenshot.fileName)
+                    .font(.caption.weight(.semibold))
+
+                Text(screenshot.timeLabel)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func annotationOverlay(
+        annotation: IssueScreenshotAnnotation,
+        imageFrame: CGRect
+    ) -> some View {
+        let baseRect = displayRect(for: annotation, imageFrame: imageFrame)
+        let isActive = activeAnnotationID == annotation.id
+        let displayRect = isActive
+            ? baseRect.offsetBy(dx: dragTranslation.width, dy: dragTranslation.height)
+            : baseRect
+
+        return ZStack(alignment: .topTrailing) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.orange.opacity(0.14))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color.orange.opacity(0.95), lineWidth: isActive ? 3 : 2)
+                )
+
+            Button {
+                onRemove(annotation)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white, .black.opacity(0.75))
+            }
+            .buttonStyle(.plain)
+            .padding(6)
+            .accessibilityLabel("Remove annotation \(annotation.label ?? "highlight") from \(screenshot.fileName)")
+        }
+        .overlay(alignment: .topLeading) {
+            if let label = annotation.label, !label.isEmpty {
+                Text(label)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.ultraThinMaterial, in: Capsule(style: .continuous))
+                    .padding(8)
+            }
+        }
+        .frame(width: displayRect.width, height: displayRect.height)
+        .position(x: displayRect.midX, y: displayRect.midY)
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    activeAnnotationID = annotation.id
+                    dragTranslation = value.translation
+                }
+                .onEnded { value in
+                    activeAnnotationID = nil
+                    dragTranslation = .zero
+
+                    guard imageFrame.width > 0, imageFrame.height > 0 else {
+                        return
+                    }
+
+                    var updatedAnnotation = annotation
+                    updatedAnnotation.move(
+                        x: value.translation.width / imageFrame.width,
+                        y: value.translation.height / imageFrame.height
+                    )
+                    onUpdate(updatedAnnotation)
+                }
+        )
+        .accessibilityLabel(annotation.label ?? "UI highlight")
+        .accessibilityHint("Drag to reposition the highlighted region.")
+    }
+
+    private func displayRect(for annotation: IssueScreenshotAnnotation, imageFrame: CGRect) -> CGRect {
+        let rect = annotation.normalizedRect
+        return CGRect(
+            x: imageFrame.origin.x + (rect.origin.x * imageFrame.width),
+            y: imageFrame.origin.y + (rect.origin.y * imageFrame.height),
+            width: rect.width * imageFrame.width,
+            height: rect.height * imageFrame.height
+        )
+    }
+
+    private func aspectFitFrame(for imageSize: CGSize, in containerSize: CGSize) -> CGRect {
+        guard imageSize.width > 0,
+              imageSize.height > 0,
+              containerSize.width > 0,
+              containerSize.height > 0 else {
+            return .zero
+        }
+
+        let scale = min(containerSize.width / imageSize.width, containerSize.height / imageSize.height)
+        let fittedSize = CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        let origin = CGPoint(
+            x: (containerSize.width - fittedSize.width) / 2,
+            y: (containerSize.height - fittedSize.height) / 2
+        )
+        return CGRect(origin: origin, size: fittedSize)
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -1329,6 +1329,16 @@ struct TranscriptView: View {
 
             let relatedScreenshots = (extractedIssue(sessionID: session.id, issueID: issue.id) ?? issue).relatedScreenshotIDs
                 .compactMap(session.screenshot(with:))
+            let annotatedScreenshots = relatedScreenshots.filter {
+                !liveIssue.screenshotAnnotations(for: $0.id).isEmpty
+            }
+            if !annotatedScreenshots.isEmpty {
+                issueScreenshotAnnotationSection(
+                    issue: liveIssue,
+                    screenshots: annotatedScreenshots,
+                    sessionID: session.id
+                )
+            }
             if !relatedScreenshots.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Screenshots:")
@@ -1343,6 +1353,40 @@ struct TranscriptView: View {
                         .accessibilityLabel("Open related screenshot \(screenshot.fileName)")
                     }
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func issueScreenshotAnnotationSection(
+        issue: ExtractedIssue,
+        screenshots: [SessionScreenshot],
+        sessionID: UUID
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Annotated Screenshots")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            ForEach(screenshots) { screenshot in
+                IssueScreenshotAnnotationPreview(
+                    screenshot: screenshot,
+                    annotations: issue.screenshotAnnotations(for: screenshot.id),
+                    onUpdate: { updatedAnnotation in
+                        updateScreenshotAnnotation(
+                            updatedAnnotation,
+                            issueID: issue.id,
+                            sessionID: sessionID
+                        )
+                    },
+                    onRemove: { annotation in
+                        removeScreenshotAnnotation(
+                            annotationID: annotation.id,
+                            issueID: issue.id,
+                            sessionID: sessionID
+                        )
+                    }
+                )
             }
         }
     }
@@ -1650,6 +1694,33 @@ struct TranscriptView: View {
                 appState.updateExtractedIssue(updatedIssue, in: sessionID)
             }
         )
+    }
+
+    private func updateScreenshotAnnotation(
+        _ updatedAnnotation: IssueScreenshotAnnotation,
+        issueID: UUID,
+        sessionID: UUID
+    ) {
+        guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID),
+              let annotationIndex = updatedIssue.screenshotAnnotations.firstIndex(where: { $0.id == updatedAnnotation.id }) else {
+            return
+        }
+
+        updatedIssue.screenshotAnnotations[annotationIndex] = updatedAnnotation
+        appState.updateExtractedIssue(updatedIssue, in: sessionID)
+    }
+
+    private func removeScreenshotAnnotation(
+        annotationID: UUID,
+        issueID: UUID,
+        sessionID: UUID
+    ) {
+        guard var updatedIssue = extractedIssue(sessionID: sessionID, issueID: issueID) else {
+            return
+        }
+
+        updatedIssue.screenshotAnnotations.removeAll { $0.id == annotationID }
+        appState.updateExtractedIssue(updatedIssue, in: sessionID)
     }
 
     private func sessionRowAccessibilitySummary(for entry: SessionLibraryEntry) -> String {

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -10,6 +10,9 @@ final class GitHubExportProviderTests: XCTestCase {
 
     func testMakeURLRequestIncludesAuthorizationAndIssueBody() async throws {
         let provider = GitHubExportProvider(session: makeMockURLSession())
+        let screenshotURL = makeScreenshotFileURL(named: "review-shot.png")
+        let screenshot = SessionScreenshot(elapsedTime: 14, filePath: screenshotURL.path)
+        let artifactsDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
         let issue = ExtractedIssue(
             title: "Login button is disabled",
             category: .bug,
@@ -19,7 +22,7 @@ final class GitHubExportProviderTests: XCTestCase {
             evidenceExcerpt: "The login button never re-enabled after typing a valid email.",
             deduplicationHint: "issue-login-disabled",
             timestamp: 14,
-            relatedScreenshotIDs: [],
+            relatedScreenshotIDs: [screenshot.id],
             requiresReview: true,
             reproductionSteps: [
                 IssueReproductionStep(
@@ -27,6 +30,17 @@ final class GitHubExportProviderTests: XCTestCase {
                     expectedResult: "The login button enables.",
                     actualResult: "The login button stays disabled.",
                     timestamp: 14
+                )
+            ],
+            screenshotAnnotations: [
+                IssueScreenshotAnnotation(
+                    screenshotID: screenshot.id,
+                    label: "Login button",
+                    x: 0.44,
+                    y: 0.52,
+                    width: 0.24,
+                    height: 0.16,
+                    confidence: 0.82
                 )
             ]
         )
@@ -37,7 +51,9 @@ final class GitHubExportProviderTests: XCTestCase {
             model: "whisper-1",
             languageHint: nil,
             prompt: nil,
-            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+            screenshots: [screenshot],
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue]),
+            artifactsDirectoryPath: artifactsDirectory.path
         )
         let request = try await provider.makeURLRequest(
             issue: issue,
@@ -67,6 +83,9 @@ final class GitHubExportProviderTests: XCTestCase {
         XCTAssertTrue(payload.body.contains("## Reproduction Steps"))
         XCTAssertTrue(payload.body.contains("Expected: The login button enables."))
         XCTAssertTrue(payload.body.contains("Actual: The login button stays disabled."))
+        XCTAssertTrue(payload.body.contains("## Annotated Screenshots"))
+        XCTAssertTrue(payload.body.contains("Login button"))
+        XCTAssertTrue(payload.body.contains("review-shot-annotated"))
     }
 
     func testExportMapsRepositoryNotFound() async throws {
@@ -183,4 +202,13 @@ private struct GitHubIssueRequestPayload: Decodable {
     let title: String
     let body: String
     let labels: [String]?
+}
+
+private func makeScreenshotFileURL(named fileName: String) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    let pngData = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
+    )!
+    try? pngData.write(to: url)
+    return url
 }

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -27,6 +27,18 @@ final class IssueExtractionServiceTests: XCTestCase {
               "timestamp": "00:08",
               "sectionTitle": "Save flow",
               "relatedScreenshotFileNames": ["review-shot.png"],
+              "screenshotAnnotations": [
+                {
+                  "relatedScreenshotFileName": "review-shot.png",
+                  "label": "Save button",
+                  "x": 0.48,
+                  "y": 0.62,
+                  "width": 0.22,
+                  "height": 0.14,
+                  "confidence": 0.81,
+                  "style": "highlight"
+                }
+              ],
               "reproductionSteps": [
                 {
                   "instruction": "Open the save modal.",
@@ -46,6 +58,12 @@ final class IssueExtractionServiceTests: XCTestCase {
         MockURLProtocol.requestHandler = { request in
             XCTAssertEqual(request.url?.absoluteString, "https://api.openai.com/v1/chat/completions")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer fixture-openai-key")
+
+            let body = try XCTUnwrap(request.httpBody)
+            let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let messages = try XCTUnwrap(payload["messages"] as? [[String: Any]])
+            let userContent = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
+            XCTAssertTrue(userContent.contains(where: { ($0["type"] as? String) == "image_url" }))
 
             return (self.successResponse(for: request), self.makeChatCompletionData(content: content))
         }
@@ -68,6 +86,9 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.actualResult, "The save button is clipped on the right edge.")
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.timestamp, 8)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.screenshotID, session.screenshots.first?.id)
+        XCTAssertEqual(result.issues.first?.screenshotAnnotations.count, 1)
+        XCTAssertEqual(result.issues.first?.screenshotAnnotations.first?.label, "Save button")
+        XCTAssertEqual(result.issues.first?.screenshotAnnotations.first?.screenshotID, session.screenshots.first?.id)
     }
 
     func testExtractIssuesParsesArrayBasedContentWithMarkdownFenceAndAliasKeys() async throws {
@@ -87,6 +108,16 @@ final class IssueExtractionServiceTests: XCTestCase {
               "timecode": "00:08",
               "section": "Save flow",
               "screenshotFileNames": ["review-shot.png"],
+              "annotations": [
+                {
+                  "screenshot": "review-shot.png",
+                  "target": "Save button",
+                  "left": 0.45,
+                  "top": 0.60,
+                  "w": 0.24,
+                  "h": 0.15
+                }
+              ],
               "stepsToReproduce": [
                 {
                   "step": "Open the save modal.",
@@ -137,6 +168,8 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.issues.first?.reproductionSteps.count, 1)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.timestamp, 8)
         XCTAssertEqual(result.issues.first?.reproductionSteps.first?.screenshotID, session.screenshots.first?.id)
+        XCTAssertEqual(result.issues.first?.screenshotAnnotations.count, 1)
+        XCTAssertEqual(result.issues.first?.screenshotAnnotations.first?.label, "Save button")
     }
 
     func testExtractIssuesInfersSeverityAndDeduplicationHintWhenMissing() async throws {
@@ -251,7 +284,12 @@ final class IssueExtractionServiceTests: XCTestCase {
     }
 
     private func makeReviewSession() -> TranscriptSession {
-        let screenshot = SessionScreenshot(elapsedTime: 8, filePath: "/tmp/review-shot.png")
+        let screenshotURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("review-shot.png")
+        let pngData = Data(
+            base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
+        )!
+        try? pngData.write(to: screenshotURL)
+        let screenshot = SessionScreenshot(elapsedTime: 8, filePath: screenshotURL.path)
         return TranscriptSession(
             createdAt: Date(timeIntervalSince1970: 10),
             transcript: "The save button is clipped and the modal is confusing.",

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -10,6 +10,9 @@ final class JiraExportProviderTests: XCTestCase {
 
     func testMakeURLRequestIncludesBasicAuthAndProjectFields() async throws {
         let provider = JiraExportProvider(session: makeMockURLSession())
+        let screenshotURL = makeScreenshotFileURL(named: "modal-shot.png")
+        let screenshot = SessionScreenshot(elapsedTime: 22, filePath: screenshotURL.path)
+        let artifactsDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
         let issue = ExtractedIssue(
             title: "Modal lacks close affordance",
             category: .uxIssue,
@@ -19,6 +22,7 @@ final class JiraExportProviderTests: XCTestCase {
             evidenceExcerpt: "I cannot tell how to dismiss the modal.",
             deduplicationHint: "issue-modal-close-affordance",
             timestamp: 22,
+            relatedScreenshotIDs: [screenshot.id],
             requiresReview: true,
             reproductionSteps: [
                 IssueReproductionStep(
@@ -26,6 +30,16 @@ final class JiraExportProviderTests: XCTestCase {
                     expectedResult: "A close affordance is visible immediately.",
                     actualResult: "No close affordance appears in the modal chrome.",
                     timestamp: 22
+                )
+            ],
+            screenshotAnnotations: [
+                IssueScreenshotAnnotation(
+                    screenshotID: screenshot.id,
+                    label: "Modal close affordance",
+                    x: 0.78,
+                    y: 0.12,
+                    width: 0.14,
+                    height: 0.16
                 )
             ]
         )
@@ -36,7 +50,9 @@ final class JiraExportProviderTests: XCTestCase {
             model: "whisper-1",
             languageHint: nil,
             prompt: nil,
-            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+            screenshots: [screenshot],
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue]),
+            artifactsDirectoryPath: artifactsDirectory.path
         )
         let request = try await provider.makeURLRequest(
             issue: issue,
@@ -72,6 +88,9 @@ final class JiraExportProviderTests: XCTestCase {
         XCTAssertTrue(payloadString.contains("Reproduction steps"))
         XCTAssertTrue(payloadString.contains("Expected: A close affordance is visible immediately."))
         XCTAssertTrue(payloadString.contains("Actual: No close affordance appears in the modal chrome."))
+        XCTAssertTrue(payloadString.contains("Annotated screenshots"))
+        XCTAssertTrue(payloadString.contains("Modal close affordance"))
+        XCTAssertTrue(payloadString.contains("modal-shot-annotated"))
     }
 
     func testExportMapsValidationFailure() async throws {
@@ -184,4 +203,13 @@ final class JiraExportProviderTests: XCTestCase {
             XCTAssertTrue(message.contains("Issue type is invalid"))
         }
     }
+}
+
+private func makeScreenshotFileURL(named fileName: String) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    let pngData = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
+    )!
+    try? pngData.write(to: url)
+    return url
 }

--- a/Tests/BugNarratorTests/ScreenshotAnnotationTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotAnnotationTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import XCTest
+@testable import BugNarrator
+
+final class ScreenshotAnnotationTests: XCTestCase {
+    func testIssueScreenshotAnnotationMoveClampsIntoImageBounds() {
+        var annotation = IssueScreenshotAnnotation(
+            screenshotID: UUID(),
+            label: "Primary button",
+            x: 0.72,
+            y: 0.68,
+            width: 0.24,
+            height: 0.18
+        )
+
+        annotation.move(x: 0.3, y: 0.3)
+
+        XCTAssertEqual(annotation.x, 0.76, accuracy: 0.0001)
+        XCTAssertEqual(annotation.y, 0.82, accuracy: 0.0001)
+        XCTAssertEqual(annotation.width, 0.24, accuracy: 0.0001)
+        XCTAssertEqual(annotation.height, 0.18, accuracy: 0.0001)
+    }
+
+    func testRendererWritesAnnotatedScreenshotAsset() throws {
+        let screenshotURL = makeScreenshotFileURL(named: "annotation-source.png")
+        let screenshot = SessionScreenshot(elapsedTime: 9, filePath: screenshotURL.path)
+        let issue = ExtractedIssue(
+            title: "Submit button does not respond",
+            category: .bug,
+            summary: "The highlighted submit button does not respond.",
+            evidenceExcerpt: "The submit button never reacts to clicks.",
+            timestamp: 9,
+            relatedScreenshotIDs: [screenshot.id],
+            screenshotAnnotations: [
+                IssueScreenshotAnnotation(
+                    screenshotID: screenshot.id,
+                    label: "Submit button",
+                    x: 0.42,
+                    y: 0.56,
+                    width: 0.22,
+                    height: 0.16
+                )
+            ]
+        )
+        let outputDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let renderer = IssueScreenshotAnnotationRenderer()
+
+        let asset = try renderer.writeAnnotatedScreenshot(
+            for: issue,
+            screenshot: screenshot,
+            to: outputDirectory
+        )
+
+        XCTAssertNotNil(asset)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: asset?.fileURL.path ?? ""))
+        XCTAssertTrue(asset?.fileName.contains("annotated") == true)
+    }
+}
+
+private func makeScreenshotFileURL(named fileName: String) -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("\(UUID().uuidString)-\(fileName)")
+    let pngData = Data(
+        base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
+    )!
+    try? pngData.write(to: url)
+    return url
+}

--- a/artifacts/n4-smart-screenshot-annotation/validate.log
+++ b/artifacts/n4-smart-screenshot-annotation/validate.log
@@ -1,0 +1,5 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 12 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Config loaded from ai.config.json

--- a/artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log
+++ b/artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log
@@ -1,0 +1,108 @@
+Command line invocation:
+    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n4-tests test "-only-testing:BugNarratorTests/ScreenshotAnnotationTests" "-only-testing:BugNarratorTests/GitHubExportProviderTests" "-only-testing:BugNarratorTests/JiraExportProviderTests"
+
+Build settings from command line:
+    CODE_SIGNING_ALLOWED = NO
+
+2026-04-13 06:15:04.511 xcodebuild[62549:2540421] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, arch:x86_64, id:00006002-001470622E03401E, name:My Mac }
+{ platform:macOS, name:Any Mac }
+ComputePackagePrebuildTargetDependencyGraph
+
+Prepare packages
+
+CreateBuildRequest
+
+SendProjectDescription
+
+CreateBuildOperation
+
+ComputeTargetDependencyGraph
+note: Building targets in dependency order
+note: Target dependency graph (2 targets)
+    Target 'BugNarratorTests' in project 'BugNarrator'
+        ➜ Explicit dependency on target 'BugNarrator' in project 'BugNarrator'
+    Target 'BugNarrator' in project 'BugNarrator' (no dependencies)
+
+GatherProvisioningInputs
+
+CreateBuildDescription
+
+ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk /tmp/bugnarrator-n4-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+    cd /Users/deffenda/Code/bug-narrator/BugNarrator.xcodeproj
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.4.sdk -o /tmp/bugnarrator-n4-tests/SDKStatCaches.noindex/macosx26.4-25E236-30f9ca8789b706f8bd3fc906a70d770f.sdkstatcache
+
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+2026-04-13 06:15:05.850660-0400 BugNarrator[62691:2540828] [settings] 2026-04-13T10:15:05.849Z [INFO] [settings] settings_loaded - Settings finished loading. debug_mode=disabled has_github_token=<redacted> has_jira_token=<redacted> has_openai_key=no launch_at_login=disabled launch_at_login_supported=yes
+2026-04-13 06:15:05.851287-0400 BugNarrator[62691:2540828] [session-library] 2026-04-13T10:15:05.851Z [INFO] [session-library] session_store_empty - No existing session history was found on disk.
+2026-04-13 06:15:05.856478-0400 BugNarrator[62691:2540828] [settings] 2026-04-13T10:15:05.856Z [INFO] [settings] app_state_initialized - BugNarrator finished initializing application state. debug_mode=disabled has_openai_key=no
+2026-04-13 06:15:05.867879-0400 BugNarrator[62691:2540828] [permissions] 2026-04-13T10:15:05.868Z [INFO] [permissions] launch_permission_snapshot - Captured the initial permission state snapshot for this BugNarrator app copy. bundle_path=/private/tmp/bugnarrator-n4-tests/Build/Products/Debug/BugNarrator.app is_local_testing_build=no microphone_status=notDetermined screen_capture_status=notDetermined
+2026-04-13 06:15:05.868144-0400 BugNarrator[62691:2540828] [session-library] 2026-04-13T10:15:05.868Z [INFO] [session-library] launch_session_store_snapshot - Captured the initial session library state at launch. selected_transcript_id=<redacted> stored_session_count=0
+Test Suite 'Selected tests' started at 2026-04-13 06:15:06.330.
+Test Suite 'BugNarratorTests.xctest' started at 2026-04-13 06:15:06.331.
+Test Suite 'GitHubExportProviderTests' started at 2026-04-13 06:15:06.331.
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' started.
+2026-04-13 06:15:06.332937-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.333Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=1 repository=acme/bugnarrator session_id=4CDC56E8-1309-4FB6-82A4-F1BBFD287E2C
+2026-04-13 06:15:06.336018-0400 BugNarrator[62691:2540837] [export] 2026-04-13T10:15:06.336Z [ERROR] [export] github_export_failed - Export failed: GitHub could not find acme/bugnarrator. Check the owner, repository name, and token permissions. source_issue_id=7AA601CF-1805-4859-B202-1E4D7CB830D7 successful_count=0
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportMapsRepositoryNotFound]' passed (0.007 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 06:15:06.339413-0400 BugNarrator[62691:2540844] [export] 2026-04-13T10:15:06.339Z [INFO] [export] github_export_requested - Exporting selected issues to GitHub. issue_count=2 repository=acme/bugnarrator session_id=B484A2DD-93C9-4C18-83F4-988CA893CDC9
+2026-04-13 06:15:06.340279-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.340Z [INFO] [export] github_issue_exported - Exported one issue to GitHub. remote_identifier=#101 source_issue_id=5DD4591F-220E-470F-AD84-53A7BDC644B9
+2026-04-13 06:15:06.340911-0400 BugNarrator[62691:2540844] [export] 2026-04-13T10:15:06.341Z [ERROR] [export] github_export_failed - Export failed: GitHub rejected the issue payload: Validation Failed source_issue_id=F6CB8EC8-3D70-45BE-9D07-ADE3437A38D1 successful_count=1
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.006 seconds).
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' started.
+2026-04-13 06:15:06.347338-0400 BugNarrator[62691:2540862] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.347375-0400 BugNarrator[62691:2540862] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.347403-0400 BugNarrator[62691:2540862] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.347417-0400 BugNarrator[62691:2540862] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.347440-0400 BugNarrator[62691:2540862] [com.abdenterprises.bugnarrator] img_image: Bad image source
+Test Case '-[BugNarratorTests.GitHubExportProviderTests testMakeURLRequestIncludesAuthorizationAndIssueBody]' passed (0.011 seconds).
+Test Suite 'GitHubExportProviderTests' passed at 2026-04-13 06:15:06.356.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.023 (0.025) seconds
+Test Suite 'JiraExportProviderTests' started at 2026-04-13 06:15:06.356.
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' started.
+2026-04-13 06:15:06.357231-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.357Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=1 project_key=FM session_id=982F9D89-DCDC-4F4E-BB59-3B229E6E9A5C
+2026-04-13 06:15:06.358464-0400 BugNarrator[62691:2540844] [export] 2026-04-13T10:15:06.358Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=F41739C2-4373-4950-8040-AF09F8916855 successful_count=0
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportMapsValidationFailure]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' started.
+2026-04-13 06:15:06.360519-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.360Z [INFO] [export] jira_export_requested - Exporting selected issues to Jira. issue_count=2 project_key=FM session_id=07941DF0-2481-4DD6-B467-0DF09B8B6702
+2026-04-13 06:15:06.361295-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.361Z [INFO] [export] jira_issue_exported - Exported one issue to Jira. remote_identifier=FM-101 source_issue_id=58F79A79-BBBB-422C-81A2-8C74258E088B
+2026-04-13 06:15:06.362133-0400 BugNarrator[62691:2540833] [export] 2026-04-13T10:15:06.362Z [ERROR] [export] jira_export_failed - Export failed: Jira rejected the issue payload: Issue type is invalid source_issue_id=585A2472-F613-4642-8690-64B6C57F47D1 successful_count=1
+Test Case '-[BugNarratorTests.JiraExportProviderTests testExportReportsPartialSuccessWhenLaterIssueFails]' passed (0.003 seconds).
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' started.
+2026-04-13 06:15:06.364625-0400 BugNarrator[62691:2540844] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.364675-0400 BugNarrator[62691:2540844] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.364712-0400 BugNarrator[62691:2540844] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.364728-0400 BugNarrator[62691:2540844] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.364744-0400 BugNarrator[62691:2540844] [com.abdenterprises.bugnarrator] img_image: Bad image source
+Test Case '-[BugNarratorTests.JiraExportProviderTests testMakeURLRequestIncludesBasicAuthAndProjectFields]' passed (0.004 seconds).
+Test Suite 'JiraExportProviderTests' passed at 2026-04-13 06:15:06.367.
+	 Executed 3 tests, with 0 failures (0 unexpected) in 0.010 (0.011) seconds
+Test Suite 'ScreenshotAnnotationTests' started at 2026-04-13 06:15:06.367.
+Test Case '-[BugNarratorTests.ScreenshotAnnotationTests testIssueScreenshotAnnotationMoveClampsIntoImageBounds]' started.
+Test Case '-[BugNarratorTests.ScreenshotAnnotationTests testIssueScreenshotAnnotationMoveClampsIntoImageBounds]' passed (0.001 seconds).
+Test Case '-[BugNarratorTests.ScreenshotAnnotationTests testRendererWritesAnnotatedScreenshotAsset]' started.
+2026-04-13 06:15:06.369522-0400 BugNarrator[62691:2540828] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.369556-0400 BugNarrator[62691:2540828] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.369582-0400 BugNarrator[62691:2540828] [BugNarrator] handle_error:268: IDAT: CRC error
+2026-04-13 06:15:06.369596-0400 BugNarrator[62691:2540828] [BugNarrator] imagePNG_error_break:384: *** ERROR: imagePNG_error_break
+2026-04-13 06:15:06.369608-0400 BugNarrator[62691:2540828] [com.abdenterprises.bugnarrator] img_image: Bad image source
+Test Case '-[BugNarratorTests.ScreenshotAnnotationTests testRendererWritesAnnotatedScreenshotAsset]' passed (0.002 seconds).
+Test Suite 'ScreenshotAnnotationTests' passed at 2026-04-13 06:15:06.371.
+	 Executed 2 tests, with 0 failures (0 unexpected) in 0.003 (0.004) seconds
+Test Suite 'BugNarratorTests.xctest' passed at 2026-04-13 06:15:06.371.
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.036 (0.040) seconds
+Test Suite 'Selected tests' passed at 2026-04-13 06:15:06.371.
+	 Executed 8 tests, with 0 failures (0 unexpected) in 0.036 (0.041) seconds
+2026-04-13 06:15:06.638 xcodebuild[62549:2540421] [MT] IDETestOperationsObserverDebug: 1.315 elapsed -- Testing started completed.
+2026-04-13 06:15:06.638 xcodebuild[62549:2540421] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2026-04-13 06:15:06.638 xcodebuild[62549:2540421] [MT] IDETestOperationsObserverDebug: 1.315 sec, +1.315 sec -- end
+
+Test session results, code coverage, and logs:
+	/tmp/bugnarrator-n4-tests/Logs/Test/Test-BugNarrator-2026.04.13_06-15-04--0400.xcresult
+
+** TEST SUCCEEDED **
+
+Testing started

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,35 +1,39 @@
 {
-  "last_updated": "2026-04-13T09:49:22Z",
-  "code_changes_present": false,
+  "last_updated": "2026-04-13T10:15:44Z",
+  "code_changes_present": true,
   "claims": {
-    "implementation": "not_started",
-    "validation": "not_started",
+    "implementation": "complete",
+    "validation": "complete",
     "deployment": "not_started"
   },
   "external_inputs": [],
   "evidence": {
     "build": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T09:49:22Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T10:15:44Z",
+      "reason": "Targeted macOS test build passed for the N4 annotation slice.",
+      "paths": [
+        "artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log"
+      ]
     },
     "test": {
-      "status": "not_run",
-      "updated_at": "2026-04-13T09:49:22Z",
-      "reason": "",
-      "paths": []
+      "status": "passed",
+      "updated_at": "2026-04-13T10:15:44Z",
+      "reason": "Targeted screenshot annotation and export provider tests passed.",
+      "paths": [
+        "artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log"
+      ]
     },
     "run": {
       "status": "not_run",
       "reason": "",
-      "updated_at": "2026-04-13T09:49:22Z",
+      "updated_at": "2026-04-13T10:15:44Z",
       "paths": []
     },
     "deploy": {
       "status": "not_run",
       "reason": "",
-      "updated_at": "2026-04-13T09:49:22Z",
+      "updated_at": "2026-04-13T10:15:44Z",
       "paths": []
     }
   }

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,4 +1,4 @@
 # Controller State
 
-current_state: ready_for_codex
+current_state: ready_for_review
 current_task: N4

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -3,13 +3,13 @@
 task_id: N4
 description: Smart screenshot annotation — auto-highlight relevant UI elements
 scope: Sources/BugNarrator/Services/, Sources/BugNarrator/Views/
-status: pending
-current_state: ready_for_codex
-execution_status: in_progress
-execution_branch: codex/N4-smart-screenshot-annotation-auto-highlight-relevant-ui-elements
-execution_started_at: 2026-04-13T10:03:53Z
-execution_heartbeat_at: 2026-04-13T10:03:53Z
-execution_lease_expires_at: 2026-04-13T11:33:53Z
+status: done
+current_state: ready_for_review
+execution_status: idle
+execution_branch:
+execution_started_at:
+execution_heartbeat_at:
+execution_lease_expires_at:
 execution_host_id:
 execution_worker_id:
 review_failure_count: 0

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -5,11 +5,11 @@ description: Smart screenshot annotation — auto-highlight relevant UI elements
 scope: Sources/BugNarrator/Services/, Sources/BugNarrator/Views/
 status: pending
 current_state: ready_for_codex
-execution_status: idle
-execution_branch:
-execution_started_at:
-execution_heartbeat_at:
-execution_lease_expires_at:
+execution_status: in_progress
+execution_branch: codex/N4-smart-screenshot-annotation-auto-highlight-relevant-ui-elements
+execution_started_at: 2026-04-13T10:03:53Z
+execution_heartbeat_at: 2026-04-13T10:03:53Z
+execution_lease_expires_at: 2026-04-13T11:33:53Z
 execution_host_id:
 execution_worker_id:
 review_failure_count: 0

--- a/state/handoff.json
+++ b/state/handoff.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-04-13T01:34:16Z",
-  "summary": "N2 is ready for review on codex/N2-ai-generated-reproduction-steps-from-narration-screenshots with structured reproduction-step generation, editing, and tracker export support.",
-  "next_action": "Review the N2 PR, focusing on reproduction-step quality in the review UI and exported issue payloads.",
+  "last_updated": "2026-04-13T10:15:44Z",
+  "summary": "N4 is ready for review on codex/N4-smart-screenshot-annotation-auto-highlight-relevant-ui-elements with multimodal screenshot annotation extraction, draggable review overlays, and export-side annotation support.",
+  "next_action": "Review the N4 PR, focusing on annotation payload parsing, overlay edit behavior, and exported screenshot annotation context.",
   "discovered_issues": []
 }

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,29 +1,43 @@
 # Implementation Notes
 
-task_id: N3-H1
+task_id: N4
 status: ready_for_review
 
 completed_task_ids:
-- N3-H1
+- N4
 
 CHANGED:
+- BugNarrator.xcodeproj/project.pbxproj
 - Sources/BugNarrator/Models/ExtractedIssue.swift
+- Sources/BugNarrator/Services/GitHubExportProvider.swift
 - Sources/BugNarrator/Services/IssueExtractionService.swift
+- Sources/BugNarrator/Services/JiraExportProvider.swift
+- Sources/BugNarrator/Utilities/IssueScreenshotAnnotationRenderer.swift
+- Sources/BugNarrator/Views/IssueScreenshotAnnotationPreview.swift
+- Sources/BugNarrator/Views/TranscriptView.swift
+- Tests/BugNarratorTests/GitHubExportProviderTests.swift
 - Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+- Tests/BugNarratorTests/JiraExportProviderTests.swift
+- Tests/BugNarratorTests/ScreenshotAnnotationTests.swift
+- artifacts/n4-smart-screenshot-annotation/validate.log
+- artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log
 - state/artifacts.json
 - state/controller.md
 - state/current_task.md
+- state/handoff.json
 - state/tasks.json
 - state/validation_report.md
 
 DID:
-- Pinned deduplication-hint normalization to `en_US_POSIX` so identical issue text hashes consistently across machines and user locales.
-- Moved the severity keyword lists in `IssueExtractionService` to static constants so extraction inference reuses them instead of allocating on every parse.
-- Added a regression test that exercises locale-sensitive casing and verifies the deduplication hash matches fixed-locale normalization.
+- Extended extracted issues to persist normalized screenshot annotation rectangles, labels, and confidence values.
+- Upgraded issue extraction to send screenshot images as multimodal input and parse `screenshotAnnotations` from the model response.
+- Added annotated screenshot previews with draggable highlight boxes and remove controls inside each review issue card.
+- Generated annotation details for GitHub/Jira export payloads and added an export-time renderer for annotated screenshot sidecar assets.
+- Added focused coverage for annotation parsing, export payload content, and annotation renderer output.
 
 VALIDATED:
 - ./scripts/validate.sh
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n4-tests test -only-testing:BugNarratorTests/ScreenshotAnnotationTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests
 
 NEXT:
-- Ready for PR review on the N3-H1 hardening slice.
+- Ready for PR review on the N4 screenshot-annotation slice, focusing on multimodal extraction payload shape and review overlay editing.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-13T10:00:00Z",
+  "last_updated": "2026-04-13T10:14:11Z",
   "tasks": [
     {
       "id": "N1",
@@ -27,8 +27,9 @@
     },
     {
       "id": "N4",
-      "status": "pending",
-      "title": "Smart screenshot annotation — auto-highlight relevant UI elements"
+      "status": "done",
+      "title": "Smart screenshot annotation — auto-highlight relevant UI elements",
+      "completed_at": "2026-04-13T10:14:11Z"
     }
   ]
 }

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,13 +1,13 @@
 # Validation Report
 
-task_id: N3-H1
+task_id: N4
 result: passed
-summary: Runtime guardrails plus the targeted BugNarrator extraction/export macOS tests passed for the N3-H1 locale-stability and inference-optimization slice.
+summary: Runtime guardrails plus the targeted screenshot annotation and export provider macOS tests passed for the N4 smart screenshot annotation slice.
 
 artifacts:
-- artifacts/n3-h1-hardening/validate.log
-- artifacts/n3-h1-hardening/xcodebuild-test.log
+- artifacts/n4-smart-screenshot-annotation/validate.log
+- artifacts/n4-smart-screenshot-annotation/xcodebuild-test.log
 
 commands:
 - ./scripts/validate.sh -> PASS
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n3h1-tests test -only-testing:BugNarratorTests/IssueExtractionServiceTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -> PASS
+- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n4-tests test -only-testing:BugNarratorTests/ScreenshotAnnotationTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -> PASS


### PR DESCRIPTION
## Summary
- add multimodal screenshot annotation extraction and parsed normalized annotation payloads
- add draggable annotation overlays in the review UI and export-side annotation summaries/assets
- cover the new annotation flow with targeted extraction/export/renderer tests

## Validation
- ./scripts/validate.sh
- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n4-tests test -only-testing:BugNarratorTests/ScreenshotAnnotationTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multimodal OpenAI requests and new screenshot-annotation data persisted in issues, plus new export-time file rendering; this touches core extraction/export flows and could affect payload size, performance, and export output correctness.
> 
> **Overview**
> Enables **smart screenshot annotations** by extending `ExtractedIssue` with persisted `IssueScreenshotAnnotation` rectangles (normalized 0–1 coords, optional labels/confidence) and helper APIs for per-screenshot lookups.
> 
> Updates `IssueExtractionService` to send screenshots as multimodal `image_url` parts and to parse `screenshotAnnotations` from model JSON (with alias key support), then surfaces these in the review UI via a new `IssueScreenshotAnnotationPreview` that shows draggable/removable highlight overlays.
> 
> Enhances GitHub/Jira exports to include an *Annotated Screenshots* section and optionally render annotated PNG sidecar assets (written to `annotated-exports/`) via the new `IssueScreenshotAnnotationRenderer`; adds focused unit tests and project wiring for the new functionality, plus state/validation artifact updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f41a8ad97ae9023b35afd76d779648aacc9229a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->