### PR TITLE
fix: correct .gitignore to not block required state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ site/node_modules/
 site/.docusaurus/
 site/build/
 
-state/implementation_notes.md
-state/validation_report.md
 !ai.config.json
 !state/tasks.json
 !state/risks.json
@@ -39,5 +37,7 @@ state/validation_report.md
 !ai/bootstrap.md
 !state/controller.md
 !state/current_task.md
+# Do NOT add state/implementation_notes.md or state/validation_report.md here
+# These are required pipeline files that must be tracked by git
 !state/implementation_notes.md
 !state/validation_report.md


### PR DESCRIPTION
## Summary
- Remove contradictory block/allow pattern for `state/implementation_notes.md` and `state/validation_report.md`
- The old pattern had `state/implementation_notes.md` (block) followed by `!state/implementation_notes.md` (allow) — confusing and error-prone
- Simplify to only keep the negation entries with a clear comment explaining these files must always be tracked

## Test plan
- [ ] Verify `git check-ignore state/implementation_notes.md` returns nothing (not ignored)
- [ ] Verify `git check-ignore state/validation_report.md` returns nothing (not ignored)
- [ ] Confirm pipeline validator passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)