### PR TITLE
fix: chunk long-form transcription for 1.0.23

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -609,7 +609,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.22;
+				MARKETING_VERSION = 1.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -623,7 +623,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 23;
+				CURRENT_PROJECT_VERSION = 24;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -632,7 +632,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.22;
+				MARKETING_VERSION = 1.0.23;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.23 - 2026-04-17
+
+- Fixed long-form transcription reliability by chunking extended recordings before upload, then stitching the returned transcript text and segment timestamps back together so BugNarrator no longer truncates or loops repeated sections on longer sessions.
+
 ## 1.0.22 - 2026-03-28
 
 - Preserved finished recordings when transcription cannot start because the OpenAI API key is missing, invalid, or revoked, and surfaced retry-needed sessions more clearly in the menu bar and session library so recovery is easier after relaunch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Repo Is
 
-BugNarrator is a desktop tool for narrated software testing sessions. macOS app (Swift/SwiftUI, menu bar) is production at v1.0.22. Windows app (C#/.NET 8/WPF, system tray) is in development.
+BugNarrator is a desktop tool for narrated software testing sessions. macOS app (Swift/SwiftUI, menu bar) is production at v1.0.23. Windows app (C#/.NET 8/WPF, system tray) is in development.
 
 Core workflow: `record -> review -> refine -> export`
 

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -1,3 +1,4 @@
+@preconcurrency import AVFoundation
 import Foundation
 
 struct TranscriptionRequest: Sendable {
@@ -22,10 +23,16 @@ actor TranscriptionClient: TranscriptionServing {
     private let validationEndpoint = URL(string: "https://api.openai.com/v1/models")!
     private let session: URLSession
     private let fileManager: FileManager
+    private let transcriptionChunker: any TranscriptionChunking
     private let logger = DiagnosticsLogger(category: .transcription)
 
-    init(session: URLSession? = nil, fileManager: FileManager = .default) {
+    init(
+        session: URLSession? = nil,
+        fileManager: FileManager = .default,
+        transcriptionChunker: (any TranscriptionChunking)? = nil
+    ) {
         self.fileManager = fileManager
+        self.transcriptionChunker = transcriptionChunker ?? DefaultTranscriptionChunker()
         if let session {
             self.session = session
         } else {
@@ -37,6 +44,83 @@ actor TranscriptionClient: TranscriptionServing {
     }
 
     func transcribe(fileURL: URL, apiKey: String, request: TranscriptionRequest) async throws -> TranscriptionResult {
+        try validateAudioFile(at: fileURL)
+
+        let fallbackChunk = TranscriptionAudioChunk(fileURL: fileURL, startTime: 0, isTemporary: false)
+        let chunks = await preparedChunks(for: fileURL, fallback: fallbackChunk)
+
+        if chunks.count == 1 {
+            return try await transcribeSingleFile(fileURL: fileURL, apiKey: apiKey, request: request)
+        }
+
+        logger.info(
+            "transcription_chunked_requested",
+            "Uploading chunked audio to OpenAI for transcription.",
+            metadata: [
+                "file_name": fileURL.lastPathComponent,
+                "chunk_count": "\(chunks.count)",
+                "model": request.model
+            ]
+        )
+
+        defer { cleanupTemporaryChunks(chunks) }
+
+        var transcriptParts: [String] = []
+        var adjustedSegments: [TranscriptionSegment] = []
+
+        for (index, chunk) in chunks.enumerated() {
+            logger.debug(
+                "transcription_chunk_upload",
+                "Uploading a transcription chunk to OpenAI.",
+                metadata: [
+                    "chunk_index": "\(index + 1)",
+                    "chunk_count": "\(chunks.count)",
+                    "chunk_file_name": chunk.fileURL.lastPathComponent,
+                    "chunk_start_seconds": String(format: "%.2f", chunk.startTime)
+                ]
+            )
+
+            let result = try await transcribeSingleFile(fileURL: chunk.fileURL, apiKey: apiKey, request: request)
+            transcriptParts.append(result.text.trimmingCharacters(in: .whitespacesAndNewlines))
+            adjustedSegments.append(
+                contentsOf: result.segments.map { segment in
+                    TranscriptionSegment(
+                        start: segment.start + chunk.startTime,
+                        end: segment.end + chunk.startTime,
+                        text: segment.text
+                    )
+                }
+            )
+        }
+
+        let transcript = transcriptParts
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !transcript.isEmpty else {
+            logger.warning("transcription_empty", "OpenAI returned an empty transcript after chunked transcription.")
+            throw AppError.emptyTranscript
+        }
+
+        logger.info(
+            "transcription_chunked_completed",
+            "OpenAI returned a completed transcript after chunked transcription.",
+            metadata: [
+                "character_count": "\(transcript.count)",
+                "segments_count": "\(adjustedSegments.count)",
+                "chunk_count": "\(chunks.count)"
+            ]
+        )
+
+        return TranscriptionResult(text: transcript, segments: adjustedSegments)
+    }
+
+    private func transcribeSingleFile(
+        fileURL: URL,
+        apiKey: String,
+        request: TranscriptionRequest
+    ) async throws -> TranscriptionResult {
         let urlRequest = try makeURLRequest(fileURL: fileURL, apiKey: apiKey, request: request)
         logger.info(
             "transcription_requested",
@@ -93,6 +177,28 @@ actor TranscriptionClient: TranscriptionServing {
                 (error as? AppError)?.userMessage ?? error.localizedDescription
             )
             throw OpenAIErrorMapper.mapTransportError(error, fallback: AppError.transcriptionFailure)
+        }
+    }
+
+    private func preparedChunks(
+        for fileURL: URL,
+        fallback fallbackChunk: TranscriptionAudioChunk
+    ) async -> [TranscriptionAudioChunk] {
+        do {
+            return try await transcriptionChunker.chunks(for: fileURL)
+        } catch {
+            logger.warning(
+                "transcription_chunking_unavailable",
+                "BugNarrator could not prepare transcription chunks and will fall back to a single upload.",
+                metadata: ["error": error.localizedDescription]
+            )
+            return [fallbackChunk]
+        }
+    }
+
+    private func cleanupTemporaryChunks(_ chunks: [TranscriptionAudioChunk]) {
+        for chunk in chunks where chunk.isTemporary {
+            try? fileManager.removeItem(at: chunk.fileURL)
         }
     }
 
@@ -220,6 +326,112 @@ actor TranscriptionClient: TranscriptionServing {
         default:
             return "application/octet-stream"
         }
+    }
+}
+
+struct TranscriptionAudioChunk: Sendable {
+    let fileURL: URL
+    let startTime: TimeInterval
+    let isTemporary: Bool
+}
+
+protocol TranscriptionChunking: Sendable {
+    func chunks(for fileURL: URL) async throws -> [TranscriptionAudioChunk]
+}
+
+struct DefaultTranscriptionChunker: TranscriptionChunking {
+    private let maxChunkDuration: TimeInterval
+
+    init(maxChunkDuration: TimeInterval = 8 * 60) {
+        self.maxChunkDuration = maxChunkDuration
+    }
+
+    func chunks(for fileURL: URL) async throws -> [TranscriptionAudioChunk] {
+        let asset = AVURLAsset(url: fileURL)
+        let durationTime = try await asset.load(.duration)
+        let totalDuration = CMTimeGetSeconds(durationTime)
+
+        guard totalDuration.isFinite, totalDuration > maxChunkDuration else {
+            return [TranscriptionAudioChunk(fileURL: fileURL, startTime: 0, isTemporary: false)]
+        }
+
+        var chunks: [TranscriptionAudioChunk] = []
+        var startTime: TimeInterval = 0
+
+        while startTime < totalDuration {
+            let chunkDuration = min(maxChunkDuration, totalDuration - startTime)
+            let chunkURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BugNarrator-Chunk-\(UUID().uuidString)")
+                .appendingPathExtension("m4a")
+
+            try await exportChunk(
+                from: asset,
+                startTime: startTime,
+                duration: chunkDuration,
+                outputURL: chunkURL
+            )
+
+            chunks.append(
+                TranscriptionAudioChunk(
+                    fileURL: chunkURL,
+                    startTime: startTime,
+                    isTemporary: true
+                )
+            )
+            startTime += chunkDuration
+        }
+
+        return chunks.isEmpty
+            ? [TranscriptionAudioChunk(fileURL: fileURL, startTime: 0, isTemporary: false)]
+            : chunks
+    }
+
+    private func exportChunk(
+        from asset: AVURLAsset,
+        startTime: TimeInterval,
+        duration: TimeInterval,
+        outputURL: URL
+    ) async throws {
+        try? FileManager.default.removeItem(at: outputURL)
+
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+            throw AppError.transcriptionFailure("The recorded audio could not be prepared for chunked transcription.")
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .m4a
+        exportSession.timeRange = CMTimeRange(
+            start: CMTime(seconds: startTime, preferredTimescale: 600),
+            duration: CMTime(seconds: duration, preferredTimescale: 600)
+        )
+        let exportBridge = AssetExportSessionBridge(exportSession)
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            exportBridge.session.exportAsynchronously {
+                switch exportBridge.session.status {
+                case .completed:
+                    continuation.resume()
+                case .failed:
+                    continuation.resume(throwing: exportBridge.session.error ?? AppError.transcriptionFailure("The recorded audio chunk export failed."))
+                case .cancelled:
+                    continuation.resume(throwing: AppError.transcriptionFailure("The recorded audio chunk export was cancelled."))
+                default:
+                    continuation.resume(throwing: AppError.transcriptionFailure("The recorded audio chunk export did not complete successfully."))
+                }
+            }
+        }
+
+        guard FileManager.default.fileExists(atPath: outputURL.path) else {
+            throw AppError.transcriptionFailure("The recorded audio chunk could not be created.")
+        }
+    }
+}
+
+private final class AssetExportSessionBridge: @unchecked Sendable {
+    let session: AVAssetExportSession
+
+    init(_ session: AVAssetExportSession) {
+        self.session = session
     }
 }
 

--- a/Tests/BugNarratorTests/TranscriptionClientTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionClientTests.swift
@@ -181,11 +181,79 @@ final class TranscriptionClientTests: XCTestCase {
         }
     }
 
+    func testTranscribeMergesChunkedResultsAndAdjustsSegmentTimes() async throws {
+        let originalFileURL = try makeAudioFile(named: "chunked-original", contents: "audio-data")
+        let firstChunkURL = try makeAudioFile(named: "chunk-1", contents: "chunk-one")
+        let secondChunkURL = try makeAudioFile(named: "chunk-2", contents: "chunk-two")
+        defer { try? FileManager.default.removeItem(at: originalFileURL) }
+
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestCount += 1
+
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+
+            let payload: String
+            switch requestCount {
+            case 1:
+                payload = #"{"text":"First section","segments":[{"start":0,"end":4.5,"text":"First section"}]}"#
+            case 2:
+                payload = #"{"text":"Second section","segments":[{"start":0.25,"end":3.0,"text":"Second section"}]}"#
+            default:
+                XCTFail("Unexpected extra transcription request.")
+                payload = #"{"text":"","segments":[]}"#
+            }
+
+            return (response, Data(payload.utf8))
+        }
+
+        let client = TranscriptionClient(
+            session: makeMockURLSession(),
+            transcriptionChunker: MockTranscriptionChunker(
+                chunks: [
+                    TranscriptionAudioChunk(fileURL: firstChunkURL, startTime: 0, isTemporary: true),
+                    TranscriptionAudioChunk(fileURL: secondChunkURL, startTime: 120, isTemporary: true)
+                ]
+            )
+        )
+
+        let result = try await client.transcribe(
+            fileURL: originalFileURL,
+            apiKey: "fixture-openai-key",
+            request: TranscriptionRequest(model: "whisper-1", languageHint: nil, prompt: nil)
+        )
+
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(result.text, "First section\n\nSecond section")
+        XCTAssertEqual(result.segments.map(\.text), ["First section", "Second section"])
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].start, 0, accuracy: 0.001)
+        XCTAssertEqual(result.segments[0].end, 4.5, accuracy: 0.001)
+        XCTAssertEqual(result.segments[1].start, 120.25, accuracy: 0.001)
+        XCTAssertEqual(result.segments[1].end, 123.0, accuracy: 0.001)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstChunkURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondChunkURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: originalFileURL.path))
+    }
+
     private func makeAudioFile(named name: String, contents: String) throws -> URL {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-TranscriptionTests-\(name)")
             .appendingPathExtension("m4a")
         try Data(contents.utf8).write(to: fileURL)
         return fileURL
+    }
+}
+
+private struct MockTranscriptionChunker: TranscriptionChunking {
+    let chunks: [TranscriptionAudioChunk]
+
+    func chunks(for fileURL: URL) async throws -> [TranscriptionAudioChunk] {
+        chunks
     }
 }

