### PR TITLE
Fix Windows packaged single instance

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -48,6 +48,7 @@ powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Conf
 powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
 powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
 powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
+powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64
 ```
 
 Current Windows milestone status:
@@ -60,7 +61,7 @@ Current Windows milestone status:
 - the post-MVP hardening milestone is implemented, including shared atomic file writes, root-bound session path validation, corrupted-secret tolerance, diagnostic redaction, safer export/session loading, friendlier network failure messages, and defensive screenshot preview handling
 - stopping a recording now saves the session even when no OpenAI API key is configured and preserves a clear failure state if transcription fails
 - automated coverage currently includes `9` core tests and `29` Windows tests
-- `windows/scripts/package-windows.ps1` currently produces a zipped `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
+- `windows/scripts/package-windows.ps1` currently produces a zipped self-contained `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
 - `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then writes a structured package smoke report for CI/release evidence
 - CI now uploads `bugnarrator-windows-package` and `bugnarrator-windows-validation` artifacts from the Windows runner
 - manual validation is still required for live OpenAI transcription, live issue extraction, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop

--- a/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
+++ b/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
@@ -6,7 +6,7 @@ This document describes the current Windows packaging, signing, and release work
 
 ## Current Packaging Format
 
-The current branch packages BugNarrator as a zipped `dotnet publish` output using:
+The current branch packages BugNarrator as a zipped self-contained `dotnet publish` output using:
 
 - `windows/scripts/package-windows.ps1`
 
@@ -15,7 +15,7 @@ That script publishes `BugNarrator.Windows.csproj` for `win-x64` by default and 
 - `windows/artifacts/publish/<runtime>/`
 - `windows/artifacts/packages/BugNarrator-windows-<runtime>.zip`
 
-This is sufficient for internal validation and external handoff while installer work remains deferred. The signed tester release work is tracked in GitHub issue #75.
+This is sufficient for internal validation and external handoff while installer work remains deferred. The package includes the .NET runtime for the target runtime identifier so tester machines do not need a matching desktop runtime installed first. The signed tester release work is tracked in GitHub issue #75.
 
 CI now validates the packaged zip contents and writes a structured package smoke report before uploading the Windows artifact from `windows-latest`. This improves release-candidate confidence, but it does not replace a real desktop validation pass for tray, microphone, screenshot, or hotkey behavior.
 

--- a/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
+++ b/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
@@ -31,6 +31,7 @@ powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Conf
 powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
 powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
 powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
+powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64
 ```
 
 Optional run command:

--- a/windows/scripts/package-windows.ps1
+++ b/windows/scripts/package-windows.ps1
@@ -24,7 +24,7 @@ try {
     dotnet publish "windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj" `
         -c $Configuration `
         -r $Runtime `
-        --self-contained false `
+        --self-contained true `
         -o $publishDirectory
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed."
@@ -34,7 +34,12 @@ try {
         Remove-Item $packagePath -Force
     }
 
-    Compress-Archive -Path (Join-Path $publishDirectory "*") -DestinationPath $packagePath
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $publishDirectory,
+        $packagePath,
+        [System.IO.Compression.CompressionLevel]::Optimal,
+        $false)
     Write-Host "Package created at $packagePath"
 }
 finally {

--- a/windows/scripts/validate-windows-package.ps1
+++ b/windows/scripts/validate-windows-package.ps1
@@ -123,6 +123,13 @@ if (-not $dotNetVersion -and $runtimeConfig.runtimeOptions.frameworks) {
             Select-Object -First 1
     ).version
 }
