### PR TITLE
[codex] fix screenshot capture selection lifecycle

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -64,7 +64,7 @@ final class AppState: ObservableObject {
     private var isStoppingSession = false
     private var isCancellingSession = false
     private var isValidatingAPIKey = false
-    private var isCapturingScreenshot = false
+    @Published private(set) var isScreenshotCaptureInProgress = false
     private var toastDismissTask: Task<Void, Never>?
 
     var gitHubValidationState: APIKeyValidationState {
@@ -543,6 +543,7 @@ final class AppState: ObservableObject {
         isStoppingSession = true
         defer { isStoppingSession = false }
 
+        cancelPendingScreenshotSelection(reason: "Stopping the active session cancels pending screenshot selection.")
         stopTimer(resetElapsed: false)
         let request = makeTranscriptionRequest()
 
@@ -713,6 +714,7 @@ final class AppState: ObservableObject {
         defer { isCancellingSession = false }
 
         showDiscardConfirmation = false
+        cancelPendingScreenshotSelection(reason: "Discarding the active session cancels pending screenshot selection.")
         stopTimer(resetElapsed: true)
         endActivity()
         await audioRecorder.cancelRecording(preserveFile: settingsStore.debugMode)
@@ -771,6 +773,7 @@ final class AppState: ObservableObject {
             "BugNarrator blocked an app termination request while a recording session was still active.",
             metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
         )
+        cancelPendingScreenshotSelection(reason: "Quit was requested while recording, so pending screenshot selection was cancelled.")
         showRecordingControlWindow?()
         showToast("Stop recording before quitting BugNarrator.", style: .informational)
         return .terminateCancel
@@ -1184,7 +1187,7 @@ final class AppState: ObservableObject {
             return
         }
 
-        if isCapturingScreenshot {
+        if isScreenshotCaptureInProgress {
             let error = AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
             screenshotLogger.warning("screenshot_rejected_busy", error.userMessage)
             setStatus(.recording(error.userMessage), error: error)
@@ -1195,7 +1198,7 @@ final class AppState: ObservableObject {
         let markerIndex = recordingSession.markers.count + 1
         let elapsedTime = max(audioRecorder.currentDuration, elapsedDuration)
         let markerID = UUID()
-            let markerTitle = "Screenshot \(screenshotIndex)"
+        let markerTitle = "Screenshot \(screenshotIndex)"
 
         do {
             let screenshot = try await performScreenshotCapture(
@@ -1210,6 +1213,7 @@ final class AppState: ObservableObject {
                       activeRecordingSession?.sessionID == recordingSession.sessionID else {
                     return
                 }
+                setStatus(.recording(recordingDetailMessage()))
                 showToast("Screenshot canceled", style: .informational)
                 return
             }
@@ -2132,12 +2136,12 @@ final class AppState: ObservableObject {
         elapsedTime: TimeInterval,
         associatedMarkerID: UUID?
     ) async throws -> SessionScreenshot? {
-        guard !isCapturingScreenshot else {
+        guard !isScreenshotCaptureInProgress else {
             throw AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
         }
 
-        isCapturingScreenshot = true
-        defer { isCapturingScreenshot = false }
+        isScreenshotCaptureInProgress = true
+        defer { isScreenshotCaptureInProgress = false }
 
         let preflightResult = await screenCapturePermissionService.preflightForScreenshotCapture(
             screenshotCaptureService: screenshotCaptureService,
@@ -2147,6 +2151,7 @@ final class AppState: ObservableObject {
             throw preflightError
         }
 
+        setStatus(.recording("Drag to select a screenshot region. Press Esc to cancel."))
         prepareForScreenshotSelection?()
         defer {
             restoreAfterScreenshotSelection?()
@@ -2182,6 +2187,15 @@ final class AppState: ObservableObject {
             filePath: screenshotURL.path,
             associatedMarkerID: associatedMarkerID
         )
+    }
+
+    private func cancelPendingScreenshotSelection(reason: String) {
+        guard isScreenshotCaptureInProgress else {
+            return
+        }
+
+        screenshotLogger.info("screenshot_selection_cancel_requested", reason)
+        screenshotSelectionService.cancelActiveSelection()
     }
 
     private func showToast(_ message: String, style: TransientToastStyle = .success) {

--- a/Sources/BugNarrator/Services/ScreenshotSelectionService.swift
+++ b/Sources/BugNarrator/Services/ScreenshotSelectionService.swift
@@ -63,12 +63,22 @@ final class ScreenshotSelectionService: ScreenshotSelecting {
 
         return result
     }
+
+    func cancelActiveSelection() {
+        overlayController?.cancelSelection()
+    }
 }
 
 @MainActor
 private final class ScreenshotSelectionOverlayController {
+    private static let selectionTimeoutNanoseconds: UInt64 = 30_000_000_000
+
     private let window: ScreenshotSelectionOverlayWindow
     private let overlayView: ScreenshotSelectionOverlayView
+    private var continuation: CheckedContinuation<ScreenshotSelectionResult, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var hasFinished = false
+    private var didPushCursor = false
 
     init() throws {
         let overlayFrame = NSScreen.screens
@@ -96,39 +106,86 @@ private final class ScreenshotSelectionOverlayController {
         window.level = .screenSaver
         window.ignoresMouseEvents = false
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        window.onResignedKey = { [weak self] in
+            self?.cancelSelection()
+        }
     }
 
     func presentSelectionOverlay() async -> ScreenshotSelectionResult {
         await withCheckedContinuation { continuation in
+            self.continuation = continuation
             overlayView.onSelectionCompleted = { [weak self] rect in
-                self?.finish()
-                continuation.resume(returning: .selected(rect.offsetBy(
-                    dx: self?.window.frame.minX ?? 0,
-                    dy: self?.window.frame.minY ?? 0
+                guard let self else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+
+                self.complete(.selected(rect.offsetBy(
+                    dx: self.window.frame.minX,
+                    dy: self.window.frame.minY
                 )))
             }
 
             overlayView.onSelectionCancelled = { [weak self] in
-                self?.finish()
-                continuation.resume(returning: .cancelled)
+                self?.cancelSelection()
             }
 
             NSCursor.crosshair.push()
+            didPushCursor = true
             window.makeKeyAndOrderFront(nil)
             window.makeFirstResponder(overlayView)
             NSApp.activate(ignoringOtherApps: true)
+            timeoutTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: Self.selectionTimeoutNanoseconds)
+                guard !Task.isCancelled else {
+                    return
+                }
+
+                self?.cancelSelection()
+            }
         }
     }
 
-    private func finish() {
+    func cancelSelection() {
+        complete(.cancelled)
+    }
+
+    private func complete(_ result: ScreenshotSelectionResult) {
+        guard !hasFinished else {
+            return
+        }
+
+        hasFinished = true
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        overlayView.onSelectionCompleted = nil
+        overlayView.onSelectionCancelled = nil
+        finishPresentation()
+
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume(returning: result)
+    }
+
+    private func finishPresentation() {
         window.orderOut(nil)
-        NSCursor.pop()
+        if didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
+        }
     }
 }
 
 private final class ScreenshotSelectionOverlayWindow: NSWindow {
+    var onResignedKey: (() -> Void)?
+
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
+
+    override func resignKey() {
+        super.resignKey()
+        onResignedKey?()
+    }
 }
 
 private final class ScreenshotSelectionOverlayView: NSView {
@@ -138,6 +195,7 @@ private final class ScreenshotSelectionOverlayView: NSView {
     private let overlayCornerRadius: CGFloat = 8
     private var dragStartPoint: CGPoint?
     private var currentSelectionRect: CGRect?
+    private var hasCompletedSelection = false
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -165,13 +223,17 @@ private final class ScreenshotSelectionOverlayView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        guard !hasCompletedSelection else {
+            return
+        }
+
         dragStartPoint = convert(event.locationInWindow, from: nil)
         currentSelectionRect = nil
         needsDisplay = true
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let dragStartPoint else {
+        guard !hasCompletedSelection, let dragStartPoint else {
             return
         }
 
@@ -185,8 +247,12 @@ private final class ScreenshotSelectionOverlayView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        guard !hasCompletedSelection else {
+            return
+        }
+
         guard let dragStartPoint else {
-            onSelectionCancelled?()
+            completeSelection(with: nil)
             return
         }
 
@@ -200,18 +266,18 @@ private final class ScreenshotSelectionOverlayView: NSView {
         currentSelectionRect = nil
         needsDisplay = true
 
-        if let selectedRect {
-            onSelectionCompleted?(selectedRect)
-        } else {
-            onSelectionCancelled?()
-        }
+        completeSelection(with: selectedRect)
     }
 
     override func cancelOperation(_ sender: Any?) {
+        guard !hasCompletedSelection else {
+            return
+        }
+
         dragStartPoint = nil
         currentSelectionRect = nil
         needsDisplay = true
-        onSelectionCancelled?()
+        completeSelection(with: nil)
     }
 
     override func keyDown(with event: NSEvent) {
@@ -225,6 +291,19 @@ private final class ScreenshotSelectionOverlayView: NSView {
 
     override func resetCursorRects() {
         addCursorRect(bounds, cursor: .crosshair)
+    }
+
+    private func completeSelection(with rect: CGRect?) {
+        guard !hasCompletedSelection else {
+            return
+        }
+
+        hasCompletedSelection = true
+        if let rect {
+            onSelectionCompleted?(rect)
+        } else {
+            onSelectionCancelled?()
+        }
     }
 
     private func drawInstructionHint() {

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -147,6 +147,7 @@ protocol ScreenshotCapturing {
 @MainActor
 protocol ScreenshotSelecting {
     func selectRegion() async throws -> ScreenshotSelectionResult
+    func cancelActiveSelection()
 }
 
 protocol IssueExtracting: Sendable {

--- a/Sources/BugNarrator/Utilities/AppBootstrap.swift
+++ b/Sources/BugNarrator/Utilities/AppBootstrap.swift
@@ -330,6 +330,8 @@ private final class UITestScreenshotSelectionService: ScreenshotSelecting {
     func selectRegion() async throws -> ScreenshotSelectionResult {
         .selected(CGRect(x: 10, y: 10, width: 120, height: 80))
     }
+
+    func cancelActiveSelection() {}
 }
 
 private final class UITestScreenshotCaptureService: ScreenshotCapturing {

--- a/Sources/BugNarrator/Views/RecordingControlPanelView.swift
+++ b/Sources/BugNarrator/Views/RecordingControlPanelView.swift
@@ -182,7 +182,7 @@ struct RecordingControlPanelView: View {
     }
 
     private var canUseLiveControls: Bool {
-        appState.status.phase == .recording
+        appState.status.phase == .recording && !appState.isScreenshotCaptureInProgress
     }
 
     private var statusHeadline: String {

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -1238,6 +1238,64 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.transientToast?.message, "Screenshot canceled")
     }
 
+    func testCancelSessionCancelsPendingScreenshotSelectionAndClearsBusyState() async {
+        let selectionStarted = expectation(description: "screenshot selection started")
+        let selectionService = MockScreenshotSelectionService()
+        selectionService.suspendUntilCancelled = true
+        selectionService.onSelectRegionStart = {
+            selectionStarted.fulfill()
+        }
+        let harness = AppStateHarness(screenshotSelectionService: selectionService)
+        defer { harness.cleanup() }
+
+        await harness.appState.startSession()
+
+        async let capture: Void = harness.appState.captureScreenshot()
+        await fulfillment(of: [selectionStarted], timeout: 1.0)
+
+        XCTAssertTrue(harness.appState.isScreenshotCaptureInProgress)
+
+        await harness.appState.cancelSession()
+        _ = await capture
+
+        XCTAssertEqual(selectionService.cancelActiveSelectionCallCount, 1)
+        XCTAssertFalse(harness.appState.isScreenshotCaptureInProgress)
+        XCTAssertEqual(harness.appState.status.phase, .idle)
+        XCTAssertNil(harness.appState.activeRecordingSession)
+    }
+
+    func testStopSessionCancelsPendingScreenshotSelectionAndClearsBusyState() async throws {
+        let selectionStarted = expectation(description: "screenshot selection started")
+        let selectionService = MockScreenshotSelectionService()
+        selectionService.suspendUntilCancelled = true
+        selectionService.onSelectRegionStart = {
+            selectionStarted.fulfill()
+        }
+        let harness = AppStateHarness(screenshotSelectionService: selectionService)
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "stopped-with-pending-screenshot")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        await harness.transcriptionClient.enqueue(
+            .success(TranscriptionResult(text: "Stopped while screenshot selection was open.", segments: []))
+        )
+
+        await harness.appState.startSession()
+
+        async let capture: Void = harness.appState.captureScreenshot()
+        await fulfillment(of: [selectionStarted], timeout: 1.0)
+
+        XCTAssertTrue(harness.appState.isScreenshotCaptureInProgress)
+
+        await harness.appState.stopSession()
+        _ = await capture
+
+        XCTAssertEqual(selectionService.cancelActiveSelectionCallCount, 1)
+        XCTAssertFalse(harness.appState.isScreenshotCaptureInProgress)
+        XCTAssertEqual(harness.appState.status.phase, .success)
+        XCTAssertNil(harness.appState.activeRecordingSession)
+    }
+
     func testCaptureScreenshotFailureKeepsRecordingAndShowsMessage() async {
         let harness = AppStateHarness(
             screenshotCaptureService: MockScreenshotCaptureService(

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -201,16 +201,33 @@ final class MockScreenshotCaptureService: ScreenshotCapturing {
 final class MockScreenshotSelectionService: ScreenshotSelecting {
     var nextResult: ScreenshotSelectionResult = .selected(CGRect(x: 20, y: 20, width: 120, height: 80))
     var error: Error?
+    var suspendUntilCancelled = false
+    var onSelectRegionStart: (() -> Void)?
     private(set) var selectRegionCallCount = 0
+    private(set) var cancelActiveSelectionCallCount = 0
+    private var selectionContinuation: CheckedContinuation<ScreenshotSelectionResult, Error>?
 
     func selectRegion() async throws -> ScreenshotSelectionResult {
         selectRegionCallCount += 1
+        onSelectRegionStart?()
 
         if let error {
             throw error
         }
 
+        if suspendUntilCancelled {
+            return try await withCheckedThrowingContinuation { continuation in
+                selectionContinuation = continuation
+            }
+        }
+
         return nextResult
+    }
+
+    func cancelActiveSelection() {
+        cancelActiveSelectionCallCount += 1
+        selectionContinuation?.resume(returning: .cancelled)
+        selectionContinuation = nil
     }
 }
 


### PR DESCRIPTION
## Summary
- add cancellable screenshot region selection with timeout and one-shot completion
- clear screenshot busy state when stopping, discarding, or blocking quit during an active selection
- disable live recording controls while screenshot capture is in progress
- add AppState regression coverage for stop/cancel while selection is pending

## Root cause
The selection overlay could remain active without completing or cancelling, leaving later screenshot attempts rejected as busy. Diagnostics showed `screenshot_selection_started` without a matching completion/cancel event, followed by `screenshot_rejected_busy`.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO test -only-testing:BugNarratorTests` passed: 243 tests, 0 failures.
- `.ai/validate.sh` passed.
- Full scheme test previously ran unit tests successfully, but the `BugNarratorUITests-Runner` hung before establishing its XCTest connection; evidence retained under `.ai/artifacts/TASK-001/`.
