### PR TITLE
Release 1.0.33: resilience hardening and DMG stapling fix

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -740,7 +740,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -749,7 +749,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.32;
+				MARKETING_VERSION = 1.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -763,7 +763,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 34;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -772,7 +772,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.32;
+				MARKETING_VERSION = 1.0.33;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.0.33 - 2026-05-06
+
+- Added concurrent retry guard to prevent duplicate transcription retry attempts from compounding failures.
+- Added retry attempt counting to preserved sessions so repeated failures surface clearer guidance instead of silently accepting infinite retries.
+- Added exponential backoff with Retry-After header support for OpenAI 429 rate-limit responses in the transcription client.
+- Fixed DMG packaging to staple the notarization ticket to the app bundle before packaging, so users who drag BugNarrator out of the DMG get an app that passes Gatekeeper even offline. Previously only the DMG carried the stapled ticket, which caused "BugNarrator is damaged" alerts when the online notarization check failed or timed out.
+
 ## 1.0.32 - 2026-04-29
 
 - Hardened screenshot region capture so an abandoned selection cannot leave future screenshot attempts stuck in a busy state, and stopping or discarding a recording now cancels any pending screenshot selection cleanly.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -18,6 +18,7 @@ final class AppState: ObservableObject {
     @Published private(set) var exportHistory: [ExportReceipt] = []
     @Published private(set) var recoveredRecordingImportCount = 0
     @Published private(set) var apiKeyValidationState: APIKeyValidationState = .idle
+    @Published private(set) var retryingSessionID: UUID?
 
     let settingsStore: SettingsStore
     let transcriptStore: TranscriptStore
@@ -971,6 +972,18 @@ final class AppState: ObservableObject {
             return
         }
 
+        guard retryingSessionID == nil else {
+            transcriptionLogger.warning(
+                "transcription_retry_already_in_progress",
+                "Ignoring duplicate retry request while a retry is already in progress.",
+                metadata: [
+                    "requested_session_id": sessionID.uuidString,
+                    "active_retry_session_id": retryingSessionID?.uuidString ?? "unknown"
+                ]
+            )
+            return
+        }
+
         guard var session = sessionSnapshot(with: sessionID),
               let pendingTranscription = session.pendingTranscription,
               let audioFileURL = session.pendingTranscriptionAudioURL else {
@@ -992,6 +1005,7 @@ final class AppState: ObservableObject {
         }
 
         let request = makeTranscriptionRequest()
+        retryingSessionID = sessionID
         selectedTranscriptID = session.id
         currentTranscript = session
         setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
@@ -1001,7 +1015,8 @@ final class AppState: ObservableObject {
             "Retrying transcription from preserved audio.",
             metadata: [
                 "session_id": session.id.uuidString,
-                "failure_reason": pendingTranscription.failureReason.rawValue
+                "failure_reason": pendingTranscription.failureReason.rawValue,
+                "attempt_count": "\(pendingTranscription.attemptCount + 1)"
             ]
         )
 
@@ -1059,6 +1074,7 @@ final class AppState: ObservableObject {
                     try persistUpdatedSession(updatedSession)
                 } catch {
                     cleanupPreservedRetryAudioIfNeeded(at: audioFileURL)
+                    retryingSessionID = nil
                     endActivity()
                     issueExtractionSessionID = nil
                     presentPostTranscriptionError(error)
@@ -1069,6 +1085,7 @@ final class AppState: ObservableObject {
             }
 
             cleanupPreservedRetryAudioIfNeeded(at: audioFileURL)
+            retryingSessionID = nil
             showTranscriptWindow?()
             endActivity()
             setStatus(.success(
@@ -1083,7 +1100,8 @@ final class AppState: ObservableObject {
                 session.pendingTranscription = PendingTranscription(
                     audioFileName: pendingTranscription.audioFileName,
                     failureReason: failureReason,
-                    preservedAt: pendingTranscription.preservedAt
+                    preservedAt: pendingTranscription.preservedAt,
+                    attemptCount: pendingTranscription.attemptCount + 1
                 )
 
                 do {
@@ -1093,17 +1111,23 @@ final class AppState: ObservableObject {
                     selectedTranscriptID = session.id
                 }
 
+                retryingSessionID = nil
                 endActivity()
                 let appError = failureReason.appError
                 logAppError(appError, context: "retry_pending_transcription")
+
+                let attemptMessage = pendingTranscription.attemptCount >= 2
+                    ? " This session has been retried \(pendingTranscription.attemptCount + 1) times."
+                    : ""
                 setStatus(.error(
-                    session.transcriptionRecoveryMessage ?? appError.userMessage
+                    (session.transcriptionRecoveryMessage ?? appError.userMessage) + attemptMessage
                 ), error: appError)
                 showTranscriptWindow?()
                 showSettingsWindow?()
                 return
             }
 
+            retryingSessionID = nil
             presentError(error)
         }
     }
@@ -2221,7 +2245,7 @@ final class AppState: ObservableObject {
             settingsLogger.warning("app_error", error.userMessage, metadata: metadata)
         case .recordingFailure:
             recordingLogger.error("app_error", error.userMessage, metadata: metadata)
-        case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure:
+        case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure, .rateLimited:
             transcriptionLogger.error("app_error", error.userMessage, metadata: metadata)
         case .screenshotCaptureFailure:
             screenshotLogger.error("app_error", error.userMessage, metadata: metadata)

--- a/Sources/BugNarrator/Models/AppError.swift
+++ b/Sources/BugNarrator/Models/AppError.swift
@@ -17,6 +17,7 @@ enum AppError: LocalizedError, Equatable {
     case emptyTranscript
     case networkTimeout
     case networkFailure
+    case rateLimited(retryAfter: TimeInterval?)
     case exportConfigurationMissing(String)
     case exportFailure(String)
     case storageFailure(String)
@@ -56,6 +57,11 @@ enum AppError: LocalizedError, Equatable {
             return "The request to OpenAI timed out. Check your connection and try again."
         case .networkFailure:
             return "BugNarrator could not reach OpenAI. Check your internet connection and try again."
+        case .rateLimited(let retryAfter):
+            if let retryAfter {
+                return "OpenAI rate limit reached. Try again in \(Int(retryAfter)) seconds."
+            }
+            return "OpenAI rate limit reached. Wait a moment and try again."
         case .exportConfigurationMissing(let message):
             return "Export setup is incomplete: \(message)"
         case .exportFailure(let message):
@@ -89,7 +95,7 @@ enum AppError: LocalizedError, Equatable {
             return "Screenshot Failed"
         case .issueExtractionFailure:
             return "Issue Extraction Failed"
-        case .networkTimeout, .networkFailure:
+        case .networkTimeout, .networkFailure, .rateLimited:
             return "Network Issue"
         case .exportConfigurationMissing:
             return "Export Setup Needed"
@@ -118,7 +124,7 @@ enum AppError: LocalizedError, Equatable {
             return "Add your OpenAI API key before continuing."
         case .invalidAPIKey, .revokedAPIKey:
             return "Replace your OpenAI API key before continuing."
-        case .networkTimeout, .networkFailure:
+        case .networkTimeout, .networkFailure, .rateLimited:
             return "BugNarrator could not reach OpenAI."
         case .exportConfigurationMissing:
             return "Finish export setup before continuing."

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -51,17 +51,29 @@ struct PendingTranscription: Codable, Equatable {
     var failureReason: PendingTranscriptionFailureReason
     var preservedAt: Date
     var recoveredSourceFileName: String?
+    var attemptCount: Int
 
     init(
         audioFileName: String,
         failureReason: PendingTranscriptionFailureReason,
         preservedAt: Date,
-        recoveredSourceFileName: String? = nil
+        recoveredSourceFileName: String? = nil,
+        attemptCount: Int = 0
     ) {
         self.audioFileName = audioFileName
         self.failureReason = failureReason
         self.preservedAt = preservedAt
         self.recoveredSourceFileName = recoveredSourceFileName
+        self.attemptCount = attemptCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        audioFileName = try container.decode(String.self, forKey: .audioFileName)
+        failureReason = try container.decode(PendingTranscriptionFailureReason.self, forKey: .failureReason)
+        preservedAt = try container.decode(Date.self, forKey: .preservedAt)
+        recoveredSourceFileName = try container.decodeIfPresent(String.self, forKey: .recoveredSourceFileName)
+        attemptCount = try container.decodeIfPresent(Int.self, forKey: .attemptCount) ?? 0
     }
 }
 

--- a/Sources/BugNarrator/Services/OpenAIErrorMapper.swift
+++ b/Sources/BugNarrator/Services/OpenAIErrorMapper.swift
@@ -4,7 +4,8 @@ enum OpenAIErrorMapper {
     static func mapResponse(
         statusCode: Int,
         data: Data,
-        fallback: (String) -> AppError
+        fallback: (String) -> AppError,
+        responseHeaders: [AnyHashable: Any]? = nil
     ) -> AppError {
         let message = decodeAPIError(from: data) ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
         let normalizedMessage = message.lowercased()
@@ -22,11 +23,23 @@ enum OpenAIErrorMapper {
             return .revokedAPIKey
         }
 
+        if statusCode == 429 {
+            let retryAfter = parseRetryAfter(from: responseHeaders)
+            return .rateLimited(retryAfter: retryAfter)
+        }
+
         if (400...499).contains(statusCode) {
             return .openAIRequestRejected(message)
         }
 
         return fallback(message)
+    }
+
+    private static func parseRetryAfter(from headers: [AnyHashable: Any]?) -> TimeInterval? {
+        guard let retryValue = headers?["Retry-After"] as? String ?? headers?["retry-after"] as? String else {
+            return nil
+        }
+        return TimeInterval(retryValue)
     }
 
     static func mapTransportError(_ error: Error, fallback: (String) -> AppError) -> AppError {

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -157,22 +157,63 @@ actor TranscriptionClient: TranscriptionServing {
         )
     }
 
+    private static let maxRetryAttempts = 3
+    private static let initialBackoffSeconds: TimeInterval = 2
+
     private func transcribeSingleFile(
         fileURL: URL,
         apiKey: String,
         request: TranscriptionRequest
     ) async throws -> TranscriptionResult {
+        var lastError: Error?
+
+        for attempt in 0..<Self.maxRetryAttempts {
+            do {
+                return try await attemptTranscription(fileURL: fileURL, apiKey: apiKey, request: request, attempt: attempt)
+            } catch let error as AppError {
+                if case .rateLimited(let retryAfter) = error, attempt < Self.maxRetryAttempts - 1 {
+                    let delay = retryAfter ?? (Self.initialBackoffSeconds * pow(2, Double(attempt)))
+                    let clampedDelay = min(delay, 60)
+                    logger.warning(
+                        "transcription_rate_limited_retrying",
+                        "OpenAI rate limit hit. Backing off before retry.",
+                        metadata: [
+                            "attempt": "\(attempt + 1)",
+                            "backoff_seconds": String(format: "%.1f", clampedDelay)
+                        ]
+                    )
+                    try await Task.sleep(nanoseconds: UInt64(clampedDelay * 1_000_000_000))
+                    lastError = error
+                    continue
+                }
+                throw error
+            } catch {
+                throw error
+            }
+        }
+
+        throw lastError ?? AppError.transcriptionFailure("Transcription failed after retries.")
+    }
+
+    private func attemptTranscription(
+        fileURL: URL,
+        apiKey: String,
+        request: TranscriptionRequest,
+        attempt: Int
+    ) async throws -> TranscriptionResult {
         let urlRequest = try makeURLRequest(fileURL: fileURL, apiKey: apiKey, request: request)
-        logger.info(
-            "transcription_requested",
-            "Uploading audio to OpenAI for transcription.",
-            metadata: [
-                "file_name": fileURL.lastPathComponent,
-                "model": request.model,
-                "has_language_hint": request.languageHint == nil ? "no" : "yes",
-                "has_prompt": request.prompt == nil ? "no" : "yes"
-            ]
-        )
+        if attempt == 0 {
+            logger.info(
+                "transcription_requested",
+                "Uploading audio to OpenAI for transcription.",
+                metadata: [
+                    "file_name": fileURL.lastPathComponent,
+                    "model": request.model,
+                    "has_language_hint": request.languageHint == nil ? "no" : "yes",
+                    "has_prompt": request.prompt == nil ? "no" : "yes"
+                ]
+            )
+        }
 
         do {
             let (data, response) = try await session.data(for: urlRequest)
@@ -191,7 +232,8 @@ actor TranscriptionClient: TranscriptionServing {
                 throw OpenAIErrorMapper.mapResponse(
                     statusCode: httpResponse.statusCode,
                     data: data,
-                    fallback: AppError.transcriptionFailure
+                    fallback: AppError.transcriptionFailure,
+                    responseHeaders: httpResponse.allHeaderFields
                 )
             }
 

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -2044,4 +2044,91 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.status.phase, .success)
         XCTAssertNil(harness.appState.activeRecordingSession)
     }
+
+    // MARK: - Concurrent Retry Guard
+
+    func testRetryPendingTranscriptionClearsRetryingSessionIDOnSuccess() async throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "retry-guard-success")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+
+        await harness.appState.startSession()
+        harness.settingsStore.removeAPIKey()
+        await harness.appState.stopSession()
+
+        let preservedSession = try XCTUnwrap(harness.transcriptStore.sessions.first)
+
+        harness.settingsStore.apiKey = "restored-key"
+        await harness.transcriptionClient.enqueue(
+            .success(TranscriptionResult(text: "Recovered", segments: []))
+        )
+
+        XCTAssertNil(harness.appState.retryingSessionID)
+        await harness.appState.retryPendingTranscription(for: preservedSession.id)
+        XCTAssertNil(harness.appState.retryingSessionID)
+    }
+
+    func testRetryPendingTranscriptionClearsRetryingSessionIDOnFailure() async throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "retry-guard-failure")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+
+        await harness.appState.startSession()
+        harness.settingsStore.removeAPIKey()
+        await harness.appState.stopSession()
+
+        let preservedSession = try XCTUnwrap(harness.transcriptStore.sessions.first)
+
+        harness.settingsStore.apiKey = "restored-key"
+        await harness.transcriptionClient.enqueue(
+            .failure(AppError.invalidAPIKey)
+        )
+
+        await harness.appState.retryPendingTranscription(for: preservedSession.id)
+        XCTAssertNil(harness.appState.retryingSessionID)
+    }
+
+    // MARK: - Attempt Counting
+
+    func testRetryPendingTranscriptionIncrementsAttemptCount() async throws {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "retry-attempt-count")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+
+        await harness.appState.startSession()
+        harness.settingsStore.removeAPIKey()
+        await harness.appState.stopSession()
+
+        let preservedSession = try XCTUnwrap(harness.transcriptStore.sessions.first)
+        XCTAssertEqual(preservedSession.pendingTranscription?.attemptCount, 0)
+
+        harness.settingsStore.apiKey = "restored-key"
+        await harness.transcriptionClient.enqueue(
+            .failure(AppError.invalidAPIKey)
+        )
+
+        await harness.appState.retryPendingTranscription(for: preservedSession.id)
+
+        let updatedSession = try XCTUnwrap(harness.transcriptStore.session(with: preservedSession.id))
+        XCTAssertEqual(updatedSession.pendingTranscription?.attemptCount, 1)
+    }
+
+    func testPendingTranscriptionAttemptCountDefaultsToZeroForLegacyData() throws {
+        let json = """
+        {
+            "audioFileName": "test.m4a",
+            "failureReason": "missingAPIKey",
+            "preservedAt": 0
+        }
+        """
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(PendingTranscription.self, from: data)
+        XCTAssertEqual(decoded.attemptCount, 0)
+    }
 }

--- a/Tests/BugNarratorTests/TranscriptionClientTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionClientTests.swift
@@ -397,6 +397,44 @@ final class TranscriptionClientTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: chunkURL.path))
     }
 
+    func testTranscribeMapsRateLimitResponse() async throws {
+        let fileURL = try makeAudioFile(named: "rate-limited", contents: "audio-data")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        var requestCount = 0
+        MockURLProtocol.requestHandler = { request in
+            requestCount += 1
+            let headers = ["Retry-After": "1"]
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 429,
+                httpVersion: nil,
+                headerFields: headers
+            )!
+            let data = Data(#"{"error":{"message":"Rate limit exceeded."}}"#.utf8)
+            return (response, data)
+        }
+
+        let client = TranscriptionClient(session: makeMockURLSession())
+
+        do {
+            _ = try await client.transcribe(
+                fileURL: fileURL,
+                apiKey: "fixture-openai-key",
+                request: TranscriptionRequest(model: "whisper-1", languageHint: nil, prompt: nil)
+            )
+            XCTFail("Expected a rate limit error.")
+        } catch let error as AppError {
+            guard case .rateLimited(let retryAfter) = error else {
+                XCTFail("Unexpected app error: \(error)")
+                return
+            }
+            XCTAssertEqual(retryAfter, 1)
+        }
+
+        XCTAssertGreaterThan(requestCount, 1, "Expected at least one retry before giving up.")
+    }
+
     private func makeAudioFile(named name: String, contents: String) throws -> URL {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-TranscriptionTests-\(name)")

--- a/project.yml
+++ b/project.yml
@@ -22,8 +22,8 @@ targets:
         PRODUCT_NAME: BugNarrator
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Resources/Info.plist
-        CURRENT_PROJECT_VERSION: 33
-        MARKETING_VERSION: 1.0.32
+        CURRENT_PROJECT_VERSION: 34
+        MARKETING_VERSION: 1.0.33
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS: Resources/BugNarrator.entitlements
         ENABLE_HARDENED_RUNTIME: YES

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -479,6 +479,44 @@ if [[ "$NOTARIZE" == "YES" ]]; then
     fi
 
     printf '%s\n' "$notarize_output"
+
+    # Staple the notarization ticket to the .app before rebuilding the DMG.
+    # Without this, users who drag BugNarrator.app out of the DMG get an app
+    # without a stapled ticket. Gatekeeper then requires an online check and
+    # shows a "damaged" alert when the check fails or times out.
+    echo "Stapling notarization ticket to the app bundle..."
+    xcrun stapler staple -v "$APP_PATH"
+    xcrun stapler validate "$APP_PATH"
+
+    # Rebuild the DMG with the now-stapled .app inside it.
+    echo "Rebuilding DMG with stapled app bundle..."
+    rm -f "$VERSIONED_DMG_PATH"
+
+    mkdir -p "$STAGING_BACKGROUND_DIR"
+    swift "$BACKGROUND_RENDER_SCRIPT" "$STAGING_BACKGROUND_PATH"
+
+    "$DMGBUILD_PYTHON_BIN" -m dmgbuild \
+        -s "$DMGBUILD_SETTINGS_PATH" \
+        -D "app_path=$APP_PATH" \
+        -D "background_path=$STAGING_BACKGROUND_PATH" \
+        -D "volume_icon_path=$APP_ICON_ICNS_PATH" \
+        -D "window_left=$DMG_WINDOW_LEFT" \
+        -D "window_top=$DMG_WINDOW_TOP" \
+        -D "window_width=$DMG_WINDOW_WIDTH" \
+        -D "window_height=$DMG_WINDOW_HEIGHT" \
+        -D "icon_size=$DMG_ICON_SIZE" \
+        -D "text_size=$DMG_TEXT_SIZE" \
+        -D "app_icon_x=$DMG_APP_ICON_X" \
+        -D "app_icon_y=$DMG_APP_ICON_Y" \
+        -D "applications_icon_x=$DMG_APPLICATIONS_ICON_X" \
+        -D "applications_icon_y=$DMG_APPLICATIONS_ICON_Y" \
+        "$VOLUME_NAME" \
+        "$VERSIONED_DMG_PATH"
+
+    rm -rf "$STAGING_DIR"
+
+    # Staple the DMG itself as well so both layers carry the ticket.
+    echo "Stapling notarization ticket to the DMG..."
     xcrun stapler staple -v "$VERSIONED_DMG_PATH"
     xcrun stapler validate "$VERSIONED_DMG_PATH"
     if ! dmg_spctl_output="$(spctl -a -vv -t open "$VERSIONED_DMG_PATH" 2>&1)"; then


### PR DESCRIPTION
## Summary

- Adds concurrent retry guard (`retryingSessionID`) to prevent duplicate transcription retry attempts
- Adds `attemptCount` to `PendingTranscription` with escalating user messaging after repeated failures
- Adds exponential backoff with `Retry-After` header parsing for OpenAI 429 rate-limit responses
- Adds `AppError.rateLimited` case with proper error mapping through `OpenAIErrorMapper`
- **Fixes "BugNarrator is damaged" Gatekeeper alert** by stapling the notarization ticket to the `.app` bundle before packaging into the DMG, then rebuilding and re-stapling the DMG

## Test plan

- [x] 248 unit tests pass, 0 failures
- [x] 5 new tests covering retry guard, attempt counting, legacy data decoding, and 429 backoff
- [x] `build_dmg.sh` syntax validated
- [ ] Signed release workflow builds notarized DMG with stapled `.app` inside
- [ ] Downloaded DMG installs without "damaged" alert on a clean Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)