--- a/artifacts/release-1.0.23/accessibility.log
+++ b/artifacts/release-1.0.23/accessibility.log
@@ -1,0 +1,14 @@
+Running BugNarrator accessibility regression checks...
+ok  recording controls default action keyboard shortcut
+ok  recording controls cancel keyboard shortcut
+ok  recording toast accessibility announcement
+ok  session-library filter selected-state announcement
+ok  review workspace section heading announcement
+ok  issue export checkbox labeling
+ok  settings API key label
+ok  settings Jira issue type label
+ok  menu bar recording controls hint
+ok  menu bar microphone recovery label
+ok  hotkey recorder assignment label
+ok  hotkey recorder clear label
+Accessibility regression checks passed.

--- a/artifacts/release-1.0.23/release-smoke.log
+++ b/artifacts/release-1.0.23/release-smoke.log
@@ -1,0 +1,28 @@
+Running debug tests...
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:39:30: warning: 'SecKeychainGetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let previousStatus = SecKeychainGetUserInteractionAllowed(&previousInteractionAllowed)
+                             ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:40:29: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let disableStatus = SecKeychainSetUserInteractionAllowed(false)
+                            ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:45:21: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+                _ = SecKeychainSetUserInteractionAllowed(restoreState)
+                    ^
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+Testing started
+Running unsigned release build...
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:39:30: warning: 'SecKeychainGetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let previousStatus = SecKeychainGetUserInteractionAllowed(&previousInteractionAllowed)
+                             ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:40:29: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let disableStatus = SecKeychainSetUserInteractionAllowed(false)
+                            ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:45:21: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+                _ = SecKeychainSetUserInteractionAllowed(restoreState)
+                    ^
+Running startup keychain smoke test...
+Startup keychain smoke test passed.
+App path: /private/tmp/bugnarrator-release-work/build/DerivedData/Build/Products/Release/BugNarrator.app
+Launch log: /var/folders/8c/chgwzrz94b7gv3h1b856_q880000gn/T/bugnarrator-startup-smoke.XXXXXX.log.uEc1Rh3JR8
+Release smoke test passed.
+Release app: /private/tmp/bugnarrator-release-work/build/DerivedData/Build/Products/Release/BugNarrator.app

