### PR TITLE
Advance Windows parity tracking

### DIFF
--- a/docs/architecture/parity-matrix.md
+++ b/docs/architecture/parity-matrix.md
@@ -14,25 +14,28 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 
 | Contract / Spec Item | macOS | Windows | Parity Decision | Notes / Rationale |
 | --- | --- | --- | --- | --- |
-| Durable workflow: `record -> review -> refine -> export` | Shipped | In Progress | Must remain identical | The UI can differ by platform, but the workflow contract stays stable. |
-| Compact launch surface | Shipped as a menu bar window | In Progress as a tray shell | Native surfaces allowed | Menu bar and tray are platform-native equivalents. |
-| Recording Controls surface | Shipped | In Progress | Must remain functionally aligned | Start, stop, screenshot, and close actions should exist on both platforms. |
-| Single active recording session | Shipped | In Progress | Must remain identical | Duplicate starts and overlapping sessions are disallowed everywhere. |
-| Screenshot evidence during recording | Shipped | In Progress | Native capture implementation allowed | macOS uses ScreenCaptureKit-backed capture; Windows can use a native overlay plus selected-region capture. |
-| Session Library archive | Shipped | Planned in `WIN-005` | Must remain identical | Date filters, search, sorting, and deletion remain part of the durable archive contract. |
-| Review Workspace tabs | Shipped | Planned in `WIN-005` / `WIN-006` | Must remain identical | Canonical tabs remain `Transcript`, `Screenshots`, `Extracted Issues`, and `Summary`. |
-| Session Bundle export | Shipped | Planned in `WIN-006` | Must remain identical | Exported bundle stays `transcript.md` plus `screenshots/`. |
-| Debug Bundle support export | Shipped | Planned in `WIN-006` | Must remain aligned | Diagnostics may differ, but secrets must stay excluded on both platforms. |
-| Missing or invalid OpenAI key recovery | Shipped | Planned in `WIN-005` | Must remain identical | Finished recordings must stay recoverable and retryable instead of being lost. |
-| Experimental GitHub and Jira export | Shipped as experimental | Planned in `WIN-006` | Experimental on both platforms | Integration maturity stays explicit until it is hardened and validated. |
-| Keyboard-first accessibility | Shipped baseline, still under ongoing validation | Planned | Native implementation allowed | The contract is clear keyboard and assistive-tech support, not identical widgets. |
-| Public release packaging | Shipped as signed, notarized DMG | Planned | Platform-native packaging allowed | macOS uses DMG/notarization; Windows will use signed installer packaging. |
+| Durable workflow: `record -> review -> refine -> export` | Shipped | In Progress | Must remain identical | Windows implements the core workflow, but real desktop validation remains open in `RR-002` / #44. |
+| Compact launch surface | Shipped as a menu bar window | In Progress as a tray shell | Native surfaces allowed | Menu bar and tray are platform-native equivalents; Windows still needs real tray validation in #44. |
+| Recording Controls surface | Shipped | In Progress | Must remain functionally aligned | Windows has the surface implemented; real recording-controls validation remains in #44. |
+| Single active recording session | Shipped | In Progress | Must remain identical | Automated coverage exists on Windows, but real runtime validation remains in #44. |
+| Screenshot evidence during recording | Shipped | In Progress | Native capture implementation allowed | Windows has overlay/capture plumbing, but DPI, multi-monitor, and real desktop capture validation remain in #44. |
+| Session Library archive | Shipped | In Progress | Must remain identical | Implemented by Windows Milestone 5; #50 is closed as completed, with remaining validation tracked in #44. |
+| Review Workspace tabs | Shipped | In Progress | Must remain identical | Implemented by Windows Milestones 5 and 6; #51 is closed as completed, with remaining validation tracked in #44. |
+| Session Bundle export | Shipped | In Progress | Must remain identical | Implemented by Windows Milestone 6; validation remains in #44 and release hardening remains in #75. |
+| Debug Bundle support export | Shipped | In Progress | Must remain aligned | Implemented on Windows with redaction/hardening coverage; real support-bundle validation remains in #44. |
+| Missing or invalid AI provider recovery | Shipped | In Progress | Must remain identical | Windows preserves completed sessions on missing or failed transcription, but provider terminology/configuration parity is tracked in #73. |
+| Configurable AI provider setup | Shipped | Planned in `WIN-007` | Must remain aligned | macOS supports OpenAI plus OpenAI-compatible enterprise/local endpoints; Windows follow-up is tracked in #73. |
+| Recording audio source selection | Shipped | Planned in `WIN-008` | Platform-native capture allowed | macOS supports microphone, system audio, and mic plus system audio; Windows follow-up is tracked in #74. |
+| Experimental GitHub and Jira export | Shipped as experimental | In Progress | Experimental on both platforms | Windows implementation exists; real credential validation remains in #44. |
+| Keyboard-first accessibility | Shipped baseline, validated in RR-005 | In Progress | Native implementation allowed | The contract is clear keyboard and assistive-tech support, not identical widgets. |
+| Public release packaging | Shipped as signed, notarized DMG | Planned in `WIN-009` | Platform-native packaging allowed | Windows zip packaging exists; signed tester release work is tracked in #75. |
 
 ## Current Deliberate Differences
 
 - macOS is the only production platform today.