+if (-not $dotNetVersion -and $runtimeConfig.runtimeOptions.includedFrameworks) {
+    $dotNetVersion = (
+        $runtimeConfig.runtimeOptions.includedFrameworks |
+            Where-Object { $_.name -eq "Microsoft.NETCore.App" } |
+            Select-Object -First 1
+    ).version
+}
 
 $smokeReport = [PSCustomObject]@{
     mode = "smoke"

--- a/windows/scripts/validate-windows-single-instance.ps1
+++ b/windows/scripts/validate-windows-single-instance.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [string]$Runtime = "win-x64",
+    [string]$OutputRoot = "windows/artifacts",
+    [int]$StartupDelaySeconds = 6
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$publishDirectory = Join-Path $repoRoot "$OutputRoot\publish\$Runtime"
+$executablePath = Join-Path $publishDirectory "BugNarrator.Windows.exe"
+
+if (-not (Test-Path $executablePath)) {
+    throw "Packaged executable was not found: $executablePath"
+}
+
+function Get-BugNarratorProcesses {
+    return @(Get-Process BugNarrator.Windows -ErrorAction SilentlyContinue)
+}
+
+$existingProcesses = Get-BugNarratorProcesses
+if ($existingProcesses.Count -gt 0) {
+    throw "BugNarrator.Windows is already running. Close it before running single-instance validation."
+}
+
+$firstProcess = $null
+$secondProcess = $null
+
+try {
+    $firstProcess = Start-Process `
+        -FilePath $executablePath `
+        -WorkingDirectory $publishDirectory `
+        -WindowStyle Hidden `
+        -PassThru
+    Start-Sleep -Seconds $StartupDelaySeconds
+
+    $afterFirstLaunch = Get-BugNarratorProcesses
+    if ($afterFirstLaunch.Count -ne 1) {
+        throw "Expected exactly one BugNarrator process after first launch, found $($afterFirstLaunch.Count)."
+    }
+
+    $secondProcess = Start-Process `
+        -FilePath $executablePath `
+        -WorkingDirectory $publishDirectory `
+        -WindowStyle Hidden `
+        -PassThru
+    Start-Sleep -Seconds $StartupDelaySeconds
+    $secondProcess.Refresh()
+
+    $afterSecondLaunch = Get-BugNarratorProcesses
+    if ($afterSecondLaunch.Count -ne 1) {
+        throw "Expected exactly one BugNarrator process after duplicate launch, found $($afterSecondLaunch.Count)."
+    }
+
+    if (-not $secondProcess.HasExited) {
+        throw "Duplicate BugNarrator launch did not exit promptly."
+    }
+
+    if ($secondProcess.ExitCode -ne 0) {
+        throw "Duplicate BugNarrator launch exited with code $($secondProcess.ExitCode)."
+    }
+
+    $result = [PSCustomObject]@{
+        runtime = $Runtime
+        firstProcessId = $firstProcess.Id
+        secondProcessId = $secondProcess.Id
+        secondExitCode = $secondProcess.ExitCode
+        runningProcessIds = ($afterSecondLaunch | ForEach-Object Id)
+        validatedAt = (Get-Date).ToUniversalTime().ToString("o")
+    }
+
+    $result | ConvertTo-Json -Depth 4
+    Write-Host "Windows single-instance validation passed."
+}
+finally {
+    Get-BugNarratorProcesses | Stop-Process -Force
+}

--- a/windows/src/BugNarrator.Windows/App.xaml.cs
+++ b/windows/src/BugNarrator.Windows/App.xaml.cs
@@ -25,6 +25,8 @@ public partial class App : Application
     private WindowsAppShell? appShell;
     private WindowsDiagnostics? diagnostics;
 
+    internal SingleInstanceService? PrimarySingleInstanceService { private get; set; }
+
     public App()
     {
         try
@@ -52,7 +54,7 @@ public partial class App : Application
         diagnostics = new WindowsDiagnostics(storagePaths);
         diagnostics.Info("app", "starting Windows shell bootstrap");
 
-        var singleInstanceService = new SingleInstanceService("ABDEnterprises.BugNarrator.Windows");
+        var singleInstanceService = PrimarySingleInstanceService ?? new SingleInstanceService(Program.ApplicationId);
         var audioInputDeviceCatalog = new NAudioInputDeviceCatalog();
         var microphonePreflightService = new MicrophonePreflightService();
         var screenCapturePreflightService = new ScreenCapturePreflightService();
@@ -120,7 +122,9 @@ public partial class App : Application
 
         if (!appShell.Initialize())
         {
-            Shutdown();
+            appShell.Dispose();
+            appShell = null;
+            Environment.Exit(0);
         }
     }
 

--- a/windows/src/BugNarrator.Windows/Program.cs
+++ b/windows/src/BugNarrator.Windows/Program.cs
@@ -1,10 +1,13 @@
 using BugNarrator.Windows.Services.Diagnostics;
+using BugNarrator.Windows.Shell;
 using System.Runtime.CompilerServices;
 
 namespace BugNarrator.Windows;
 
 internal static class Program
 {
+    public const string ApplicationId = "ABDEnterprises.BugNarrator.Windows";
+
     [ModuleInitializer]
     internal static void InitializeSmokeProbe()
     {
@@ -21,7 +24,14 @@ internal static class Program
     {
         RunSmokeProbe(args);
 
+        using var singleInstanceGuard = new EarlySingleInstanceGuard(ApplicationId);
+        if (!singleInstanceGuard.TryAcquire())
+        {
+            Environment.Exit(0);
+        }
+
         var app = new App();
+        app.PrimarySingleInstanceService = singleInstanceGuard.TransferOwnership();
         app.InitializeComponent();
         app.Run();
     }

--- a/windows/src/BugNarrator.Windows/Shell/EarlySingleInstanceGuard.cs
+++ b/windows/src/BugNarrator.Windows/Shell/EarlySingleInstanceGuard.cs
@@ -1,0 +1,42 @@
+using BugNarrator.Windows.Services.Shell;
+
+namespace BugNarrator.Windows.Shell;
+
+internal sealed class EarlySingleInstanceGuard : IDisposable
+{
+    private readonly SingleInstanceService singleInstanceService;
+    private bool disposed;
+
+    public EarlySingleInstanceGuard(string applicationId)
+    {
+        singleInstanceService = new SingleInstanceService(applicationId);
+    }
+
+    public bool TryAcquire()
+    {
+        if (singleInstanceService.TryAcquirePrimaryInstance())
+        {
+            return true;
+        }
+
+        singleInstanceService.SignalPrimaryInstance();
+        return false;
+    }
+
+    public SingleInstanceService TransferOwnership()
+    {
+        disposed = true;
+        return singleInstanceService;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        singleInstanceService.Dispose();
+        disposed = true;
+    }
+}


### PR DESCRIPTION
## Summary
- acquire the Windows single-instance mutex before WPF shell startup so duplicate packaged launches exit immediately
- publish Windows packages as self-contained artifacts so win-x64 tester builds run without a separately installed x64 .NET desktop runtime
- add repeatable packaged duplicate-launch validation and document it in the Windows validation flow

## Validation
- powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64

Fixes #77