### PR TITLE
[codex] Document AI provider support strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The product is organized around one durable workflow:
 It can:
 
 - record a narrated session from the menu bar
-- transcribe the finished recording with the OpenAI API
+- transcribe the finished recording with the configured AI provider
 - capture screenshots during a live review and turn them into timeline markers automatically
 - generate a review summary
 - extract draft bugs, UX issues, enhancements, and follow-up questions
@@ -56,19 +56,21 @@ It can:
 - keep a searchable session library with date filters and deletion
 - stay responsive with larger local histories by caching session-library metadata for faster filtering, search, and selection changes
 
-## Bring Your Own OpenAI API Key
+## Bring Your Own AI Provider
 
-BugNarrator does not ship with a built-in OpenAI API key.
+BugNarrator does not ship with built-in AI access or credits.
 
-Every user must provide their own key in `Settings` before transcription or issue extraction will work.
+OpenAI is the default provider. In `Settings`, you can also choose an OpenAI-compatible enterprise gateway or a local-compatible endpoint when that endpoint exposes the OpenAI-compatible APIs BugNarrator needs.
 
 Important:
 
-- transcription uses the OpenAI API, not a local Whisper model
-- issue extraction also uses the OpenAI API
-- OpenAI usage may cost money on your account
-- the app stores your key in macOS Keychain when available
-- the key is not bundled into the source code or compiled app
+- transcription requires a provider endpoint compatible with `/v1/audio/transcriptions`
+- issue extraction requires a provider endpoint compatible with `/v1/chat/completions`
+- local-compatible providers can leave the API key blank if the local endpoint does not require authentication
+- unsupported local/default model combinations show clear setup guidance in Settings instead of starting a broken transcription
+- provider usage may cost money on your account when you use a hosted provider
+- the app stores your provider credential in macOS Keychain when available
+- credentials are not bundled into the source code or compiled app
 - global hotkeys are optional and start unassigned until you assign them
 
 ## Install On macOS
@@ -78,7 +80,7 @@ Important:
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
 5. If Gatekeeper warns about the app, open `Applications`, Control-click `BugNarrator.app`, choose `Open`, then confirm once.
-6. On first run, expect OpenAI API key setup. Microphone permission is requested the first time you try to start recording.
+6. On first run, expect AI provider setup. Microphone permission is requested the first time you try to start recording.
 7. If you use screenshot capture, expect Screen Recording permission on first use.
 8. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
 9. If you try to launch BugNarrator a second time, macOS should bring the existing BugNarrator instance forward instead of opening another menu bar copy.
@@ -87,8 +89,8 @@ Important:
 
 1. Launch BugNarrator and open the menu bar item.
 2. Open `Settings`.
