### PR TITLE
[codex] add system audio recording modes

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09CA463A8DF59221937A2C7 /* TranscriptView.swift */; };
 		2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */; };
 		2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */; };
+		30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */; };
 		334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554387017B49D9CD63967BE3 /* AppStateTests.swift */; };
 		33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800BFCC6407B534886C65D77 /* TranscriptionClient.swift */; };
 		3426E7C93FFCC254F7016A99 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F03E1852A3D56F888E98739E /* Assets.xcassets */; };
@@ -68,7 +69,9 @@
 		7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
+		79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */; };
 		7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3104282993DE974208688237 /* TranscriptQualityFinding.swift */; };
+		7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */; };
 		7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
 		821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */; };
@@ -101,6 +104,7 @@
 		B3F726638452CBD7F5A4DC16 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */; };
 		B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A663ED1B160E290FCFAC3AED /* ClipboardService.swift */; };
 		B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */; };
+		BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */; };
 		C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB2CC94CABCD51955891BF /* AppStatus.swift */; };
 		C4DEF637FA4D2980FA55A9C9 /* APIKeyValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084D11633172FCB62C674D40 /* APIKeyValidationState.swift */; };
 		C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */; };
@@ -118,6 +122,7 @@
 		EB26330B3289473ED7361280 /* BugNarratorDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */; };
 		EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */; };
 		F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */; };
+		F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */; };
 		F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */; };
 		FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */; };
 		FFF767231D9C465D49D307F8 /* AudioUploadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */; };
@@ -146,6 +151,7 @@
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
 		0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingControlPanelView.swift; sourceTree = "<group>"; };
+		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionResolver.swift; sourceTree = "<group>"; };
 		1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
@@ -175,6 +181,7 @@
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
+		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
 		54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureService.swift; sourceTree = "<group>"; };
 		553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
 		554387017B49D9CD63967BE3 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
@@ -186,6 +193,7 @@
 		5C5346EDB503C6B05C81C368 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionResolverTests.swift; sourceTree = "<group>"; };
 		5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServiceContainer.swift; sourceTree = "<group>"; };
+		6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioRecorder.swift; sourceTree = "<group>"; };
 		60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWorkspace.swift; sourceTree = "<group>"; };
 		60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocation.swift; sourceTree = "<group>"; };
 		60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapper.swift; sourceTree = "<group>"; };
@@ -221,6 +229,7 @@
 		9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionServiceTests.swift; sourceTree = "<group>"; };
 		A663ED1B160E290FCFAC3AED /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRecoveryAndHistoryViews.swift; sourceTree = "<group>"; };
+		A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorder.swift; sourceTree = "<group>"; };
 		A8E2942C142197B34696946C /* TranscriptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSection.swift; sourceTree = "<group>"; };
 		A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBundleDirectoryWriter.swift; sourceTree = "<group>"; };
 		AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalTelemetryRecorder.swift; sourceTree = "<group>"; };
@@ -233,6 +242,7 @@
 		BB303E43134D880AB6207D21 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		BC5286F2E07F27DFA63F4B76 /* RecoveredRecordingImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImporter.swift; sourceTree = "<group>"; };
 		BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionService.swift; sourceTree = "<group>"; };
+		BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingAudioSource.swift; sourceTree = "<group>"; };
 		C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitorTests.swift; sourceTree = "<group>"; };
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
 		C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
@@ -293,6 +303,7 @@
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				2DE808CBBBE2F1EEE4FF5BEC /* RecoveredRecordingImporterTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
+				4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */,
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
 				8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */,
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
@@ -320,6 +331,7 @@
 				3B361DA07CDFA2543A36258F /* ExtractedIssue.swift */,
 				598E006D3F529E46315F3585 /* HotkeyAction.swift */,
 				6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */,
+				BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */,
 				22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */,
 				86D135AC919EF9A5E8C21235 /* SessionMarker.swift */,
 				5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */,
@@ -397,10 +409,12 @@
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
+				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				BC5286F2E07F27DFA63F4B76 /* RecoveredRecordingImporter.swift */,
+				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
@@ -408,6 +422,7 @@
 				9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */,
 				76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */,
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
+				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
 				BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */,
@@ -606,6 +621,7 @@
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				62313F663336184217D1020B /* RecoveredRecordingImporterTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
+				79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */,
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
 				28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */,
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
@@ -677,14 +693,17 @@
 				4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */,
 				2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */,
 				D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */,
+				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
+				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				A31A0BF8A4486E52DEA38F29 /* RecoveredRecordingImporter.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
+				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,
 				6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */,
 				CBE08ABB1F52871FE33471BA /* ScreenshotPreviewCache.swift in Sources */,
@@ -699,6 +718,7 @@
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
 				6470CFDC78DB57C49819E4A9 /* SupportView.swift in Sources */,
+				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,
 				D0754552F75E1CE6B4128800 /* TranscriptExporter.swift in Sources */,

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -30,5 +30,7 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>BugNarrator records microphone audio so you can narrate software testing sessions while working in other apps.</string>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>BugNarrator can record system audio only when you choose a system audio mode for a session.</string>
 </dict>
 </plist>

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -198,7 +198,7 @@ final class AppState: ObservableObject {
         self.init(
             settingsStore: settingsStore,
             transcriptStore: transcriptStore,
-            services: .production(),
+            services: .production(settingsStore: settingsStore),
             runtimeEnvironment: runtimeEnvironment
         )
     }