--- a/artifacts/release-1.0.23/transcription-tests.log
+++ b/artifacts/release-1.0.23/transcription-tests.log
@@ -1,0 +1,11 @@
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:39:30: warning: 'SecKeychainGetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let previousStatus = SecKeychainGetUserInteractionAllowed(&previousInteractionAllowed)
+                             ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:40:29: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+        let disableStatus = SecKeychainSetUserInteractionAllowed(false)
+                            ^
+/tmp/bugnarrator-release-work/Sources/BugNarrator/Services/KeychainService.swift:45:21: warning: 'SecKeychainSetUserInteractionAllowed' was deprecated in macOS 10.10: SecKeychain is deprecated
+                _ = SecKeychainSetUserInteractionAllowed(restoreState)
+                    ^
+note: Disabling hardened runtime with ad-hoc codesigning. (in target 'BugNarrator' from project 'BugNarrator')
+Testing started

--- a/artifacts/release-1.0.23/validate.log
+++ b/artifacts/release-1.0.23/validate.log
@@ -1,0 +1,6 @@
+PASS:
+- Phase build (build) satisfies the runtime contract
+- 5 non-doc code/config file(s) require evidence in this diff
+- Run profile standard
+- Execution mode strict
+- Config loaded from ai.config.json

--- a/docs/release/release-process.md
+++ b/docs/release/release-process.md
@@ -49,7 +49,7 @@ BugNarrator uses semantic versioning:
 - minor for meaningful new features
 - patch for fixes and internal hardening
 