-3. Paste your own `OpenAI API Key`.
-4. Optionally click `Validate Key`.
+3. Choose an AI provider and enter the required key or base URL.
+4. Optionally click `Validate Key` or `Validate Connection`.
 5. Click `Show Recording Controls`.
 6. Click `Start Recording`.
 7. Speak while you continue reviewing the target app. For better transcripts and bug reports, follow the [Tester Narration Guide](docs/UserGuide.md#tester-narration-guide).
@@ -188,13 +190,13 @@ BugNarrator does not require Accessibility permission for its core workflow beca
 Data that stays local on your Mac:
 
 - session history
-- transcripts after they return from OpenAI
+- transcripts after they return from the configured AI provider
 - screenshot-driven timeline markers and older marker data from existing sessions
 - screenshots and screenshot metadata
 - extracted issue drafts
 - exported bundles you explicitly create
 
-Data sent to OpenAI:
+Data sent to the configured AI provider:
 
 - recorded audio when you stop a session and request transcription
 - transcript context used for issue extraction or summary generation

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -15,11 +15,12 @@ Structured counterpart: [docs/testing/testing.md](testing/testing.md)
 - Launch BugNarrator a second time while it is already running and confirm the existing instance becomes active instead of creating a second menu bar item.
 - Confirm a double-launch attempt does not produce duplicate recording state, duplicate export work, or duplicate menu bar icons.
 - Confirm the first launch does not trigger an unexpected Keychain or admin-style credential prompt before you open Settings or start a key-dependent action.
-- Confirm the menu bar explains that the app requires the user's own OpenAI API key.
-- Open Settings and verify the onboarding copy explains that OpenAI usage may incur charges.
-- Verify the OpenAI API key can be entered, remains masked, and shows a secure-storage note.
-- Verify `Validate Key` reports success for a working key and a clear error for a bad key.
-- Verify `Remove Key` clears the stored OpenAI key.
+- Confirm the menu bar explains that the app requires the user's own AI provider configuration.
+- Open Settings and verify the onboarding copy explains that hosted AI-provider usage may incur charges.
+- Verify the default OpenAI API key can be entered, remains masked, and shows a secure-storage note.
+- Verify OpenAI-Compatible and Local-Compatible provider choices expose provider-specific base URL and credential guidance.
+- Verify `Validate Key` or `Validate Connection` reports success for a working configuration and a clear error for a bad one.
+- Verify `Remove Key` clears the stored AI provider credential.
 - Verify GitHub and Jira tokens remain masked and can be removed.
 - Verify `Export Debug Bundle` is hidden by default in the menu bar and appears only while the `Option` key is held down.
 - Verify `Export Debug Bundle` writes a local bundle containing `system-info.json`, `app-version.txt`, `macos-version.txt`, `recent-log.txt`, and `session-metadata.json`.
@@ -188,10 +189,10 @@ Structured counterpart: [docs/testing/testing.md](testing/testing.md)
 
 ## Failure Cases
 
-- Remove the OpenAI API key and attempt to start a session.
-  Expected: recording can still start after microphone permission is granted, but the app explains that transcription will require the user's own OpenAI API key before the session can be finished with OpenAI features.
-- Start recording, remove the OpenAI API key from Settings, then stop the session.
-  Expected: the app preserves the finished session and audio, explains that the key is missing, keeps the session available in the library, and allows transcription to be retried after the key is restored.
+- Remove the AI provider credential and attempt to start a session.
+  Expected: recording can still start after microphone permission is granted, but the app explains that transcription will require valid AI provider setup before the session can be finished with AI features.
+- Start recording, remove or invalidate the AI provider configuration in Settings, then stop the session.
+  Expected: the app preserves the finished session and audio, explains that provider setup is missing or invalid, keeps the session available in the library, and allows transcription to be retried after the configuration is restored.
 - Deny microphone permission and attempt to start a session.
   Expected: recording does not start, the error explains how to re-enable access in System Settings, and `Open Microphone Settings` opens the expected privacy pane or a safe fallback.
 - Force or simulate a restricted microphone state if practical.
@@ -212,8 +213,8 @@ Structured counterpart: [docs/testing/testing.md](testing/testing.md)
   Expected: BugNarrator explains that the local screenshot file is no longer available instead of failing silently.
 - Disconnect networking or force a timeout during transcription.
   Expected: transcription ends in a clear timeout or API error state and the app returns to a usable state.
-- Use an invalid OpenAI API key.
-  Expected: transcription or issue extraction ends in a clear invalid-key error, Settings opens, and the preserved session remains available so transcription can be retried after the key is replaced.
+- Use an invalid hosted-provider API key or unsupported local-compatible model combination.
+  Expected: transcription or issue extraction ends in clear provider setup guidance, Settings opens when useful, and the preserved session remains available so transcription can be retried after the configuration is fixed.
 - Simulate a local history write failure after a successful transcription if practical.
   Expected: the transcript window still opens, the completed session remains available as an unsaved session, screenshots remain accessible, and `Save to History` can be retried later after storage is fixed.
 - Cancel an active recording.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ Use this checklist before cutting a public test build or release candidate.
 
 ## Core Product Workflow
 
-- Add or validate an OpenAI API key in Settings.
+- Add or validate the intended AI provider configuration in Settings.
 - Start a recording session and confirm the app enters `Recording`.
 - Capture at least one screenshot during the session and confirm it creates a visible timeline moment in review.
 - Stop the session and confirm transcription succeeds.
@@ -48,7 +48,7 @@ Use this checklist before cutting a public test build or release candidate.
 
 - Quit and relaunch the app and confirm existing sessions reload correctly.
 - If local history storage fails after a successful transcription, confirm the transcript still opens as an unsaved session and can be saved later after storage is restored.
-- If transcription cannot start because the OpenAI key is missing, invalid, or revoked after recording finishes, confirm the finished audio stays preserved in the session artifacts and the session remains retryable after the key is restored.
+- If transcription cannot start because the AI provider configuration is missing, invalid, or revoked after recording finishes, confirm the finished audio stays preserved in the session artifacts and the session remains retryable after the configuration is restored.
 - Delete a session with screenshots and verify the local managed screenshot folder is removed.
 - Confirm exported bundles outside the app remain untouched after deletion.
 - In non-debug mode, verify temporary audio files are cleaned up after success, failure, and cancellation, except for preserved retryable sessions where the finished audio is intentionally retained until transcription succeeds or the session is deleted.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -42,19 +42,20 @@ It helps you:
 - macOS 14 or later
 - microphone permission for recording
 - Screen Recording permission if you want screenshot capture
-- your own OpenAI API key for transcription and issue extraction
+- your own AI provider configuration for transcription and issue extraction
 
 ## First Run
 
 1. Launch BugNarrator and confirm the menu bar icon appears.
 2. Open `Settings`.
-3. Paste your own `OpenAI API Key`.
-4. Optionally click `Validate Key`.
-5. Optionally assign global hotkeys for `Start Recording`, `Stop Recording`, and `Capture Screenshot`. They begin as `Not Set` until you choose them.
-6. Click `Show Recording Controls`.
-6. Start a session with `Start Recording`.
+3. Choose an AI provider.
+4. Enter the required API key or base URL for that provider.
+5. Optionally click `Validate Key` or `Validate Connection`.
+6. Optionally assign global hotkeys for `Start Recording`, `Stop Recording`, and `Capture Screenshot`. They begin as `Not Set` until you choose them.
+7. Click `Show Recording Controls`.
+8. Start a session with `Start Recording`.
 
-BugNarrator does not ship with a built-in OpenAI API key. Transcription and issue extraction use your own OpenAI account and may incur charges under OpenAI pricing.
+BugNarrator does not ship with built-in AI access or credits. OpenAI is the default provider. You can also select an OpenAI-compatible enterprise gateway or a local-compatible endpoint when that endpoint exposes the OpenAI-compatible transcription and chat APIs BugNarrator needs. Hosted provider usage may incur charges on that provider account.
 
 ## Core Workflow
 
@@ -72,9 +73,9 @@ You can keep using global hotkeys if you assign them in Settings, but the record
 
 ### Stop A Session
 
-When you finish, stop the session from the control window or a stop hotkey you explicitly assigned. BugNarrator then preserves the finished audio inside the session artifacts and, when your OpenAI API key is available, uploads the recorded audio to OpenAI and waits for the transcript result.
+When you finish, stop the session from the control window or a stop hotkey you explicitly assigned. BugNarrator then preserves the finished audio inside the session artifacts and, when your AI provider configuration is available, uploads the recorded audio to the configured provider and waits for the transcript result.
 
-If the key is missing, invalid, or revoked at stop time, the session still stays in the library as a retryable item. Restore or replace the key in `Settings`, then open the session again and retry transcription from the preserved session.
+If the provider configuration is missing, invalid, or revoked at stop time, the session still stays in the library as a retryable item. Restore or replace the configuration in `Settings`, then open the session again and retry transcription from the preserved session.
 
 ### Review The Session
 
@@ -242,7 +243,7 @@ Deleting a session removes it from the library immediately and also removes loca
 
 ## Support Development
 
-BugNarrator is free to use. Donations are optional and separate from any OpenAI costs.
+BugNarrator is free to use. Donations are optional and separate from any hosted AI-provider costs.
 
 - [Open the PayPal support page](https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8)
 
@@ -261,7 +262,7 @@ BugNarrator keeps diagnostics local until you explicitly export or copy them for
 
 ### No Transcript Generated
 
-- confirm your OpenAI API key is configured in `Settings`
+- confirm your AI provider configuration is valid in `Settings`
 - validate the key if needed
 - confirm the Mac has network access
 - retry with a short test recording to rule out an empty or corrupt audio file
@@ -283,20 +284,20 @@ BugNarrator keeps diagnostics local until you explicitly export or copy them for
 - if you try to launch a second copy, the existing instance should become active and the new copy should exit
 - if you see two BugNarrator menu bar items at once, quit both copies and relaunch the copy in `Applications`
 
-### API Key Missing
+### Provider Credential Missing
 
 - open `Settings`
-- paste your own OpenAI API key
-- click `Validate Key` if you want to check it before transcription or issue extraction
-- BugNarrator stores the key in macOS Keychain when available
-- if a completed session could not be transcribed because the key was missing at stop time, keep the session and retry after adding the key back
+- choose an AI provider and enter your own provider credential or base URL
+- click `Validate Key` or `Validate Connection` if you want to check it before transcription or issue extraction
+- BugNarrator stores provider credentials in macOS Keychain when available
+- if a completed session could not be transcribed because the provider configuration was missing at stop time, keep the session and retry after restoring the configuration
 
-### API Key Rejected Or Revoked
+### Provider Credential Rejected Or Revoked
 
 - open `Settings`
-- replace the key or remove it and paste a new one
-- click `Validate Key`
-- try the preserved session again after OpenAI accepts the new key
+- replace the provider credential or fix the configured endpoint/model
+- click `Validate Key` or `Validate Connection`
+- try the preserved session again after the provider accepts the new configuration
 
 ### Screenshots Not Appearing
 
@@ -326,7 +327,7 @@ What stays local on your Mac:
 - extracted issue drafts
 - exported session bundles
 
-What is sent to OpenAI:
+What is sent to the configured AI provider:
 
 - recorded audio after you stop a session and request transcription
 - transcript context used for review summary or issue extraction

--- a/docs/architecture/product-spec.md
+++ b/docs/architecture/product-spec.md
@@ -165,7 +165,7 @@ If issue extraction returns no draft issues, the review flow must fall back to `
 
 Settings owns:
 
-- OpenAI credential setup
+- AI provider credential and endpoint setup
 - transcription defaults
 - issue-extraction defaults
 - workflow defaults
@@ -203,11 +203,13 @@ The app must:
 
 BugNarrator generates transcripts after recording ends.
 
-It does not continuously stream live audio to OpenAI while the user is still recording.
+It does not continuously stream live audio to the configured AI provider while the user is still recording.
+
+OpenAI remains the default provider. OpenAI-compatible enterprise gateways and local-compatible endpoints are supported when they expose the transcription and chat APIs BugNarrator needs. Unsupported provider/model combinations must fail before transcription or issue extraction starts with clear setup guidance.
 
 ### Recovery
 
-If the OpenAI key is missing, invalid, or revoked when a session finishes recording:
+If the AI provider configuration is missing, invalid, or revoked when a session finishes recording:
 
 - the completed session must remain preserved locally
 - the library must expose that the session needs transcription retry
@@ -297,7 +299,7 @@ It may include:
 
 It must not include:
 
-- raw OpenAI keys
+- raw AI provider credentials
 - raw GitHub tokens
 - raw Jira tokens
 - other raw credentials
@@ -306,11 +308,11 @@ It must not include:
 
 ### Credentials
 
-BugNarrator does not ship with a built-in OpenAI API key.
+BugNarrator does not ship with built-in AI access or credits.
 
 Users must provide their own credentials for:
 
-- OpenAI transcription and issue extraction
+- AI-provider transcription and issue extraction
 - GitHub export
 - Jira export
 
@@ -336,7 +338,7 @@ Current product behavior:
 Data that remains local unless the user explicitly exports it:
 
 - session history
-- transcript results returned from OpenAI
+- transcript results returned from the configured AI provider
 - screenshots and screenshot metadata
 - extracted issue drafts
 - debug bundles
@@ -344,7 +346,7 @@ Data that remains local unless the user explicitly exports it:
 
 Data sent off-device only when the user invokes the relevant workflow:
 
-- recorded audio for OpenAI transcription
+- recorded audio for configured-provider transcription
 - transcript context for summary or issue extraction
 - selected issue payloads for GitHub or Jira export
 

--- a/docs/user/user-manual.md
+++ b/docs/user/user-manual.md
@@ -21,7 +21,7 @@ BugNarrator is a macOS menu bar app for narrated software testing sessions. It h
 You need:
 
 - a macOS 14 or later Mac
-- your own OpenAI API key for transcription and issue extraction
+- your own AI provider configuration for transcription and issue extraction
 - microphone permission for recording
 - Screen Recording permission if you want screenshots
 
@@ -36,10 +36,11 @@ You need:
 
 1. Open the menu bar item.
 2. Open `Settings`.
-3. Paste your OpenAI API key.
-4. Optionally validate the key.
+3. Choose an AI provider.
+4. Enter the required API key or base URL.
+5. Optionally validate the key or connection.
 
-BugNarrator does not ship with a built-in OpenAI key.
+BugNarrator does not ship with built-in AI access or credits. OpenAI remains the default provider, and OpenAI-compatible enterprise or local-compatible endpoints can be configured when they expose the transcription and chat APIs BugNarrator needs.
 
 ## Recording Workflow
 
@@ -51,7 +52,7 @@ BugNarrator does not ship with a built-in OpenAI key.
 
 The recording controls window stays open until you close it.
 
-If the OpenAI key is missing, invalid, or revoked when the recording finishes, BugNarrator preserves the finished session in the library so you can restore the key and retry transcription later.
+If the AI provider configuration is missing, invalid, or revoked when the recording finishes, BugNarrator preserves the finished session in the library so you can restore the configuration and retry transcription later.
 
 Sessions waiting for transcription retry are also surfaced in the menu bar window and at the top of the session-library list, so the recovery flow stays visible after relaunch.
 
@@ -89,7 +90,7 @@ Common fixes:
 
 - microphone blocked: use `Open Microphone Settings`
 - screenshot blocked: use `Open Screen Recording Settings`
-- invalid OpenAI key: open `Settings`, replace the key, and retry
+- invalid AI provider setup: open `Settings`, replace the credential or fix the endpoint/model, and retry
 
 For support, hold `Option` while the menu bar window is open to reveal `Export Debug Bundle`.
 

--- a/site/docs/onboarding/getting-started.md
+++ b/site/docs/onboarding/getting-started.md
@@ -8,7 +8,7 @@ This page mirrors the canonical onboarding guidance in the repository and points
 
 1. Download the latest DMG from [GitHub Releases](https://github.com/deffenda/bug-narrator/releases).
 2. Install `BugNarrator.app` into `Applications`.
-3. Open BugNarrator and add your OpenAI API key in `Settings`.
+3. Open BugNarrator and configure your AI provider in `Settings`.
 4. Open `Show Recording Controls` and start a narrated session.
 5. Follow the [Tester Narration Guide](https://github.com/deffenda/bug-narrator/blob/main/docs/UserGuide.md#tester-narration-guide) during real testing passes.
 

--- a/site/docs/user/user-manual.md
+++ b/site/docs/user/user-manual.md
@@ -11,20 +11,22 @@ This site page mirrors the canonical user manual in the repository and stays foc
 You need:
 
 - a macOS 14 or later Mac
-- your own OpenAI API key for transcription and issue extraction
+- your own AI provider configuration for transcription and issue extraction
 - microphone permission for recording
 - Screen Recording permission if you want screenshots
 
 ## Recording Workflow
 
 1. Open the menu bar item.
-2. Open `Settings` and add your OpenAI API key.
+2. Open `Settings` and configure your AI provider.
 3. Click `Show Recording Controls`.
 4. Click `Start Recording`.
 5. Narrate what you are doing and capture screenshots when important evidence appears.
 6. Click `Stop Recording`.
 
-If the OpenAI key is missing, invalid, or revoked when recording stops, BugNarrator preserves the finished session so you can restore the key and retry transcription later.
+OpenAI remains the default provider. OpenAI-compatible enterprise or local-compatible endpoints can be configured when they expose the transcription and chat APIs BugNarrator needs.
+
+If the AI provider configuration is missing, invalid, or revoked when recording stops, BugNarrator preserves the finished session so you can restore the configuration and retry transcription later.
 
 ## Review Workflow
 


### PR DESCRIPTION
## Summary
- documents the current AI-provider strategy for #64 across README, user docs, QA, release, and product-spec surfaces
- clarifies that OpenAI remains the default while OpenAI-compatible enterprise gateways and local-compatible endpoints can be configured when they expose the required transcription and chat APIs
- records the unsupported local/default-model behavior as clear setup guidance rather than a broken transcription path

## Validation
- ./scripts/validate.sh origin/main
- git diff --check
- npm run build --prefix site
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- test -only-testing:BugNarratorTests/SettingsStoreTests/testSettingsPersistAcrossReloads -only-testing:BugNarratorTests/TranscriptionClientTests/testCustomAPIBaseURLIsUsedForRequests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- test -only-testing:BugNarratorTests/SettingsStoreTests/testLocalCompatibleProviderRequiresExplicitBaseURLAndModels -only-testing:BugNarratorTests/SettingsStoreTests/testOpenAICompatibleProviderRequiresNonDefaultBaseURL

Closes #64