@@ -233,7 +233,7 @@ final class AppState: ObservableObject {
     init(
         settingsStore: SettingsStore,
         transcriptStore: TranscriptStore,
-        audioRecorder: AudioRecording,
+        audioRecorder: any AudioRecording,
         microphonePermissionService: any MicrophonePermissionServicing,
         screenCapturePermissionService: any ScreenCapturePermissionServicing,
         transcriptionClient: any TranscriptionServing,
@@ -347,6 +347,7 @@ final class AppState: ObservableObject {
             metadata: [
                 "has_openai_key": settingsStore.hasAPIKey ? "yes" : "no",
                 "ai_provider": settingsStore.aiProvider.rawValue,
+                "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
                 "debug_mode": settingsStore.debugMode ? "enabled" : "disabled"
             ]
         )
@@ -605,7 +606,7 @@ final class AppState: ObservableObject {
                 metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
             )
             setStatus(.recording(recordingDetailMessage()))
-            beginActivity(reason: "Recording a spoken feedback session")
+            beginActivity(reason: recordingActivityReason())
             startTimer()
             return
         }
@@ -634,13 +635,14 @@ final class AppState: ObservableObject {
                 )
 
                 setStatus(.recording(recordingDetailMessage()))
-                beginActivity(reason: "Recording a spoken feedback session")
+                beginActivity(reason: recordingActivityReason())
                 startTimer()
                 recordingLogger.info(
                     "session_started",
                     "A feedback session started successfully.",
                     metadata: [
                         "session_id": sessionID.uuidString,
+                        "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
                         "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
                         "ai_provider": settingsStore.aiProvider.rawValue
                     ]
@@ -648,6 +650,7 @@ final class AppState: ObservableObject {
                 telemetryRecorder.record(
                     "recording_started",
                     metadata: [
+                        "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
                         "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
                         "ai_provider": settingsStore.aiProvider.rawValue
                     ]
@@ -662,15 +665,36 @@ final class AppState: ObservableObject {
     }
 
     private func recordingDetailMessage() -> String {
+        let prefix: String
+        switch settingsStore.recordingAudioSource {
+        case .microphone:
+            prefix = "Recording in progress."
+        case .systemAudio:
+            prefix = "Recording system audio."
+        case .microphoneAndSystemAudio:
+            prefix = "Recording microphone and system audio."
+        }
+
         if settingsStore.hasUsableAIProviderCredential && settingsStore.aiProviderCompatibilityIssue == nil {
-            return "Recording in progress."
+            return prefix
         }
 
         if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-            return "Recording in progress. \(compatibilityIssue)"
+            return "\(prefix) \(compatibilityIssue)"
         }
 
-        return "Recording in progress. Finish the AI provider setup in Settings before stopping to transcribe this session."
+        return "\(prefix) Finish the AI provider setup in Settings before stopping to transcribe this session."
+    }
+
+    private func recordingActivityReason() -> String {
+        switch settingsStore.recordingAudioSource {
+        case .microphone:
+            return "Recording a spoken feedback session"
+        case .systemAudio:
+            return "Recording system audio for a feedback session"
+        case .microphoneAndSystemAudio:
+            return "Recording microphone and system audio for a feedback session"
+        }
     }
 
     func stopSession() async {
@@ -991,6 +1015,20 @@ final class AppState: ObservableObject {
         }
 
         presentUtilityActionFailure("BugNarrator could not open Screen Recording settings automatically.")
+    }
+
+    func openSystemAudioPrivacySettings() {
+        let candidateURLs = [
+            BugNarratorLinks.screenRecordingPrivacySettings,
+            BugNarratorLinks.securityPrivacySettings,
+            BugNarratorLinks.systemSettingsApp
+        ]
+
+        for url in candidateURLs where urlHandler.open(url) {
+            return
+        }
+
+        presentUtilityActionFailure("BugNarrator could not open Screen & System Audio Recording settings automatically.")
     }
 
     func checkForUpdates() {
@@ -2467,7 +2505,13 @@ final class AppState: ObservableObject {
         telemetryRecorder.record("app_error", metadata: metadata)
 
         switch error {
-        case .microphonePermissionDenied, .microphonePermissionRestricted, .microphoneUnavailable, .screenRecordingPermissionDenied:
+        case .microphonePermissionDenied,
+             .microphonePermissionRestricted,
+             .microphoneUnavailable,
+             .systemAudioFeatureDisabled,
+             .systemAudioConsentRequired,
+             .systemAudioUnavailable,
+             .screenRecordingPermissionDenied:
             permissionsLogger.warning("app_error", error.userMessage, metadata: metadata)
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
             settingsLogger.warning("app_error", error.userMessage, metadata: metadata)
@@ -2496,6 +2540,12 @@ final class AppState: ObservableObject {
             return "microphone_permission_restricted"
         case .microphoneUnavailable:
             return "microphone_unavailable"
+        case .systemAudioFeatureDisabled:
+            return "system_audio_feature_disabled"
+        case .systemAudioConsentRequired:
+            return "system_audio_consent_required"
+        case .systemAudioUnavailable:
+            return "system_audio_unavailable"
         case .screenRecordingPermissionDenied:
             return "screen_recording_permission_denied"
         case .missingAPIKey:

--- a/Sources/BugNarrator/Models/AppError.swift
+++ b/Sources/BugNarrator/Models/AppError.swift
@@ -7,6 +7,9 @@ enum AppError: LocalizedError, Equatable {
     case microphonePermissionDenied
     case microphonePermissionRestricted
     case microphoneUnavailable(String)
+    case systemAudioFeatureDisabled
+    case systemAudioConsentRequired
+    case systemAudioUnavailable(String)
     case screenRecordingPermissionDenied
     case noActiveSession(String)
     case recordingFailure(String)
@@ -37,6 +40,12 @@ enum AppError: LocalizedError, Equatable {
             return "Microphone access is restricted on this Mac. Check System Settings > Privacy & Security > Microphone and any device-management or parental-control restrictions, then try again."
         case .microphoneUnavailable(let message):
             return "BugNarrator could not start audio capture. \(message)"
+        case .systemAudioFeatureDisabled:
+            return "System audio capture is behind an experimental flag. Enable it in Settings before choosing a system audio mode."
+        case .systemAudioConsentRequired:
+            return "System audio capture can include meeting audio and other people's voices. Open Settings and acknowledge the recording notice before starting."
+        case .systemAudioUnavailable(let message):
+            return "BugNarrator could not start system audio capture. \(message)"
         case .screenRecordingPermissionDenied:
             return "Screenshot capture requires Screen Recording permission. Recording can continue without screenshots. Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again."
         case .noActiveSession(let message):
@@ -85,6 +94,12 @@ enum AppError: LocalizedError, Equatable {
             return "Microphone Access Restricted"
         case .microphoneUnavailable:
             return "Microphone Unavailable"
+        case .systemAudioFeatureDisabled:
+            return "System Audio Disabled"
+        case .systemAudioConsentRequired:
+            return "System Audio Notice Needed"
+        case .systemAudioUnavailable:
+            return "System Audio Unavailable"
         case .screenRecordingPermissionDenied:
             return "Screen Recording Access Needed"
         case .recordingFailure:
@@ -118,6 +133,12 @@ enum AppError: LocalizedError, Equatable {
             return "Microphone access is restricted."
         case .microphoneUnavailable:
             return "Audio capture is unavailable."
+        case .systemAudioFeatureDisabled:
+            return "Enable system audio capture before continuing."
+        case .systemAudioConsentRequired:
+            return "Acknowledge the system audio recording notice before continuing."
+        case .systemAudioUnavailable:
+            return "System audio capture is unavailable."
         case .screenRecordingPermissionDenied:
             return "Screen recording access is blocked."
         case .missingAPIKey:
@@ -151,6 +172,24 @@ enum AppError: LocalizedError, Equatable {
     var suggestsMicrophoneSettings: Bool {
         switch self {
         case .microphonePermissionDenied, .microphonePermissionRestricted:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var suggestsSystemAudioSettings: Bool {
+        switch self {
+        case .systemAudioFeatureDisabled, .systemAudioConsentRequired:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var suggestsSystemAudioPrivacySettings: Bool {
+        switch self {
+        case .systemAudioUnavailable:
             return true
         default:
             return false

--- a/Sources/BugNarrator/Models/RecordingAudioSource.swift
+++ b/Sources/BugNarrator/Models/RecordingAudioSource.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum RecordingAudioSource: String, CaseIterable, Identifiable {
+    case microphone
+    case systemAudio
+    case microphoneAndSystemAudio
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .microphone:
+            return "Mic only"
+        case .systemAudio:
+            return "System audio only"
+        case .microphoneAndSystemAudio:
+            return "Mic + system audio"
+        }
+    }
+
+    var diagnosticsValue: String {
+        rawValue
+    }
+
+    var usesMicrophone: Bool {
+        switch self {
+        case .microphone, .microphoneAndSystemAudio:
+            return true
+        case .systemAudio:
+            return false
+        }
+    }
+
+    var usesSystemAudio: Bool {
+        switch self {
+        case .systemAudio, .microphoneAndSystemAudio:
+            return true
+        case .microphone:
+            return false
+        }
+    }
+}

--- a/Sources/BugNarrator/Services/MicrophonePermissionService.swift
+++ b/Sources/BugNarrator/Services/MicrophonePermissionService.swift
@@ -221,6 +221,14 @@ final class MicrophonePermissionService: MicrophonePermissionServicing {
             "Running microphone permission and recorder preflight before starting a session."
         )
 
+        guard audioRecorder.requiresMicrophonePermission else {
+            permissionsLogger.info(
+                "microphone_preflight_skipped",
+                "The selected audio source does not require microphone permission."
+            )
+            return await grantedPermissionResult(audioRecorder: audioRecorder)
+        }
+
         let permissionStatus = status(from: await permissionAccess.requestPermissionIfNeeded())
 
         switch permissionStatus {

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -1,0 +1,250 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+@MainActor
+final class MixedAudioRecorder: AudioRecording {
+    private let recordingLogger = DiagnosticsLogger(category: .recording)
+    private let microphoneRecorder: any AudioRecording
+    private let systemAudioRecorder: any AudioRecording
+    private let outputDirectoryURL: URL
+
+    private var isRecording = false
+
+    init(
+        microphoneRecorder: any AudioRecording,
+        systemAudioRecorder: any AudioRecording,
+        outputDirectoryURL: URL = AppSupportLocation.appDirectory()
+            .appendingPathComponent("RecoveredRecordings", isDirectory: true)
+    ) {
+        self.microphoneRecorder = microphoneRecorder
+        self.systemAudioRecorder = systemAudioRecorder
+        self.outputDirectoryURL = outputDirectoryURL
+    }
+
+    var currentDuration: TimeInterval {
+        max(microphoneRecorder.currentDuration, systemAudioRecorder.currentDuration)
+    }
+
+    var requiresMicrophonePermission: Bool {
+        true
+    }
+
+    func validateRecordingPrerequisites() async -> AppError? {
+        if let microphoneError = await microphoneRecorder.validateRecordingPrerequisites() {
+            return microphoneError
+        }
+
+        return await systemAudioRecorder.validateRecordingPrerequisites()
+    }
+
+    func validateRecordingActivation() async -> AppError? {
+        if let microphoneError = await microphoneRecorder.validateRecordingActivation() {
+            return microphoneError
+        }
+
+        return await systemAudioRecorder.validateRecordingActivation()
+    }
+
+    func startRecording() async throws {
+        guard !isRecording else {
+            throw AppError.recordingFailure("A recording session is already active.")
+        }
+
+        do {
+            try await systemAudioRecorder.startRecording()
+            do {
+                try await microphoneRecorder.startRecording()
+            } catch {
+                await systemAudioRecorder.cancelRecording(preserveFile: false)
+                throw error
+            }
+            isRecording = true
+            recordingLogger.info(
+                "mixed_recording_started",
+                "Microphone and system audio recording started successfully."
+            )
+        } catch let error as AppError {
+            recordingLogger.error("mixed_recording_start_failed", error.userMessage)
+            throw error
+        } catch {
+            recordingLogger.error("mixed_recording_start_failed", error.localizedDescription)
+            throw AppError.recordingFailure(error.localizedDescription)
+        }
+    }
+
+    func stopRecording() async throws -> RecordedAudio {
+        guard isRecording else {
+            throw AppError.recordingFailure("There is no active recording.")
+        }
+
+        isRecording = false
+
+        var systemResult: Result<RecordedAudio, Error>?
+        var microphoneResult: Result<RecordedAudio, Error>?
+
+        do {
+            systemResult = .success(try await systemAudioRecorder.stopRecording())
+        } catch {
+            systemResult = .failure(error)
+        }
+
+        do {
+            microphoneResult = .success(try await microphoneRecorder.stopRecording())
+        } catch {
+            microphoneResult = .failure(error)
+        }
+
+        guard let systemResult else {
+            throw AppError.recordingFailure("System audio recording was unavailable.")
+        }
+        guard let microphoneResult else {
+            throw AppError.recordingFailure("Microphone recording was unavailable.")
+        }
+
+        let systemAudio = try systemResult.get()
+        let microphoneAudio = try microphoneResult.get()
+
+        let outputURL = makeMixedRecordingURL()
+        let mixedAudio = try await mixAudioFiles(
+            microphoneAudio: microphoneAudio,
+            systemAudio: systemAudio,
+            outputURL: outputURL
+        )
+
+        recordingLogger.info(
+            "mixed_recording_stopped",
+            "Microphone and system audio recording finished successfully.",
+            metadata: [
+                "file_name": mixedAudio.fileURL.lastPathComponent,
+                "duration_seconds": String(format: "%.2f", mixedAudio.duration)
+            ]
+        )
+
+        return mixedAudio
+    }
+
+    func cancelRecording(preserveFile: Bool) async {
+        guard isRecording else {
+            return
+        }
+
+        isRecording = false
+        await microphoneRecorder.cancelRecording(preserveFile: preserveFile)
+        await systemAudioRecorder.cancelRecording(preserveFile: preserveFile)
+    }
+
+    private func mixAudioFiles(
+        microphoneAudio: RecordedAudio,
+        systemAudio: RecordedAudio,
+        outputURL: URL
+    ) async throws -> RecordedAudio {
+        try FileManager.default.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: outputURL)
+
+        let composition = AVMutableComposition()
+        var mixParameters: [AVAudioMixInputParameters] = []
+
+        try await addAudioTrack(
+            fileURL: systemAudio.fileURL,
+            to: composition,
+            volume: 1.0,
+            mixParameters: &mixParameters
+        )
+        try await addAudioTrack(
+            fileURL: microphoneAudio.fileURL,
+            to: composition,
+            volume: 1.0,
+            mixParameters: &mixParameters
+        )
+
+        let audioMix = AVMutableAudioMix()
+        audioMix.inputParameters = mixParameters
+
+        guard let exportSession = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetAppleM4A) else {
+            throw AppError.recordingFailure("The mixed audio file could not be prepared.")
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .m4a
+        exportSession.audioMix = audioMix
+
+        let exportBridge = MixedAssetExportSessionBridge(exportSession)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            exportBridge.session.exportAsynchronously {
+                switch exportBridge.session.status {
+                case .completed:
+                    continuation.resume()
+                case .failed:
+                    continuation.resume(
+                        throwing: exportBridge.session.error ?? AppError.recordingFailure("The mixed audio export failed.")
+                    )
+                case .cancelled:
+                    continuation.resume(throwing: AppError.recordingFailure("The mixed audio export was cancelled."))
+                default:
+                    continuation.resume(throwing: AppError.recordingFailure("The mixed audio export did not complete."))
+                }
+            }
+        }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: outputURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            throw AppError.recordingFailure("The mixed audio file was empty.")
+        }
+
+        return RecordedAudio(
+            fileURL: outputURL,
+            duration: max(microphoneAudio.duration, systemAudio.duration)
+        )
+    }
+
+    private func addAudioTrack(
+        fileURL: URL,
+        to composition: AVMutableComposition,
+        volume: Float,
+        mixParameters: inout [AVAudioMixInputParameters]
+    ) async throws {
+        let asset = AVURLAsset(url: fileURL)
+        guard let sourceTrack = try await asset.loadTracks(withMediaType: .audio).first else {
+            throw AppError.recordingFailure("The recording at \(fileURL.lastPathComponent) did not contain an audio track.")
+        }
+        let duration = try await asset.load(.duration)
+
+        guard let compositionTrack = composition.addMutableTrack(
+            withMediaType: .audio,
+            preferredTrackID: kCMPersistentTrackID_Invalid
+        ) else {
+            throw AppError.recordingFailure("The mixed audio track could not be created.")
+        }
+
+        try compositionTrack.insertTimeRange(
+            CMTimeRange(start: .zero, duration: duration),
+            of: sourceTrack,
+            at: .zero
+        )
+
+        let parameters = AVMutableAudioMixInputParameters(track: compositionTrack)
+        parameters.setVolume(volume, at: .zero)
+        mixParameters.append(parameters)
+    }
+
+    private func makeMixedRecordingURL() -> URL {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+        let timestamp = formatter
+            .string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+
+        return outputDirectoryURL
+            .appendingPathComponent("\(timestamp)-mixed-recording-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+    }
+}
+
+private final class MixedAssetExportSessionBridge: @unchecked Sendable {
+    let session: AVAssetExportSession
+
+    init(_ session: AVAssetExportSession) {
+        self.session = session
+    }
+}

--- a/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+@MainActor
+final class RoutingAudioRecorder: AudioRecording {
+    private let settingsStore: SettingsStore
+    private let microphoneRecorder: any AudioRecording
+    private let systemAudioRecorder: any AudioRecording
+    private let microphoneAndSystemAudioRecorder: any AudioRecording
+
+    private var activeRecorder: (any AudioRecording)?
+
+    init(
+        settingsStore: SettingsStore,
+        microphoneRecorder: any AudioRecording = AudioRecorder(),
+        systemAudioRecorder: any AudioRecording = SystemAudioRecorder(),
+        microphoneAndSystemAudioRecorder: (any AudioRecording)? = nil
+    ) {
+        self.settingsStore = settingsStore
+        self.microphoneRecorder = microphoneRecorder
+        self.systemAudioRecorder = systemAudioRecorder
+        self.microphoneAndSystemAudioRecorder = microphoneAndSystemAudioRecorder ?? MixedAudioRecorder(
+            microphoneRecorder: AudioRecorder(),
+            systemAudioRecorder: SystemAudioRecorder()
+        )
+    }
+
+    var currentDuration: TimeInterval {
+        activeRecorder?.currentDuration ?? selectedRecorder.currentDuration
+    }
+
+    var requiresMicrophonePermission: Bool {
+        settingsStore.recordingAudioSource.usesMicrophone
+    }
+
+    func validateRecordingPrerequisites() async -> AppError? {
+        if let readinessError = validateSystemAudioReadiness() {
+            return readinessError
+        }
+
+        return await selectedRecorder.validateRecordingPrerequisites()
+    }
+
+    func validateRecordingActivation() async -> AppError? {
+        if let readinessError = validateSystemAudioReadiness() {
+            return readinessError
+        }
+
+        return await selectedRecorder.validateRecordingActivation()
+    }
+
+    func startRecording() async throws {
+        guard activeRecorder == nil else {
+            throw AppError.recordingFailure("A recording session is already active.")
+        }
+
+        if let readinessError = validateSystemAudioReadiness() {
+            throw readinessError
+        }
+
+        let recorder = selectedRecorder
+        try await recorder.startRecording()
+        activeRecorder = recorder
+    }
+
+    func stopRecording() async throws -> RecordedAudio {
+        guard let activeRecorder else {
+            throw AppError.recordingFailure("There is no active recording.")
+        }
+
+        defer {
+            self.activeRecorder = nil
+        }
+
+        return try await activeRecorder.stopRecording()
+    }
+
+    func cancelRecording(preserveFile: Bool) async {
+        guard let activeRecorder else {
+            return
+        }
+
+        self.activeRecorder = nil
+        await activeRecorder.cancelRecording(preserveFile: preserveFile)
+    }
+
+    private var selectedRecorder: any AudioRecording {
+        switch settingsStore.recordingAudioSource {
+        case .microphone:
+            return microphoneRecorder
+        case .systemAudio:
+            return systemAudioRecorder
+        case .microphoneAndSystemAudio:
+            return microphoneAndSystemAudioRecorder
+        }
+    }
+
+    private func validateSystemAudioReadiness() -> AppError? {
+        guard settingsStore.recordingAudioSource.usesSystemAudio else {
+            return nil
+        }
+
+        guard settingsStore.systemAudioCaptureEnabled else {
+            return .systemAudioFeatureDisabled
+        }
+
+        guard settingsStore.hasAcceptedSystemAudioRecordingConsent else {
+            return .systemAudioConsentRequired
+        }
+
+        return nil
+    }
+}

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -84,11 +84,18 @@ enum ScreenshotSelectionResult: Equatable {
 @MainActor
 protocol AudioRecording: AnyObject {
     var currentDuration: TimeInterval { get }
+    var requiresMicrophonePermission: Bool { get }
     func validateRecordingPrerequisites() async -> AppError?
     func validateRecordingActivation() async -> AppError?
     func startRecording() async throws
     func stopRecording() async throws -> RecordedAudio
     func cancelRecording(preserveFile: Bool) async
+}
+
+extension AudioRecording {
+    var requiresMicrophonePermission: Bool {
+        true
+    }
 }
 
 @MainActor

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -187,6 +187,33 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    @Published var systemAudioCaptureEnabled: Bool = false {
+        didSet {
+            guard hasLoaded else { return }
+            defaults.set(systemAudioCaptureEnabled, forKey: Keys.systemAudioCaptureEnabled)
+            if !systemAudioCaptureEnabled, recordingAudioSource.usesSystemAudio {
+                recordingAudioSource = .microphone
+            }
+        }
+    }
+
+    @Published var recordingAudioSource: RecordingAudioSource = .microphone {
+        didSet {
+            guard hasLoaded else { return }
+            defaults.set(recordingAudioSource.rawValue, forKey: Keys.recordingAudioSource)
+        }
+    }
+
+    @Published var hasAcceptedSystemAudioRecordingConsent: Bool = false {
+        didSet {
+            guard hasLoaded else { return }
+            defaults.set(
+                hasAcceptedSystemAudioRecordingConsent,
+                forKey: Keys.hasAcceptedSystemAudioRecordingConsent
+            )
+        }
+    }
+
     @Published var openAtStartup: Bool = false {
         didSet {
             guard hasLoaded, !isSynchronizingLaunchAtLogin else { return }
@@ -788,6 +815,18 @@ final class SettingsStore: ObservableObject {
         autoCopyTranscript = boolValue(forKey: Keys.autoCopyTranscript) ?? true
         autoSaveTranscript = boolValue(forKey: Keys.autoSaveTranscript) ?? true
         autoExtractIssues = boolValue(forKey: Keys.autoExtractIssues) ?? false
+        systemAudioCaptureEnabled = boolValue(forKey: Keys.systemAudioCaptureEnabled) ?? false
+        let storedAudioSource = stringValue(forKey: Keys.recordingAudioSource)
+        recordingAudioSource = storedAudioSource
+            .flatMap(RecordingAudioSource.init(rawValue:))
+            ?? .microphone
+        if !systemAudioCaptureEnabled, recordingAudioSource.usesSystemAudio {
+            recordingAudioSource = .microphone
+            defaults.set(recordingAudioSource.rawValue, forKey: Keys.recordingAudioSource)
+        }
+        hasAcceptedSystemAudioRecordingConsent = boolValue(
+            forKey: Keys.hasAcceptedSystemAudioRecordingConsent
+        ) ?? false
         syncLaunchAtLoginState(launchAtLoginService.currentStatus())
 
         startRecordingHotkeyShortcut = loadHotkey(
@@ -825,6 +864,8 @@ final class SettingsStore: ObservableObject {
             "Settings finished loading.",
             metadata: [
                 "debug_mode": debugMode ? "enabled" : "disabled",
+                "recording_audio_source": recordingAudioSource.diagnosticsValue,
+                "system_audio_capture": systemAudioCaptureEnabled ? "enabled" : "disabled",
                 "has_openai_key": hasAPIKey ? "yes" : "no",
                 "has_github_token": hasGitHubToken ? "yes" : "no",
                 "has_jira_token": hasJiraAPIToken ? "yes" : "no",
@@ -1514,6 +1555,9 @@ private enum SecretSlot: Hashable, CaseIterable {
     static let autoCopyTranscript = "settings.autoCopyTranscript"
     static let autoSaveTranscript = "settings.autoSaveTranscript"
     static let autoExtractIssues = "settings.autoExtractIssues"
+    static let systemAudioCaptureEnabled = "settings.systemAudioCaptureEnabled"
+    static let recordingAudioSource = "settings.recordingAudioSource"
+    static let hasAcceptedSystemAudioRecordingConsent = "settings.hasAcceptedSystemAudioRecordingConsent"
     static let startRecordingHotkeyShortcut = "settings.startRecordingHotkeyShortcut"
     static let legacyRecordingHotkeyShortcut = "settings.hotkeyShortcut"
     static let legacyStartRecordingHotkeyShortcut = "settings.recordingHotkeyShortcut"

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -1,0 +1,468 @@
+import AudioToolbox
+@preconcurrency import AVFoundation
+import Foundation
+
+@MainActor
+final class SystemAudioRecorder: AudioRecording {
+    private let recordingLogger = DiagnosticsLogger(category: .recording)
+    private let recoveryDirectoryURL: URL
+    private let ioQueue = DispatchQueue(label: "BugNarrator.SystemAudioRecorder.IO", qos: .userInitiated)
+
+    private var tapSession: SystemAudioTapSession?
+    private var activeWriter: SystemAudioFileWriter?
+    private var currentFileURL: URL?
+    private var recordingStartedAt: Date?
+
+    init(
+        recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
+            .appendingPathComponent("RecoveredRecordings", isDirectory: true)
+    ) {
+        self.recoveryDirectoryURL = recoveryDirectoryURL
+    }
+
+    var currentDuration: TimeInterval {
+        guard let recordingStartedAt else {
+            return 0
+        }
+
+        return Date().timeIntervalSince(recordingStartedAt)
+    }
+
+    var requiresMicrophonePermission: Bool {
+        false
+    }
+
+    func validateRecordingPrerequisites() async -> AppError? {
+        guard tapSession == nil, activeWriter == nil else {
+            return .recordingFailure("A recording session is already active.")
+        }
+
+        guard #available(macOS 14.2, *) else {
+            return .systemAudioUnavailable("System audio capture requires macOS 14.2 or later.")
+        }
+
+        do {
+            let probe = SystemAudioTapSession()
+            _ = try probe.prepare()
+            probe.invalidate()
+            return nil
+        } catch let error as AppError {
+            return error
+        } catch {
+            return .systemAudioUnavailable(systemAudioRecoveryMessage(details: error.localizedDescription))
+        }
+    }
+
+    func validateRecordingActivation() async -> AppError? {
+        await validateRecordingPrerequisites()
+    }
+
+    func startRecording() async throws {
+        recordingLogger.info("system_audio_recording_start_requested", "System audio recording start was requested.")
+
+        guard tapSession == nil, activeWriter == nil else {
+            throw AppError.recordingFailure("A recording session is already active.")
+        }
+
+        guard #available(macOS 14.2, *) else {
+            throw AppError.systemAudioUnavailable("System audio capture requires macOS 14.2 or later.")
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+            let session = SystemAudioTapSession()
+            let format = try session.prepare()
+            let fileURL = makeRecoverableRecordingURL()
+            let writer = try SystemAudioFileWriter(fileURL: fileURL, format: format)
+
+            try session.start(on: ioQueue, writer: writer)
+
+            tapSession = session
+            activeWriter = writer
+            currentFileURL = fileURL
+            recordingStartedAt = Date()
+
+            recordingLogger.info(
+                "system_audio_recording_started",
+                "System audio recording started successfully.",
+                metadata: ["file_name": fileURL.lastPathComponent]
+            )
+        } catch let error as AppError {
+            recordingLogger.error("system_audio_recording_start_failed", error.userMessage)
+            throw error
+        } catch {
+            recordingLogger.error("system_audio_recording_start_failed", error.localizedDescription)
+            throw AppError.systemAudioUnavailable(systemAudioRecoveryMessage(details: error.localizedDescription))
+        }
+    }
+
+    func stopRecording() async throws -> RecordedAudio {
+        guard let tapSession, let activeWriter, let currentFileURL else {
+            throw AppError.recordingFailure("There is no active recording.")
+        }
+
+        let duration = currentDuration
+        recordingLogger.info(
+            "system_audio_recording_stop_requested",
+            "System audio recording is being finalized.",
+            metadata: ["file_name": currentFileURL.lastPathComponent]
+        )
+
+        tapSession.invalidate()
+        activeWriter.close()
+        cleanupActiveState()
+
+        try validateRecordedAudioFile(at: currentFileURL)
+
+        recordingLogger.info(
+            "system_audio_recording_stopped",
+            "System audio recording finished successfully.",
+            metadata: [
+                "file_name": currentFileURL.lastPathComponent,
+                "duration_seconds": String(format: "%.2f", duration)
+            ]
+        )
+
+        return RecordedAudio(fileURL: currentFileURL, duration: duration)
+    }
+
+    func cancelRecording(preserveFile: Bool) async {
+        let fileURL = currentFileURL
+        tapSession?.invalidate()
+        activeWriter?.close()
+        cleanupActiveState()
+
+        guard !preserveFile, let fileURL else {
+            return
+        }
+
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+
+    private func cleanupActiveState() {
+        tapSession = nil
+        activeWriter = nil
+        currentFileURL = nil
+        recordingStartedAt = nil
+    }
+
+    private func validateRecordedAudioFile(at url: URL) throws {
+        let attributes: [FileAttributeKey: Any]
+
+        do {
+            attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        } catch {
+            throw AppError.recordingFailure("The recorded system audio file could not be found.")
+        }
+
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            throw AppError.recordingFailure("The recorded system audio file was empty.")
+        }
+    }
+
+    private func makeRecoverableRecordingURL() -> URL {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
+        let timestamp = formatter
+            .string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+
+        return recoveryDirectoryURL
+            .appendingPathComponent("\(timestamp)-system-audio-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+    }
+
+    private func systemAudioRecoveryMessage(details: String) -> String {
+        let trimmedDetails = details.trimmingCharacters(in: .whitespacesAndNewlines)
+        let suffix = trimmedDetails.isEmpty ? "" : " \(trimmedDetails)"
+        return "Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again.\(suffix)"
+    }
+}
+
+private final class SystemAudioTapSession {
+    private var processTapID = AudioObjectID(kAudioObjectUnknown)
+    private var aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+    private var deviceProcID: AudioDeviceIOProcID?
+    private var audioFormat: AVAudioFormat?
+
+    @available(macOS 14.2, *)
+    func prepare() throws -> AVAudioFormat {
+        guard audioFormat == nil else {
+            guard let audioFormat else {
+                throw AppError.systemAudioUnavailable("The system audio tap was not prepared.")
+            }
+            return audioFormat
+        }
+
+        let excludedProcesses = (try? Self.currentProcessObjectIDs()) ?? []
+        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: excludedProcesses)
+        tapDescription.uuid = UUID()
+        tapDescription.name = "BugNarrator System Audio"
+        tapDescription.isPrivate = true
+        tapDescription.muteBehavior = .unmuted
+
+        var tapID = AudioObjectID(kAudioObjectUnknown)
+        var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio tap creation failed with status \(status)."))
+        }
+
+        processTapID = tapID
+
+        let outputDeviceID = try AudioObjectID.defaultSystemOutputDevice()
+        let outputDeviceUID = try outputDeviceID.deviceUID()
+        let streamDescription = try tapID.audioTapStreamDescription()
+        var mutableStreamDescription = streamDescription
+
+        guard let format = AVAudioFormat(streamDescription: &mutableStreamDescription) else {
+            throw AppError.systemAudioUnavailable("BugNarrator could not read the system audio format.")
+        }
+
+        let aggregateDescription: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "BugNarrator System Audio",
+            kAudioAggregateDeviceUIDKey: "BugNarrator.SystemAudio.\(UUID().uuidString)",
+            kAudioAggregateDeviceMainSubDeviceKey: outputDeviceUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [
+                    kAudioSubDeviceUIDKey: outputDeviceUID
+                ]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapUIDKey: tapDescription.uuid.uuidString
+                ]
+            ]
+        ]
+
+        aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        status = AudioHardwareCreateAggregateDevice(aggregateDescription as CFDictionary, &aggregateDeviceID)
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio aggregate device creation failed with status \(status)."))
+        }
+
+        audioFormat = format
+        return format
+    }
+
+    @available(macOS 14.2, *)
+    func start(on queue: DispatchQueue, writer: SystemAudioFileWriter) throws {
+        guard aggregateDeviceID != AudioObjectID(kAudioObjectUnknown) else {
+            throw AppError.systemAudioUnavailable("The system audio device was not prepared.")
+        }
+
+        var status = AudioDeviceCreateIOProcIDWithBlock(
+            &deviceProcID,
+            aggregateDeviceID,
+            queue
+        ) { _, inputData, _, _, _ in
+            writer.write(bufferList: inputData)
+        }
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio could not create the system audio callback with status \(status)."))
+        }
+
+        status = AudioDeviceStart(aggregateDeviceID, deviceProcID)
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio refused to start system audio capture with status \(status)."))
+        }
+    }
+
+    func invalidate() {
+        if aggregateDeviceID != AudioObjectID(kAudioObjectUnknown) {
+            _ = AudioDeviceStop(aggregateDeviceID, deviceProcID)
+
+            if let deviceProcID {
+                _ = AudioDeviceDestroyIOProcID(aggregateDeviceID, deviceProcID)
+                self.deviceProcID = nil
+            }
+
+            _ = AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+            aggregateDeviceID = AudioObjectID(kAudioObjectUnknown)
+        }
+
+        if processTapID != AudioObjectID(kAudioObjectUnknown) {
+            if #available(macOS 14.2, *) {
+                _ = AudioHardwareDestroyProcessTap(processTapID)
+            }
+            processTapID = AudioObjectID(kAudioObjectUnknown)
+        }
+
+        audioFormat = nil
+    }
+
+    deinit {
+        invalidate()
+    }
+
+    private static func recoveryMessage(_ details: String) -> String {
+        "Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again. \(details)"
+    }
+
+    private static func currentProcessObjectIDs() throws -> [AudioObjectID] {
+        let processID = getpid()
+        let objectID: AudioObjectID = try AudioObjectID.systemObject.read(
+            kAudioHardwarePropertyTranslatePIDToProcessObject,
+            defaultValue: AudioObjectID(kAudioObjectUnknown),
+            qualifier: processID
+        )
+        return objectID == AudioObjectID(kAudioObjectUnknown) ? [] : [objectID]
+    }
+}
+
+private final class SystemAudioFileWriter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let format: AVAudioFormat
+    private var file: AVAudioFile?
+
+    init(fileURL: URL, format: AVAudioFormat) throws {
+        self.format = format
+        self.file = try AVAudioFile(
+            forWriting: fileURL,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+    }
+
+    func write(bufferList: UnsafePointer<AudioBufferList>) {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+
+        guard let file,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: bufferList, deallocator: nil) else {
+            return
+        }
+
+        try? file.write(from: buffer)
+    }
+
+    func close() {
+        lock.lock()
+        file = nil
+        lock.unlock()
+    }
+}
+
+private extension AudioObjectID {
+    static var systemObject: AudioObjectID {
+        AudioObjectID(kAudioObjectSystemObject)
+    }
+
+    static func defaultSystemOutputDevice() throws -> AudioDeviceID {
+        try systemObject.read(
+            kAudioHardwarePropertyDefaultSystemOutputDevice,
+            defaultValue: AudioDeviceID(kAudioObjectUnknown)
+        )
+    }
+
+    func deviceUID() throws -> String {
+        try readString(kAudioDevicePropertyDeviceUID)
+    }
+
+    func audioTapStreamDescription() throws -> AudioStreamBasicDescription {
+        try read(kAudioTapPropertyFormat, defaultValue: AudioStreamBasicDescription())
+    }
+
+    func readString(
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+        element: AudioObjectPropertyElement = kAudioObjectPropertyElementMain
+    ) throws -> String {
+        let value: CFString = try read(
+            selector,
+            scope: scope,
+            element: element,
+            defaultValue: "" as CFString
+        )
+        return value as String
+    }
+
+    func read<T, Q>(
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+        element: AudioObjectPropertyElement = kAudioObjectPropertyElementMain,
+        defaultValue: T,
+        qualifier: Q
+    ) throws -> T {
+        var qualifier = qualifier
+        let qualifierSize = UInt32(MemoryLayout<Q>.size)
+        return try withUnsafeMutablePointer(to: &qualifier) { qualifierPointer in
+            try read(
+                selector,
+                scope: scope,
+                element: element,
+                defaultValue: defaultValue,
+                qualifierSize: qualifierSize,
+                qualifierData: qualifierPointer
+            )
+        }
+    }
+
+    func read<T>(
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+        element: AudioObjectPropertyElement = kAudioObjectPropertyElementMain,
+        defaultValue: T
+    ) throws -> T {
+        try read(
+            selector,
+            scope: scope,
+            element: element,
+            defaultValue: defaultValue,
+            qualifierSize: 0,
+            qualifierData: nil
+        )
+    }
+
+    private func read<T>(
+        _ selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+        defaultValue: T,
+        qualifierSize: UInt32,
+        qualifierData: UnsafeRawPointer?
+    ) throws -> T {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: element
+        )
+        var dataSize: UInt32 = 0
+        var status = AudioObjectGetPropertyDataSize(
+            self,
+            &address,
+            qualifierSize,
+            qualifierData,
+            &dataSize
+        )
+
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable("Core Audio property size read failed with status \(status).")
+        }
+
+        var value = defaultValue
+        status = withUnsafeMutablePointer(to: &value) { valuePointer in
+            AudioObjectGetPropertyData(
+                self,
+                &address,
+                qualifierSize,
+                qualifierData,
+                &dataSize,
+                valuePointer
+            )
+        }
+
+        guard status == noErr else {
+            throw AppError.systemAudioUnavailable("Core Audio property read failed with status \(status).")
+        }
+
+        return value
+    }
+}

--- a/Sources/BugNarrator/Utilities/AppServiceContainer.swift
+++ b/Sources/BugNarrator/Utilities/AppServiceContainer.swift
@@ -17,9 +17,9 @@ struct AppServiceContainer {
     let urlHandler: any URLOpening
     let recordingTimer: RecordingTimerViewModel
 
-    static func production() -> AppServiceContainer {
+    static func production(settingsStore: SettingsStore) -> AppServiceContainer {
         AppServiceContainer(
-            audioRecorder: AudioRecorder(),
+            audioRecorder: RoutingAudioRecorder(settingsStore: settingsStore),
             microphonePermissionService: MicrophonePermissionService(),
             screenCapturePermissionService: ScreenCapturePermissionService(),
             transcriptionClient: TranscriptionClient(),

--- a/Sources/BugNarrator/Utilities/MenuBarStatusPresentation.swift
+++ b/Sources/BugNarrator/Utilities/MenuBarStatusPresentation.swift
@@ -4,6 +4,7 @@ enum MenuBarStatusRecoveryAction: Equatable {
     case none
     case microphone
     case screenRecording
+    case systemAudio
     case openAI
     case exportConfiguration
     case storage
@@ -24,6 +25,8 @@ struct MenuBarStatusPresentation: Equatable {
             return .microphone
         case .screenRecordingPermissionDenied:
             return .screenRecording
+        case .systemAudioFeatureDisabled, .systemAudioConsentRequired, .systemAudioUnavailable:
+            return .systemAudio
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
             return .openAI
         case .exportConfigurationMissing:

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -181,6 +181,8 @@ struct MenuBarView: View {
             microphoneRecoverySection
         case .screenRecording:
             screenRecordingRecoverySection
+        case .systemAudio:
+            systemAudioRecoverySection
         case .openAI:
             openAIKeyRecoverySection
         case .exportConfiguration:
@@ -206,6 +208,35 @@ struct MenuBarView: View {
             .controlSize(.small)
             .accessibilityLabel("Open Screen Recording privacy settings")
             .accessibilityHint("Opens the macOS privacy settings for screen recording access")
+        }
+    }
+
+    private var systemAudioRecoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if appState.currentError?.suggestsSystemAudioSettings == true {
+                Text("Open Settings to enable system audio capture modes and acknowledge the recording notice.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button("Open Settings") {
+                    appState.openSettings()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            } else {
+                Text("System audio capture uses macOS Screen & System Audio Recording permission. Enable BugNarrator there, then try again.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button("Open Screen & System Audio Settings") {
+                    appState.openSystemAudioPrivacySettings()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityLabel("Open Screen and System Audio Recording privacy settings")
+            }
         }
     }
 

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -121,6 +121,48 @@ struct SettingsView: View {
                     }
                 }
 
+                GroupBox("Recording Audio") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        sectionIntro("Choose what audio BugNarrator records when a session starts.")
+
+                        Toggle("System audio capture modes (experimental)", isOn: $settingsStore.systemAudioCaptureEnabled)
+                            .disabled(secureControlsDisabled)
+
+                        labeledField(title: "Audio Source") {
+                            Picker("Audio Source", selection: $settingsStore.recordingAudioSource) {
+                                ForEach(availableRecordingAudioSources) { source in
+                                    Text(source.title)
+                                        .tag(source)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                            .disabled(secureControlsDisabled)
+                            .accessibilityLabel("Recording audio source")
+                        }
+
+                        if settingsStore.recordingAudioSource.usesSystemAudio {
+                            Toggle(
+                                "I understand system audio can include meeting audio and other people's voices",
+                                isOn: $settingsStore.hasAcceptedSystemAudioRecordingConsent
+                            )
+                            .disabled(secureControlsDisabled)
+
+                            Text("Get consent before recording system audio. BugNarrator stores finished sessions locally and sends recorded audio to OpenAI only when transcription runs.")
+                                .font(.footnote)
+                                .foregroundStyle(
+                                    settingsStore.hasAcceptedSystemAudioRecordingConsent
+                                        ? Color.secondary
+                                        : Color.orange
+                                )
+                        } else if settingsStore.systemAudioCaptureEnabled {
+                            Text("System audio modes require a separate macOS permission prompt the first time capture starts.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
                 GroupBox("Transcription Defaults") {
                     VStack(alignment: .leading, spacing: 12) {
                         sectionIntro("Choose the default transcription model and optional hints BugNarrator sends to the selected provider.")
@@ -209,6 +251,9 @@ struct SettingsView: View {
                         sectionIntro("BugNarrator only asks for the permissions it needs for recording and screenshots.")
 
                         Text("BugNarrator asks for microphone access only when you start recording.")
+                            .foregroundStyle(.secondary)
+
+                        Text("BugNarrator asks for Screen & System Audio Recording access only when a system audio mode starts.")
                             .foregroundStyle(.secondary)
 
                         Text("BugNarrator asks for Screen Recording access only when you capture a screenshot. Recording can continue without screenshots if you skip this permission.")
@@ -668,6 +713,12 @@ struct SettingsView: View {
             get: { settingsStore.apiKey },
             set: { settingsStore.apiKey = $0 }
         )
+    }
+
+    private var availableRecordingAudioSources: [RecordingAudioSource] {
+        settingsStore.systemAudioCaptureEnabled
+            ? RecordingAudioSource.allCases
+            : [.microphone]
     }
 
     private var openAIReadiness: SettingsReadinessStatus {

--- a/Tests/BugNarratorTests/MicrophonePermissionServiceTests.swift
+++ b/Tests/BugNarratorTests/MicrophonePermissionServiceTests.swift
@@ -74,6 +74,20 @@ final class MicrophonePermissionServiceTests: XCTestCase {
         XCTAssertEqual(recorder.activationProbeCallCount, 0)
     }
 
+    func testPreflightSkipsMicrophonePermissionWhenRecorderDoesNotRequireIt() async {
+        let recorder = MockAudioRecorder()
+        recorder.requiresMicrophonePermission = false
+        recorder.permissionState = .denied
+        recorder.activationProbeBehavior = .success
+        let service = MicrophonePermissionService(permissionAccess: recorder)
+
+        let result = await service.preflightForRecordingStart(audioRecorder: recorder)
+
+        XCTAssertEqual(result, .success)
+        XCTAssertEqual(recorder.permissionRequestCallCount, 0)
+        XCTAssertEqual(recorder.activationProbeCallCount, 1)
+    }
+
     func testCurrentStatusReturnsGrantedWhenPermissionIsAuthorized() {
         let recorder = MockAudioRecorder()
         recorder.permissionState = .authorized

--- a/Tests/BugNarratorTests/ProductInfoTests.swift
+++ b/Tests/BugNarratorTests/ProductInfoTests.swift
@@ -30,10 +30,10 @@ final class ProductInfoTests: XCTestCase {
     }
 
     func testProjectLinksUseExpectedPublicURLs() {
-        XCTAssertEqual(BugNarratorLinks.repository.absoluteString, "https://github.com/deffenda/bugnarrator")
-        XCTAssertEqual(BugNarratorLinks.documentation.absoluteString, "https://github.com/deffenda/bugnarrator/blob/main/docs/UserGuide.md")
-        XCTAssertEqual(BugNarratorLinks.issues.absoluteString, "https://github.com/deffenda/bugnarrator/issues/new")
-        XCTAssertEqual(BugNarratorLinks.releases.absoluteString, "https://github.com/deffenda/bugnarrator/releases")
+        XCTAssertEqual(BugNarratorLinks.repository.absoluteString, "https://github.com/deffenda/bug-narrator")
+        XCTAssertEqual(BugNarratorLinks.documentation.absoluteString, "https://github.com/deffenda/bug-narrator/blob/main/docs/UserGuide.md")
+        XCTAssertEqual(BugNarratorLinks.issues.absoluteString, "https://github.com/deffenda/bug-narrator/issues/new")
+        XCTAssertEqual(BugNarratorLinks.releases.absoluteString, "https://github.com/deffenda/bug-narrator/releases")
         XCTAssertEqual(BugNarratorLinks.supportDevelopment.absoluteString, "https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8")
     }
 

--- a/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class RoutingAudioRecorderTests: XCTestCase {
+    func testSystemAudioRequiresFeatureFlag() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.recordingAudioSource = .systemAudio
+        let systemRecorder = MockAudioRecorder()
+        systemRecorder.requiresMicrophonePermission = false
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: systemRecorder,
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        let error = await router.validateRecordingActivation()
+
+        XCTAssertEqual(error, .systemAudioFeatureDisabled)
+        XCTAssertFalse(router.requiresMicrophonePermission)
+    }
+
+    func testSystemAudioRequiresConsentAcknowledgement() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .systemAudio
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: MockAudioRecorder(),
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        let error = await router.validateRecordingActivation()
+
+        XCTAssertEqual(error, .systemAudioConsentRequired)
+    }
+
+    func testRoutesSystemAudioStartAndStopToSystemRecorder() async throws {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .systemAudio
+        store.hasAcceptedSystemAudioRecordingConsent = true
+
+        let microphoneRecorder = MockAudioRecorder()
+        let systemRecorder = MockAudioRecorder()
+        systemRecorder.requiresMicrophonePermission = false
+        systemRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: URL(fileURLWithPath: "/tmp/system.wav"), duration: 3))
+        ]
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemRecorder,
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        try await router.startRecording()
+        let recordedAudio = try await router.stopRecording()
+
+        XCTAssertEqual(recordedAudio.fileURL.lastPathComponent, "system.wav")
+        XCTAssertEqual(systemRecorder.startCallCount, 1)
+        XCTAssertEqual(systemRecorder.stopCallCount, 1)
+        XCTAssertEqual(microphoneRecorder.startCallCount, 0)
+    }
+
+    func testRoutesMicAndSystemModeToMixedRecorderAndRequiresMicrophonePermission() async throws {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .microphoneAndSystemAudio
+        store.hasAcceptedSystemAudioRecordingConsent = true
+
+        let mixedRecorder = MockAudioRecorder()
+        mixedRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: URL(fileURLWithPath: "/tmp/mixed.m4a"), duration: 5))
+        ]
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: MockAudioRecorder(),
+            microphoneAndSystemAudioRecorder: mixedRecorder
+        )
+
+        try await router.startRecording()
+        let recordedAudio = try await router.stopRecording()
+
+        XCTAssertTrue(router.requiresMicrophonePermission)
+        XCTAssertEqual(recordedAudio.fileURL.lastPathComponent, "mixed.m4a")
+        XCTAssertEqual(mixedRecorder.startCallCount, 1)
+        XCTAssertEqual(mixedRecorder.stopCallCount, 1)
+    }
+
+    private func makeSettingsStore() -> (SettingsStore, UserDefaults, String) {
+        let suiteName = "BugNarrator-RoutingAudioRecorderTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        return (store, defaults, suiteName)
+    }
+}

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -23,6 +23,9 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.stopRecordingHotkeyShortcut, .disabled)
         XCTAssertEqual(store.screenshotHotkeyShortcut, .disabled)
         XCTAssertEqual(store.jiraIssueType, "")
+        XCTAssertFalse(store.systemAudioCaptureEnabled)
+        XCTAssertEqual(store.recordingAudioSource, .microphone)
+        XCTAssertFalse(store.hasAcceptedSystemAudioRecordingConsent)
     }
 
     func testSettingsPersistAcrossReloads() {
@@ -48,6 +51,9 @@ final class SettingsStoreTests: XCTestCase {
         firstStore.autoCopyTranscript = false
         firstStore.autoSaveTranscript = false
         firstStore.autoExtractIssues = true
+        firstStore.systemAudioCaptureEnabled = true
+        firstStore.recordingAudioSource = .microphoneAndSystemAudio
+        firstStore.hasAcceptedSystemAudioRecordingConsent = true
         firstStore.openAtStartup = true
         firstStore.debugMode = true
         firstStore.startRecordingHotkeyShortcut = HotkeyShortcut(
@@ -94,6 +100,9 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(secondStore.autoCopyTranscript)
         XCTAssertFalse(secondStore.autoSaveTranscript)
         XCTAssertTrue(secondStore.autoExtractIssues)
+        XCTAssertTrue(secondStore.systemAudioCaptureEnabled)
+        XCTAssertEqual(secondStore.recordingAudioSource, .microphoneAndSystemAudio)
+        XCTAssertTrue(secondStore.hasAcceptedSystemAudioRecordingConsent)
         XCTAssertTrue(secondStore.openAtStartup)
         XCTAssertTrue(secondStore.debugMode)
         XCTAssertEqual(secondStore.startRecordingHotkeyShortcut.keyCode, 1)
@@ -345,6 +354,35 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.jiraTokenPersistenceState, .keychain)
         XCTAssertEqual(keychain.values["BugNarrator.OpenAI::openai-api-key"], "draft-openai-key")
         XCTAssertEqual(keychain.values["BugNarrator.Jira::jira-api-token"], "draft-jira-token")
+    }
+
+    func testInvalidRecordingAudioSourceFallsBackToMicrophone() {
+        let suiteName = "BugNarrator-RecordingAudioSourceInvalidTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "settings.systemAudioCaptureEnabled")
+        defaults.set("not-a-source", forKey: "settings.recordingAudioSource")
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        XCTAssertEqual(store.recordingAudioSource, .microphone)
+    }
+
+    func testSystemAudioSourceResetsWhenFeatureFlagIsDisabled() {
+        let suiteName = "BugNarrator-RecordingAudioSourceFlagTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: "settings.systemAudioCaptureEnabled")
+        defaults.set(RecordingAudioSource.systemAudio.rawValue, forKey: "settings.recordingAudioSource")
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        XCTAssertEqual(store.recordingAudioSource, .microphone)
+        XCTAssertEqual(defaults.string(forKey: "settings.recordingAudioSource"), RecordingAudioSource.microphone.rawValue)
     }
 
     func testTrackerSetupReadinessDoesNotRequireLoadedPickerSelections() {

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -11,6 +11,7 @@ final class MockAudioRecorder: AudioRecording, MicrophonePermissionAccessing {
     }
 
     var currentDuration: TimeInterval = 0
+    var requiresMicrophonePermission = true
     var startCallCount = 0
     var stopCallCount = 0
     var cancelPreserveArguments: [Bool] = []


### PR DESCRIPTION
## Summary
- Add recording source modes for mic only, system audio only, and mic + system audio behind an experimental setting.
- Add consent-oriented settings UI and recovery paths for system audio capture permissions and setup.
- Add Core Audio process-tap recording, routing, and mic/system mixing support.
- Update tests for routing, settings persistence, microphone preflight, and the current public repository links.

## Validation
- `xcodegen generate`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' test -only-testing:BugNarratorTests` (268 tests, 0 failures)

## Notes
- Local Xcode still reports the existing CoreSimulator version warning, but the macOS test target completes successfully.