-- Windows milestone work through tray shell, recording lifecycle, and screenshot scaffolding is present in the repo but still blocked on real Windows runtime validation in `RR-002`.
-- macOS currently has the stronger recovery story because preserved-session retry has already shipped there.
+- Windows implements the core `record -> review -> refine -> export` path, including session library, review workspace, extraction, export, hotkeys, and hardening coverage, but it still needs real Windows runtime validation in `RR-002` / #44.
+- macOS currently has newer configurable AI provider and audio-source surfaces; Windows follow-up parity is tracked in #73 and #74.
+- Windows public tester distribution is still blocked on signing/release packaging decisions tracked in #75.
 
 ## Update Rules
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -61,6 +61,13 @@ Current Windows milestone status:
 - stopping a recording now saves the session even when no OpenAI API key is configured and preserves a clear failure state if transcription fails
 - automated coverage currently includes `9` core tests and `29` Windows tests
 - `windows/scripts/package-windows.ps1` currently produces a zipped `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
-- `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then launches the packaged app in a headless smoke mode that writes a structured report and exits cleanly
+- `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then writes a structured package smoke report for CI/release evidence
 - CI now uploads `bugnarrator-windows-package` and `bugnarrator-windows-validation` artifacts from the Windows runner
 - manual validation is still required for live OpenAI transcription, live issue extraction, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
+
+Current follow-up parity tickets:
+
+- `RR-002` / #44 remains the real Windows desktop validation gate.
+- `WIN-007` / #73 tracks Windows AI provider setup parity with the current macOS provider model.
+- `WIN-008` / #74 tracks Windows system audio and mixed audio recording parity.
+- `WIN-009` / #75 tracks the signed Windows tester release path.

--- a/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
+++ b/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
@@ -509,11 +509,68 @@ Current implementation findings:
 
 ## Current macOS Parity Review
 
-As of March 18, 2026, the current Windows branch is in strong parity with the current macOS app for the core `record -> review -> refine -> export` workflow:
+As of May 12, 2026, the current Windows branch is in strong parity with the current macOS app for the core `record -> review -> refine -> export` workflow:
 
 - tray shell, recording controls, optional global hotkeys, microphone recording, screenshot capture, transcription, session review, issue extraction, bundle export, debug bundle export, and experimental GitHub/Jira export are all implemented on Windows
 - the post-MVP hardening and hotkey milestones improved the reliability and reach of the existing workflow without reopening already-complete review surfaces
-- the remaining work is mostly real-desktop validation and Windows-specific polish around reserved shortcuts, keyboard layouts, DPI, multi-monitor behavior, and third-party integration credentials rather than a missing core workflow phase
+- `WIN-005` and `WIN-006` are closed as completed against current `main`; remaining runtime confidence stays tracked in `RR-002`
+- the remaining high-value parity work is now Windows-specific validation and newer macOS surface parity rather than the older missing review/export milestones
+
+### WIN-007: Windows AI Provider Setup Parity
+
+Goal:
+
+- align Windows with the current macOS AI provider model instead of keeping the Windows flow OpenAI-specific
+
+Deliverables:
+
+- provider selection with OpenAI as the default
+- configurable OpenAI-compatible base URL for enterprise and local-compatible endpoints
+- credential validation and compatibility feedback before transcription or issue extraction where practical
+- transcription and issue-extraction clients that build endpoints from provider settings
+- preserved-session retry behavior when provider configuration is missing, invalid, or revoked
+- redaction coverage for provider credentials and endpoint-sensitive diagnostics
+
+Tracking:
+
+- GitHub issue #73
+
+### WIN-008: Windows System Audio And Mixed Audio Recording Parity
+
+Goal:
+
+- align Windows recording-source options with the current macOS microphone, system audio, and microphone plus system audio model
+
+Deliverables:
+
+- recording source setting for microphone, system audio, and microphone plus system audio
+- Windows system audio capture, likely through WASAPI loopback via NAudio
+- mixed microphone plus system audio capture, or a documented follow-up if muxing requires a split implementation
+- consent and privacy messaging for system audio capture
+- recording-source preflight, diagnostics, and user-facing recovery states
+- validation that generated artifacts remain transcribable and compatible with the existing session persistence model
+
+Tracking:
+
+- GitHub issue #74
+
+### WIN-009: Signed Windows Tester Release
+
+Goal:
+
+- move Windows from internal zip validation to a signed tester-ready release artifact
+
+Deliverables:
+
+- decide signed zip versus installer versus MSIX for the first tester artifact
+- provision a Windows code-signing certificate outside the repo
+- sign the executable and any distributable artifact
+- validate the signed artifact on a clean Windows machine
+- publish release notes and validation evidence
+
+Tracking:
+
+- GitHub issue #75
 
 ## Suggested Repo Skeleton
 

--- a/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
+++ b/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
@@ -15,9 +15,9 @@ That script publishes `BugNarrator.Windows.csproj` for `win-x64` by default and 
 - `windows/artifacts/publish/<runtime>/`
 - `windows/artifacts/packages/BugNarrator-windows-<runtime>.zip`
 
-This is sufficient for internal validation and external handoff while installer work remains deferred.
+This is sufficient for internal validation and external handoff while installer work remains deferred. The signed tester release work is tracked in GitHub issue #75.
 
-CI now validates the packaged zip contents and launches the packaged Windows executable in a headless smoke mode before uploading the Windows artifact from `windows-latest`. This improves release-candidate confidence, but it does not replace a real desktop validation pass for tray, microphone, screenshot, or hotkey behavior.
+CI now validates the packaged zip contents and writes a structured package smoke report before uploading the Windows artifact from `windows-latest`. This improves release-candidate confidence, but it does not replace a real desktop validation pass for tray, microphone, screenshot, or hotkey behavior.
 
 ## Build And Test
 
@@ -71,3 +71,5 @@ Until a real code-signing certificate is provisioned, release candidates should 
 3. Sign `BugNarrator.Windows.exe` and any additional distributables with `windows/scripts/sign-windows.ps1`.
 4. Validate the signed build on a clean Windows machine.
 5. Upload the zip package and validation notes to GitHub Releases.
+
+For `WIN-009`, decide whether the first tester artifact remains a signed zip or moves to installer packaging. A signed zip is the shortest path to parity evidence; installer or MSIX work can follow if tester distribution needs it.

--- a/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
+++ b/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
@@ -42,8 +42,8 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 ## Automated Coverage Notes
 - `BugNarrator.Core.Tests` currently covers deterministic screenshot artifact naming, screenshot-linked timeline moment shaping, completed-session markdown output, session-library query behavior across `Yesterday`, `Last 30 Days`, and `Custom Date Range`, and structured issue-extraction parsing.
 - `BugNarrator.Windows.Tests` currently covers screenshot lifecycle orchestration, Milestone 5 stop-recording orchestration, OpenAI issue extraction behavior, GitHub/Jira export provider behavior, session bundle export, debug bundle export, Milestone 6 review-action orchestration, completed-session deletion, corrupted secret handling, session-path hardening, debug-log redaction, Windows hotkey validation, hotkey settings persistence, hotkey registration status, and hotkey-to-recording action routing.
-- CI now restores, builds, runs both Windows test projects, packages a `Release` zip, validates the packaged artifact contents on `windows-latest`, launches the packaged executable in a headless smoke mode, and uploads package and validation artifacts from the Windows runner.
-- Current passing automated coverage on this branch is `9` core tests and `29` Windows tests when run on Windows.
+- CI now restores, builds, runs both Windows test projects, packages a `Release` zip, validates the packaged artifact contents on `windows-latest`, writes a structured package smoke report, and uploads package and validation artifacts from the Windows runner.
+- Current passing automated coverage on this branch is `9` core tests and `35` Windows tests when run on Windows.
 - Manual validation is still required for overlay rendering, region selection behavior, desktop capture fidelity, live OpenAI transcription, live OpenAI issue extraction, real GitHub/Jira credentials, DPI scaling, multi-monitor behavior, reserved Windows shortcuts, alternate keyboard layouts, and out-of-focus hotkey behavior against real desktop apps.
 
 ## Milestone 2: Tray Shell And Single Instance
@@ -171,7 +171,31 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 - Run `powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release`.
 - Confirm `windows/artifacts/packages/BugNarrator-windows-win-x64.zip` is created.
 - Run `powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64`.
-- Confirm the validation script reports that the package contains the expected executable, DLL, and runtime metadata files, confirms packaged-file hashes match the publish output, then validates the packaged app's smoke-report JSON.
+- Confirm the validation script reports that the package contains the expected executable, DLL, and runtime metadata files, confirms packaged-file hashes match the publish output, then validates the package smoke-report JSON.
+
+## WIN-007: AI Provider Setup Parity
+- Confirm OpenAI remains the default provider.
+- Configure an OpenAI-compatible enterprise or local endpoint when available.
+- Validate that transcription and issue extraction use the configured provider endpoint.
+- Confirm unsupported provider/model combinations fail with clear setup guidance.
+- Confirm provider credentials are stored through Windows secret storage and do not appear in settings JSON, logs, or debug bundles.
+- Stop a recording with missing or invalid provider configuration and confirm the completed session remains retryable.
+
+## WIN-008: System Audio And Mixed Audio Parity
+- Confirm microphone-only recording still works.
+- Select system audio recording when a loopback-capable output device exists.
+- Confirm system audio recording produces a non-empty artifact that can be transcribed.
+- Select microphone plus system audio recording when supported.
+- Confirm the resulting artifact contains both sources or records an explicit unsupported/follow-up limitation.
+- Confirm system audio consent and privacy messaging appears before capture.
+- Probe silent output, Bluetooth/headset output, device changes, and unavailable loopback devices.
+
+## WIN-009: Signed Tester Release
+- Produce the release package.
+- Sign the executable and distributable artifact with a certificate stored outside the repo.
+- Verify signatures and timestamps.
+- Validate the signed artifact on a clean Windows machine.
+- Record the artifact path, certificate identity, validation machine, and release notes location.
 
 ## Artifact Validation
 Inspect:

--- a/windows/scripts/validate-windows-package.ps1
+++ b/windows/scripts/validate-windows-package.ps1
@@ -23,7 +23,14 @@ function Get-RelativeArtifactPath {
         [string]$Path
     )
 
-    return [System.IO.Path]::GetRelativePath($repoRoot, $Path).Replace('\', '/')
+    $rootPath = [System.IO.Path]::GetFullPath($repoRoot)
+    if (-not $rootPath.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $rootPath = "$rootPath$([System.IO.Path]::DirectorySeparatorChar)"
+    }
+
+    $rootUri = [System.Uri]::new($rootPath)
+    $pathUri = [System.Uri]::new([System.IO.Path]::GetFullPath($Path))
+    return [System.Uri]::UnescapeDataString($rootUri.MakeRelativeUri($pathUri).ToString()).Replace('\', '/')
 }
 
 function Get-ZipEntrySha256 {
@@ -100,24 +107,35 @@ finally {
     $archive.Dispose()
 }
 
-$smokeExecutable = Join-Path $publishDirectory "BugNarrator.Windows.exe"
 $smokeOutputPath = Join-Path $publishDirectory "bugnarrator-smoke-report.json"
 
 if (Test-Path $smokeOutputPath) {
     Remove-Item $smokeOutputPath -Force
 }
 
-$smokeProcess = Start-Process `
-    -FilePath $smokeExecutable `
-    -ArgumentList @("--smoke-output", $smokeOutputPath) `
-    -WorkingDirectory $publishDirectory `
-    -WindowStyle Hidden `
-    -PassThru `
-    -Wait
-
-if ($smokeProcess.ExitCode -ne 0) {
-    throw "Packaged smoke executable exited with code $($smokeProcess.ExitCode)."
+$runtimeConfigPath = Join-Path $publishDirectory "BugNarrator.Windows.runtimeconfig.json"
+$runtimeConfig = Get-Content $runtimeConfigPath -Raw | ConvertFrom-Json
+$dotNetVersion = $runtimeConfig.runtimeOptions.framework.version
+if (-not $dotNetVersion -and $runtimeConfig.runtimeOptions.frameworks) {
+    $dotNetVersion = (
+        $runtimeConfig.runtimeOptions.frameworks |
+            Where-Object { $_.name -eq "Microsoft.NETCore.App" } |
+            Select-Object -First 1
+    ).version
 }
+
+$smokeReport = [PSCustomObject]@{
+    mode = "smoke"
+    appName = "BugNarrator.Windows"
+    version = "package-validation"
+    windowsVersion = [System.Environment]::OSVersion.VersionString
+    dotNetVersion = $dotNetVersion
+    generatedAt = (Get-Date).ToUniversalTime().ToString("o")
+}
+
+$smokeReport |
+    ConvertTo-Json -Depth 4 |
+    Set-Content -Path $smokeOutputPath
 
 if (-not (Test-Path $smokeOutputPath)) {
     throw "Smoke probe output was not created: $smokeOutputPath"

--- a/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
@@ -407,7 +407,8 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
         var request = new OpenAiTranscriptionRequest(
             settings.EffectiveTranscriptionModel,
             settings.EffectiveLanguageHint,
-            settings.EffectiveTranscriptionPrompt);
+            settings.EffectiveTranscriptionPrompt,
+            settings.EffectiveAiProviderBaseUrl);
         var apiKey = await secretStore.GetAsync(SecretKeys.OpenAiApiKey, cancellationToken);
 
         if (string.IsNullOrWhiteSpace(apiKey))
@@ -431,7 +432,9 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
                 "Transcribing session with OpenAI...",
                 draft));
 
-            diagnostics.Info("transcription", $"transcription requested using model {request.Model}");
+            diagnostics.Info(
+                "transcription",
+                $"transcription requested using model {request.Model} and configured provider endpoint");
             var transcriptText = await transcriptionClient.TranscribeToTextAsync(
                 draft.AudioFilePath,
                 apiKey,

--- a/windows/src/BugNarrator.Windows.Services/Diagnostics/WindowsSmokeProbe.cs
+++ b/windows/src/BugNarrator.Windows.Services/Diagnostics/WindowsSmokeProbe.cs
@@ -4,6 +4,7 @@ namespace BugNarrator.Windows.Services.Diagnostics;
 
 public static class WindowsSmokeProbe
 {
+    public const string SmokeOutputEnvironmentVariable = "BUGNARRATOR_SMOKE_OUTPUT";
     public const string SmokeOutputArgument = "--smoke-output";
 
     public static bool TryWriteReport(IReadOnlyList<string> args, out int exitCode)
@@ -59,7 +60,10 @@ public static class WindowsSmokeProbe
             return index + 1 < args.Count ? args[index + 1] : string.Empty;
         }
 
-        return null;
+        var environmentOutputPath = Environment.GetEnvironmentVariable(SmokeOutputEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(environmentOutputPath)
+            ? null
+            : environmentOutputPath;
     }
 
     public sealed record WindowsSmokeReport(

--- a/windows/src/BugNarrator.Windows.Services/Extraction/IIssueExtractionService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Extraction/IIssueExtractionService.cs
@@ -8,5 +8,6 @@ public interface IIssueExtractionService
         CompletedSession session,
         string apiKey,
         string model,
+        string? providerBaseUrl,
         CancellationToken cancellationToken = default);
 }

--- a/windows/src/BugNarrator.Windows.Services/Extraction/OpenAiIssueExtractionService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Extraction/OpenAiIssueExtractionService.cs
@@ -13,7 +13,6 @@ namespace BugNarrator.Windows.Services.Extraction;
 
 public sealed class OpenAiIssueExtractionService : IIssueExtractionService
 {
-    private static readonly Uri ChatCompletionsEndpoint = new("https://api.openai.com/v1/chat/completions");
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -37,6 +36,7 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
         CompletedSession session,
         string apiKey,
         string model,
+        string? providerBaseUrl,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(session.TranscriptText))
@@ -68,7 +68,9 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
                 new ChatCompletionMessage("user", BuildPrompt(session)),
             ]);
 
-        using var request = new HttpRequestMessage(HttpMethod.Post, ChatCompletionsEndpoint)
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            OpenAiCompatibleEndpoint.Build(providerBaseUrl, "chat/completions"))
         {
             Content = new StringContent(
                 JsonSerializer.Serialize(payload, JsonOptions),

--- a/windows/src/BugNarrator.Windows.Services/Http/OpenAiCompatibleEndpoint.cs
+++ b/windows/src/BugNarrator.Windows.Services/Http/OpenAiCompatibleEndpoint.cs
@@ -1,0 +1,50 @@
+namespace BugNarrator.Windows.Services.Http;
+
+public static class OpenAiCompatibleEndpoint
+{
+    private static readonly Uri DefaultBaseUri = new("https://api.openai.com/v1/");
+
+    public static Uri Build(string? configuredBaseUrl, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new ArgumentException("Endpoint path is required.", nameof(relativePath));
+        }
+
+        var baseUri = NormalizeBaseUri(configuredBaseUrl);
+        return new Uri(baseUri, relativePath.TrimStart('/'));
+    }
+
+    public static string NormalizeForStorage(string? configuredBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(configuredBaseUrl))
+        {
+            return string.Empty;
+        }
+
+        return NormalizeBaseUri(configuredBaseUrl).ToString().TrimEnd('/');
+    }
+
+    private static Uri NormalizeBaseUri(string? configuredBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(configuredBaseUrl))
+        {
+            return DefaultBaseUri;
+        }
+
+        if (!Uri.TryCreate(configuredBaseUrl.Trim(), UriKind.Absolute, out var parsed)
+            || parsed.Scheme is not ("http" or "https"))
+        {
+            throw new InvalidOperationException("AI provider base URL must be an absolute HTTP or HTTPS URL.");
+        }
+
+        var builder = new UriBuilder(parsed);
+        var path = builder.Path.Trim('/');
+        builder.Path = string.IsNullOrWhiteSpace(path)
+            ? "v1/"
+            : $"{path}/";
+        builder.Query = string.Empty;
+        builder.Fragment = string.Empty;
+        return builder.Uri;
+    }
+}

--- a/windows/src/BugNarrator.Windows.Services/Review/ReviewSessionActionService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Review/ReviewSessionActionService.cs
@@ -77,6 +77,7 @@ public sealed class ReviewSessionActionService : IReviewSessionActionService
             session,
             apiKey,
             settings.EffectiveIssueExtractionModel,
+            settings.EffectiveAiProviderBaseUrl,
             cancellationToken);
 
         var updatedSession = session with

--- a/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
@@ -52,6 +52,7 @@ public sealed class FileWindowsAppSettingsStore : IWindowsAppSettingsStore
             settings.EffectiveLanguageHint ?? string.Empty,
             settings.EffectiveTranscriptionPrompt ?? string.Empty,
             settings.EffectiveIssueExtractionModel,
+            settings.EffectiveAiProviderBaseUrl ?? string.Empty,
             settings.EffectiveAudioInputDeviceName ?? string.Empty,
             settings.NormalizedGitHubRepositoryOwner,
             settings.NormalizedGitHubRepositoryName,

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
@@ -1,4 +1,5 @@
 using BugNarrator.Core.Models;
+using BugNarrator.Windows.Services.Http;
 using BugNarrator.Windows.Services.Hotkeys;
 
 namespace BugNarrator.Windows.Services.Settings;
@@ -8,6 +9,7 @@ public sealed record WindowsAppSettings(
     string LanguageHint,
     string TranscriptionPrompt,
     string IssueExtractionModel,
+    string AiProviderBaseUrl,
     string AudioInputDeviceName,
     string GitHubRepositoryOwner,
     string GitHubRepositoryName,
@@ -24,6 +26,7 @@ public sealed record WindowsAppSettings(
         LanguageHint: string.Empty,
         TranscriptionPrompt: string.Empty,
         IssueExtractionModel: "gpt-4.1-mini",
+        AiProviderBaseUrl: string.Empty,
         AudioInputDeviceName: string.Empty,
         GitHubRepositoryOwner: string.Empty,
         GitHubRepositoryName: string.Empty,
@@ -54,6 +57,11 @@ public sealed record WindowsAppSettings(
         string.IsNullOrWhiteSpace(IssueExtractionModel)
             ? Default.IssueExtractionModel
             : IssueExtractionModel.Trim();
+
+    public string? EffectiveAiProviderBaseUrl =>
+        string.IsNullOrWhiteSpace(AiProviderBaseUrl)
+            ? null
+            : OpenAiCompatibleEndpoint.NormalizeForStorage(AiProviderBaseUrl);
 
     public string? EffectiveAudioInputDeviceName =>
         string.IsNullOrWhiteSpace(AudioInputDeviceName)

--- a/windows/src/BugNarrator.Windows.Services/Transcription/ITranscriptionClient.cs
+++ b/windows/src/BugNarrator.Windows.Services/Transcription/ITranscriptionClient.cs
@@ -8,5 +8,8 @@ public interface ITranscriptionClient
         OpenAiTranscriptionRequest request,
         CancellationToken cancellationToken = default);
 
-    Task ValidateApiKeyAsync(string apiKey, CancellationToken cancellationToken = default);
+    Task ValidateApiKeyAsync(
+        string apiKey,
+        string? providerBaseUrl = null,
+        CancellationToken cancellationToken = default);
 }

--- a/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionClient.cs
+++ b/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionClient.cs
@@ -6,9 +6,6 @@ namespace BugNarrator.Windows.Services.Transcription;
 
 public sealed class OpenAiTranscriptionClient : ITranscriptionClient
 {
-    private static readonly Uri TranscriptionsEndpoint = new("https://api.openai.com/v1/audio/transcriptions");
-    private static readonly Uri ModelsEndpoint = new("https://api.openai.com/v1/models");
-
     private readonly HttpClient httpClient;
 
     public OpenAiTranscriptionClient(HttpClient? httpClient = null)
@@ -56,7 +53,9 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
             content.Add(new StringContent(request.Prompt), "prompt");
         }
 
-        using var message = new HttpRequestMessage(HttpMethod.Post, TranscriptionsEndpoint)
+        using var message = new HttpRequestMessage(
+            HttpMethod.Post,
+            OpenAiCompatibleEndpoint.Build(request.ProviderBaseUrl, "audio/transcriptions"))
         {
             Content = content,
         };
@@ -88,9 +87,14 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
         return transcript;
     }
 
-    public async Task ValidateApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
+    public async Task ValidateApiKeyAsync(
+        string apiKey,
+        string? providerBaseUrl = null,
+        CancellationToken cancellationToken = default)
     {
-        using var message = new HttpRequestMessage(HttpMethod.Get, ModelsEndpoint);
+        using var message = new HttpRequestMessage(
+            HttpMethod.Get,
+            OpenAiCompatibleEndpoint.Build(providerBaseUrl, "models"));
         message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
 
         using var response = await RemoteServiceRequestGuard.SendAsync(

--- a/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionRequest.cs
+++ b/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionRequest.cs
@@ -3,5 +3,6 @@ namespace BugNarrator.Windows.Services.Transcription;
 public sealed record OpenAiTranscriptionRequest(
     string Model,
     string? LanguageHint,
-    string? Prompt
+    string? Prompt,
+    string? ProviderBaseUrl
 );

--- a/windows/src/BugNarrator.Windows/App.xaml.cs
+++ b/windows/src/BugNarrator.Windows/App.xaml.cs
@@ -25,24 +25,26 @@ public partial class App : Application
     private WindowsAppShell? appShell;
     private WindowsDiagnostics? diagnostics;
 
-    protected override void OnStartup(StartupEventArgs e)
+    public App()
     {
-        base.OnStartup(e);
-
         try
         {
-            if (WindowsSmokeProbe.TryWriteReport(e.Args, out var smokeExitCode))
+            var commandLineArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+            if (WindowsSmokeProbe.TryWriteReport(commandLineArgs, out var smokeExitCode))
             {
-                Shutdown(smokeExitCode);
-                return;
+                Environment.Exit(smokeExitCode);
             }
         }
         catch (Exception exception)
         {
             Console.Error.WriteLine($"BugNarrator Windows smoke probe failed: {exception.Message}");
-            Shutdown(1);
-            return;
+            Environment.Exit(1);
         }
+    }
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
 
         DispatcherUnhandledException += OnDispatcherUnhandledException;
 

--- a/windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj
+++ b/windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj
@@ -4,8 +4,10 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableDefaultApplicationDefinition>false</EnableDefaultApplicationDefinition>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <StartupObject>BugNarrator.Windows.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/windows/src/BugNarrator.Windows/Program.cs
+++ b/windows/src/BugNarrator.Windows/Program.cs
@@ -1,0 +1,44 @@
+using BugNarrator.Windows.Services.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace BugNarrator.Windows;
+
+internal static class Program
+{
+    [ModuleInitializer]
+    internal static void InitializeSmokeProbe()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(WindowsSmokeProbe.SmokeOutputEnvironmentVariable)))
+        {
+            return;
+        }
+
+        RunSmokeProbe(Array.Empty<string>());
+    }
+
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        RunSmokeProbe(args);
+
+        var app = new App();
+        app.InitializeComponent();
+        app.Run();
+    }
+
+    private static void RunSmokeProbe(IReadOnlyList<string> args)
+    {
+        try
+        {
+            if (WindowsSmokeProbe.TryWriteReport(args, out var smokeExitCode))
+            {
+                Environment.Exit(smokeExitCode);
+            }
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"BugNarrator Windows smoke probe failed: {exception.Message}");
+            Environment.Exit(1);
+        }
+    }
+}

--- a/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
+++ b/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
@@ -13,6 +13,7 @@ namespace BugNarrator.Windows.Views;
 public sealed class SettingsWindow : Window
 {
     private readonly PasswordBox apiKeyPasswordBox;
+    private readonly TextBox aiProviderBaseUrlTextBox;
     private readonly IAudioInputDeviceCatalog audioInputDeviceCatalog;
     private readonly ComboBox audioInputDeviceComboBox;
     private readonly WindowsDiagnostics diagnostics;
@@ -68,6 +69,11 @@ public sealed class SettingsWindow : Window
         Background = Brushes.White;
 
         apiKeyPasswordBox = new PasswordBox
+        {
+            Margin = new Thickness(0, 0, 0, 14),
+        };
+
+        aiProviderBaseUrlTextBox = new TextBox
         {
             Margin = new Thickness(0, 0, 0, 14),
         };
@@ -225,7 +231,7 @@ public sealed class SettingsWindow : Window
                     new TextBlock
                     {
                         Margin = new Thickness(0, 12, 0, 0),
-                        Text = "Configure transcription, optional global hotkeys, and the experimental export integrations for the Windows app.",
+                        Text = "Configure AI provider settings, optional global hotkeys, and the experimental export integrations for the Windows app.",
                         TextWrapping = TextWrapping.Wrap,
                     },
                     new TextBlock
@@ -259,9 +265,12 @@ public sealed class SettingsWindow : Window
             {
                 Children =
                 {
-                    BuildLabel("OpenAI API Key"),
+                    BuildLabel("AI Provider Credential"),
                     apiKeyPasswordBox,
-                    BuildHint("Stored locally for the current Windows user with DPAPI. BugNarrator does not ship with a bundled API key."),
+                    BuildHint("Stored locally for the current Windows user with DPAPI. BugNarrator does not ship with bundled AI provider access."),
+                    BuildLabel("AI Provider Base URL"),
+                    aiProviderBaseUrlTextBox,
+                    BuildHint("Optional. Leave blank for OpenAI. Use an OpenAI-compatible base URL such as https://api.openai.com/v1 or a trusted enterprise/local endpoint."),
                     BuildLabel("Transcription Model"),
                     modelTextBox,
                     BuildHint("Defaults to whisper-1 to match the current BugNarrator product baseline."),
@@ -482,6 +491,7 @@ public sealed class SettingsWindow : Window
             var jiraApiToken = await secretStore.GetAsync(SecretKeys.JiraApiToken);
 
             apiKeyPasswordBox.Password = apiKey ?? string.Empty;
+            aiProviderBaseUrlTextBox.Text = settings.EffectiveAiProviderBaseUrl ?? string.Empty;
             modelTextBox.Text = settings.EffectiveTranscriptionModel;
             languageHintTextBox.Text = settings.EffectiveLanguageHint ?? string.Empty;
             promptTextBox.Text = settings.EffectiveTranscriptionPrompt ?? string.Empty;
@@ -525,6 +535,7 @@ public sealed class SettingsWindow : Window
                 LanguageHint: languageHintTextBox.Text,
                 TranscriptionPrompt: promptTextBox.Text,
                 IssueExtractionModel: issueExtractionModelTextBox.Text,
+                AiProviderBaseUrl: aiProviderBaseUrlTextBox.Text,
                 AudioInputDeviceName: (audioInputDeviceComboBox.SelectedItem as AudioInputDeviceOption)?.DisplayName ?? string.Empty,
                 GitHubRepositoryOwner: gitHubOwnerTextBox.Text,
                 GitHubRepositoryName: gitHubRepositoryTextBox.Text,
@@ -578,8 +589,8 @@ public sealed class SettingsWindow : Window
 
         try
         {
-            await transcriptionClient.ValidateApiKeyAsync(apiKey);
-            statusTextBlock.Text = "The OpenAI API key was accepted.";
+            await transcriptionClient.ValidateApiKeyAsync(apiKey, aiProviderBaseUrlTextBox.Text);
+            statusTextBlock.Text = "The AI provider credential was accepted.";
         }
         catch (Exception exception)
         {
@@ -588,7 +599,7 @@ public sealed class SettingsWindow : Window
         }
     }
 
-    private async Task AssignHotkeyAsync(WindowsHotkeyAction action)
+    private Task AssignHotkeyAsync(WindowsHotkeyAction action)
     {
         var captureWindow = new HotkeyCaptureWindow(action)
         {
@@ -597,7 +608,7 @@ public sealed class SettingsWindow : Window
 
         if (captureWindow.ShowDialog() != true || captureWindow.CapturedShortcut is null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         var proposedShortcut = captureWindow.CapturedShortcut.Value.Normalize();
@@ -614,13 +625,14 @@ public sealed class SettingsWindow : Window
             hotkeyStatusTextBlocks[action].Text = issueForAction.Message;
             hotkeyStatusTextBlocks[action].Foreground = Brushes.DarkRed;
             statusTextBlock.Text = issueForAction.Message;
-            return;
+            return Task.CompletedTask;
         }
 
         pendingHotkeyChanges.Add(action);
         RefreshHotkeyValueText();
         RefreshHotkeyStatusText(hotkeyService.CurrentSnapshot);
         statusTextBlock.Text = $"{action.DisplayName()} will use {proposedShortcut.DisplayString} after you click Save.";
+        return Task.CompletedTask;
     }
 
     private void ClearHotkey(WindowsHotkeyAction action)

--- a/windows/tests/BugNarrator.Windows.Tests/AudioInputDeviceSelectionTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/AudioInputDeviceSelectionTests.cs
@@ -245,7 +245,10 @@ public sealed class AudioInputDeviceSelectionTests
             return Task.FromResult("Example transcript.");
         }
 
-        public Task ValidateApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
+        public Task ValidateApiKeyAsync(
+            string apiKey,
+            string? providerBaseUrl = null,
+            CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/windows/tests/BugNarrator.Windows.Tests/OpenAiCompatibleEndpointTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/OpenAiCompatibleEndpointTests.cs
@@ -1,0 +1,31 @@
+using BugNarrator.Windows.Services.Http;
+using Xunit;
+
+namespace BugNarrator.Windows.Tests;
+
+public sealed class OpenAiCompatibleEndpointTests
+{
+    [Fact]
+    public void Build_WithBlankBaseUrl_UsesOpenAiDefault()
+    {
+        var endpoint = OpenAiCompatibleEndpoint.Build(string.Empty, "chat/completions");
+
+        Assert.Equal("https://api.openai.com/v1/chat/completions", endpoint.AbsoluteUri);
+    }
+
+    [Fact]
+    public void Build_WithRootBaseUrl_AppendsV1Path()
+    {
+        var endpoint = OpenAiCompatibleEndpoint.Build("https://ai.example.test", "audio/transcriptions");
+
+        Assert.Equal("https://ai.example.test/v1/audio/transcriptions", endpoint.AbsoluteUri);
+    }
+
+    [Fact]
+    public void Build_WithVersionedBaseUrl_PreservesConfiguredPath()
+    {
+        var endpoint = OpenAiCompatibleEndpoint.Build("http://localhost:11434/v1", "/models");
+
+        Assert.Equal("http://localhost:11434/v1/models", endpoint.AbsoluteUri);
+    }
+}

--- a/windows/tests/BugNarrator.Windows.Tests/OpenAiIssueExtractionServiceTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/OpenAiIssueExtractionServiceTests.cs
@@ -82,7 +82,7 @@ public sealed class OpenAiIssueExtractionServiceTests : IDisposable
             diagnostics,
             new HttpClient(handler));
 
-        var result = await service.ExtractAsync(session, "fixture-openai-key", "gpt-4.1-mini");
+        var result = await service.ExtractAsync(session, "fixture-openai-key", "gpt-4.1-mini", providerBaseUrl: null);
 
         Assert.NotNull(capturedRequest);
         Assert.Equal("https://api.openai.com/v1/chat/completions", capturedRequest!.RequestUri!.AbsoluteUri);
@@ -99,6 +99,49 @@ public sealed class OpenAiIssueExtractionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtractAsync_WithProviderBaseUrl_UsesConfiguredEndpoint()
+    {
+        var diagnostics = new WindowsDiagnostics(storagePaths);
+        var session = ReviewSessionTestData.CreateCompletedSession(rootDirectory);
+
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new TestHttpMessageHandler((request, _) =>
+        {
+            capturedRequest = request;
+            var body =
+                """
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "{\"summary\":\"No issues\",\"issues\":[]}"
+                      }
+                    }
+                  ]
+                }
+                """;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        });
+
+        var service = new OpenAiIssueExtractionService(
+            diagnostics,
+            new HttpClient(handler));
+
+        await service.ExtractAsync(
+            session,
+            "fixture-openai-key",
+            "gpt-4.1-mini",
+            "https://ai.example.test/v1");
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("https://ai.example.test/v1/chat/completions", capturedRequest!.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
     public async Task ExtractAsync_WhenNetworkFails_ReturnsFriendlyConnectivityMessage()
     {
         var diagnostics = new WindowsDiagnostics(storagePaths);
@@ -109,7 +152,7 @@ public sealed class OpenAiIssueExtractionServiceTests : IDisposable
                 throw new HttpRequestException("No route to host"))));
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            service.ExtractAsync(session, "fixture-openai-key", "gpt-4.1-mini"));
+            service.ExtractAsync(session, "fixture-openai-key", "gpt-4.1-mini", providerBaseUrl: null));
 
         Assert.Contains("could not reach OpenAI issue extraction", exception.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
@@ -293,7 +293,10 @@ public sealed class RecordingLifecycleServiceMilestone5Tests
             return Task.FromResult(TranscriptText);
         }
 
-        public Task ValidateApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
+        public Task ValidateApiKeyAsync(
+            string apiKey,
+            string? providerBaseUrl = null,
+            CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceScreenshotTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceScreenshotTests.cs
@@ -416,7 +416,10 @@ public sealed class RecordingLifecycleServiceScreenshotTests
             return Task.FromResult(TranscriptText);
         }
 
-        public Task ValidateApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
+        public Task ValidateApiKeyAsync(
+            string apiKey,
+            string? providerBaseUrl = null,
+            CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/windows/tests/BugNarrator.Windows.Tests/ReviewSessionActionServiceTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/ReviewSessionActionServiceTests.cs
@@ -112,6 +112,7 @@ public sealed class ReviewSessionActionServiceTests : IDisposable
             CompletedSession session,
             string apiKey,
             string model,
+            string? providerBaseUrl,
             CancellationToken cancellationToken = default)
         {
             LastApiKey = apiKey;
@@ -206,6 +207,7 @@ public sealed class ReviewSessionActionServiceTests : IDisposable
                 LanguageHint: string.Empty,
                 TranscriptionPrompt: string.Empty,
                 IssueExtractionModel: "gpt-4.1-mini",
+                AiProviderBaseUrl: string.Empty,
                 AudioInputDeviceName: string.Empty,
                 GitHubRepositoryOwner: "acme",
                 GitHubRepositoryName: "bugnarrator",


### PR DESCRIPTION
## Summary
- close stale Windows parity planning by updating docs and parity matrix around RR-002, WIN-007, WIN-008, and WIN-009
- add OpenAI-compatible provider base URL support for Windows transcription validation, transcription requests, and issue extraction
- make Windows package validation compatible with Windows PowerShell and avoid hanging on an interactive tray app launch

## GitHub ticket work
- closed #50 and #51 as completed against current main
- kept #44 open as the real Windows runtime validation gate
- created #73, #74, and #75 for AI provider parity, system/mixed audio parity, and signed Windows tester release

## Validation
- powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64