-Current production application version is `1.0.22`.
+Current production application version is `1.0.23`.
 
 ## GitHub Workflow Scaffolding
 

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -4,7 +4,7 @@ This document is the human-readable roadmap companion to [state.json](state.json
 
 ## Current Status
 
-- current production app version: `1.0.22`
+- current production app version: `1.0.23`
 - current blocked phase: `RR-002 Windows Runtime Validation And Hardening`
 - recent completed work: added phase-branch CI coverage, explicit Windows test-project execution, fixed Windows-targeted service compile blockers, added packaged-app smoke execution, kept package artifact validation/upload in CI without claiming real Windows desktop validation, completed the hosted Node24 workflow validation slice, promoted both OPS-012 dependency remediation passes to `main`, covered the FAIL, NOT RUN, and missing-state-update guardrail rules with direct regression tests, closed the remaining Dependabot alerts, added a dedicated `Retry Needed` session-library filter for preserved-session recovery, and reconciled the repo to the latest `enterprise-ai-standards` validator and state contract
 

--- a/project.yml
+++ b/project.yml
@@ -22,8 +22,8 @@ targets:
         PRODUCT_NAME: BugNarrator
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Resources/Info.plist
-        CURRENT_PROJECT_VERSION: 23
-        MARKETING_VERSION: 1.0.22
+        CURRENT_PROJECT_VERSION: 24
+        MARKETING_VERSION: 1.0.23
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: Resources/BugNarrator.entitlements
         ENABLE_HARDENED_RUNTIME: YES

--- a/state/artifacts.json
+++ b/state/artifacts.json
@@ -1,36 +1,45 @@
 {
-  "last_updated": "2026-04-13T12:30:00Z",
-  "code_changes_present": false,
+  "last_updated": "2026-04-17T16:03:08Z",
+  "code_changes_present": true,
   "claims": {
-    "implementation": "not_started",
-    "validation": "not_started",
+    "implementation": "complete",
+    "validation": "complete",
     "deployment": "not_started"
   },
   "external_inputs": [],
   "evidence": {
     "build": {
-      "status": "not_run",
+      "status": "passed",
       "reason": "",
-      "updated_at": "2026-04-13T12:30:00Z",
-      "paths": []
+      "updated_at": "2026-04-17T16:03:08Z",
+      "paths": [
+        "artifacts/release-1.0.23/release-smoke.log"
+      ]
     },
     "test": {
-      "status": "not_run",
+      "status": "passed",
       "reason": "",
-      "updated_at": "2026-04-13T12:30:00Z",
-      "paths": []
+      "updated_at": "2026-04-17T16:03:08Z",
+      "paths": [
+        "artifacts/release-1.0.23/transcription-tests.log",
+        "artifacts/release-1.0.23/release-smoke.log"
+      ]
     },
     "run": {
-      "status": "not_run",
+      "status": "passed",
       "reason": "",
-      "updated_at": "2026-04-13T12:30:00Z",
-      "paths": []
+      "updated_at": "2026-04-17T16:03:08Z",
+      "paths": [
+        "artifacts/release-1.0.23/accessibility.log",
+        "artifacts/release-1.0.23/release-smoke.log"
+      ]
     },
     "deploy": {
       "status": "not_run",
-      "reason": "",
-      "updated_at": "2026-04-13T12:30:00Z",
-      "paths": []
+      "reason": "GitHub release publishing runs after merge from main.",
+      "updated_at": "2026-04-17T16:03:08Z",
+      "paths": [],
+      "metadata_only": true
     }
   }
 }

--- a/state/handoff.json
+++ b/state/handoff.json
@@ -1,6 +1,6 @@
 {
-  "last_updated": "2026-04-13T12:18:48Z",
-  "summary": "N5 is ready for review on codex/N5-similar-bug-detection-before-export with pre-export tracker duplicate checks, OpenAI confidence scoring, and duplicate-vs-related export decisions.",
-  "next_action": "Review the N5 PR, focusing on the similarity review sheet, GitHub/Jira search payloads, and how duplicate selections avoid filing new tickets.",
+  "last_updated": "2026-04-17T16:03:08Z",
+  "summary": "The 1.0.23 release branch fixes long-form transcription truncation by chunking extended recordings before upload and stitching the returned transcript plus segment timestamps back together.",
+  "next_action": "Run runtime guardrails, open and merge the release PR, then build and publish the 1.0.23 macOS DMG from main if notarization succeeds.",
   "discovered_issues": []
 }

--- a/state/implementation_notes.md
+++ b/state/implementation_notes.md
@@ -1,43 +1,37 @@
 # Implementation Notes
 
-task_id: N5
-status: ready_for_review
-
-completed_task_ids:
-- N5
+task_id: N6
+status: local_validation_passed
 
 CHANGED:
-- Sources/BugNarrator/AppState.swift
-- Sources/BugNarrator/Models/ExtractedIssue.swift
-- Sources/BugNarrator/Services/ExportService.swift
-- Sources/BugNarrator/Services/GitHubExportProvider.swift
-- Sources/BugNarrator/Services/JiraExportProvider.swift
-- Sources/BugNarrator/Services/ServiceProtocols.swift
-- Sources/BugNarrator/Views/TranscriptView.swift
-- Tests/BugNarratorTests/AppStateTests.swift
-- Tests/BugNarratorTests/GitHubExportProviderTests.swift
-- Tests/BugNarratorTests/IssueExtractionServiceTests.swift
-- Tests/BugNarratorTests/JiraExportProviderTests.swift
-- Tests/BugNarratorTests/TestSupport.swift
+- Sources/BugNarrator/Services/TranscriptionClient.swift
 - Tests/BugNarratorTests/TranscriptionClientTests.swift
-- artifacts/n5-similar-bug-detection/validate.log
-- artifacts/n5-similar-bug-detection/xcodebuild-test.log
+- CHANGELOG.md
+- project.yml
+- BugNarrator.xcodeproj/project.pbxproj
+- docs/release/release-process.md
+- docs/roadmap/roadmap.md
+- CLAUDE.md
+- artifacts/release-1.0.23/accessibility.log
+- artifacts/release-1.0.23/release-smoke.log
+- artifacts/release-1.0.23/transcription-tests.log
 - state/artifacts.json
-- state/controller.md
-- state/current_task.md
 - state/handoff.json
 - state/tasks.json
 - state/validation_report.md
 
 DID:
-- Added a pre-export similarity review flow that queries GitHub and Jira for open issues, asks OpenAI to score likely matches, and pauses export for a user decision when related bugs are found.
-- Introduced review models and AppState orchestration for `export as new`, `link as related`, and `mark duplicate` actions before tracker export.
-- Extended GitHub and Jira exports to include tracker-context notes for related issues and to skip duplicate ticket creation when the tester chooses an existing match.
-- Added targeted coverage for the new export review state machine, tracker search requests, OpenAI similarity matching, and request-body streaming in URLProtocol-backed tests.
+- Added chunked transcription for longer recordings so BugNarrator uploads bounded `.m4a` slices sequentially and stitches transcript text plus segment timestamps back together in order.
+- Added a regression test that verifies multi-chunk transcription merges cleanly, offsets segment timestamps correctly, and removes temporary chunk files after upload.
+- Bumped the macOS release version to 1.0.23 and added the release note entry for the transcription fix.
+
+OUT_OF_SCOPE_NOTES:
+- This branch is a release hotfix for long-form transcription reliability. It does not implement the planned N6 session intelligence summary feature.
 
 VALIDATED:
-- ./scripts/validate.sh
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n5-tests test -parallel-testing-enabled NO -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/IssueExtractionServiceTests
+- xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-transcription-fix-tests test -only-testing:BugNarratorTests/TranscriptionClientTests
+- ./scripts/accessibility_regression_check.sh
+- ./scripts/release_smoke_test.sh
 
 NEXT:
-- Ready for PR review on the N5 duplicate-detection slice, focusing on the pre-export review sheet, tracker search payloads, and duplicate-vs-related export decisions.
+- Run runtime guardrails, open the PR, merge it, then build and publish the 1.0.23 macOS DMG from main if notarization is available.

--- a/state/tasks.json
+++ b/state/tasks.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-13T12:30:00Z",
+  "last_updated": "2026-04-17T16:03:08Z",
   "tasks": [
     {
       "id": "N1",

--- a/state/validation_report.md
+++ b/state/validation_report.md
@@ -1,13 +1,15 @@
 # Validation Report
 
-task_id: N5
+task_id: N6
 result: passed
-summary: Runtime guardrails plus the targeted duplicate-detection, export provider, and similarity-review macOS tests passed for the N5 similar bug detection slice.
+summary: Local macOS validation passed for the transcription chunking hotfix and release-prep version bump.
 
 artifacts:
-- artifacts/n5-similar-bug-detection/validate.log
-- artifacts/n5-similar-bug-detection/xcodebuild-test.log
+- artifacts/release-1.0.23/accessibility.log
+- artifacts/release-1.0.23/release-smoke.log
+- artifacts/release-1.0.23/transcription-tests.log
 
 commands:
-- ./scripts/validate.sh -> PASS
-- xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-n5-tests test -parallel-testing-enabled NO -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/GitHubExportProviderTests -only-testing:BugNarratorTests/JiraExportProviderTests -only-testing:BugNarratorTests/IssueExtractionServiceTests -> PASS
+- xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-transcription-fix-tests test -only-testing:BugNarratorTests/TranscriptionClientTests -> PASS
+- ./scripts/accessibility_regression_check.sh -> PASS
+- ./scripts/release_smoke_test.sh -> PASS


### PR DESCRIPTION
## Summary
- chunk long recordings before upload and stitch transcript segments back together
- add regression coverage for multi-chunk transcription merging and timestamp offsets
- bump the macOS release metadata to 1.0.23 with local validation evidence

## Local validation
- xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/bugnarrator-transcription-fix-tests test -only-testing:BugNarratorTests/TranscriptionClientTests
- ./scripts/accessibility_regression_check.sh
- ./scripts/release_smoke_test.sh
- ./scripts/validate.sh origin/main