### PR TITLE
Add Windows AI provider parity

### DIFF
--- a/docs/architecture/parity-matrix.md
+++ b/docs/architecture/parity-matrix.md
@@ -23,8 +23,8 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 | Review Workspace tabs | Shipped | In Progress | Must remain identical | Implemented by Windows Milestones 5 and 6; #51 is closed as completed, with remaining validation tracked in #44. |
 | Session Bundle export | Shipped | In Progress | Must remain identical | Implemented by Windows Milestone 6; validation remains in #44 and release hardening remains in #75. |
 | Debug Bundle support export | Shipped | In Progress | Must remain aligned | Implemented on Windows with redaction/hardening coverage; real support-bundle validation remains in #44. |
-| Missing or invalid AI provider recovery | Shipped | In Progress | Must remain identical | Windows preserves completed sessions on missing or failed transcription, but provider terminology/configuration parity is tracked in #73. |
-| Configurable AI provider setup | Shipped | Planned in `WIN-007` | Must remain aligned | macOS supports OpenAI plus OpenAI-compatible enterprise/local endpoints; Windows follow-up is tracked in #73. |
+| Missing or invalid AI provider recovery | Shipped | In Progress | Must remain identical | Windows preserves completed sessions on missing, incompatible, or failed AI provider setup; real-provider validation remains in #44. |
+| Configurable AI provider setup | Shipped | In Progress | Must remain aligned | Windows supports OpenAI, OpenAI-compatible hosted endpoints, and local-compatible endpoints; real-provider validation remains in #44. |
 | Recording audio source selection | Shipped | Planned in `WIN-008` | Platform-native capture allowed | macOS supports microphone, system audio, and mic plus system audio; Windows follow-up is tracked in #74. |
 | Experimental GitHub and Jira export | Shipped as experimental | In Progress | Experimental on both platforms | Windows implementation exists; real credential validation remains in #44. |
 | Keyboard-first accessibility | Shipped baseline, validated in RR-005 | In Progress | Native implementation allowed | The contract is clear keyboard and assistive-tech support, not identical widgets. |
@@ -34,7 +34,7 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 
 - macOS is the only production platform today.
 - Windows implements the core `record -> review -> refine -> export` path, including session library, review workspace, extraction, export, hotkeys, and hardening coverage, but it still needs real Windows runtime validation in `RR-002` / #44.
-- macOS currently has newer configurable AI provider and audio-source surfaces; Windows follow-up parity is tracked in #73 and #74.
+- macOS currently has newer audio-source surfaces; Windows follow-up parity is tracked in #74.
 - Windows public tester distribution is still blocked on signing/release packaging decisions tracked in #75.
 
 ## Update Rules

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -41,7 +41,7 @@ Automated coverage currently focuses on:
 - secure settings persistence
 - transcript export and debug bundle export
 - Windows core and service-layer compilation plus core tests
-- Windows service-layer tests plus packaged zip validation and packaged-app smoke execution on Windows CI
+- Windows service-layer tests, including AI provider compatibility coverage, plus packaged zip validation and packaged-app smoke execution on Windows CI
 
 ## Manual Validation Still Required
 
@@ -49,8 +49,8 @@ Manual validation remains necessary for:
 
 - live microphone permission prompts
 - live Screen Recording prompts
-- real OpenAI transcription and issue extraction
-- retrying a preserved session after restoring a rejected OpenAI key in Settings
+- real AI provider transcription and issue extraction
+- retrying a preserved session after restoring a rejected AI provider credential in Settings
 - real GitHub and Jira export
 - DMG install/Gatekeeper validation
 - multi-display screenshot behavior

--- a/windows/README.md
+++ b/windows/README.md
@@ -54,21 +54,21 @@ powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single
 Current Windows milestone status:
 
 - Milestone 4 screenshot capture is implemented, including screenshot preflight, drag-select overlay, deterministic screenshot naming, screenshot metadata persistence, and screenshot-linked timeline moments
-- Milestone 5 transcription and review is implemented, including DPAPI-backed OpenAI API key storage, local transcription settings, completed `session.json` plus `transcript.md` persistence, and a WPF session library with transcript, screenshot, summary, and extracted-issue review tabs
-- Milestone 6 is implemented, including OpenAI issue extraction, editable/selectable draft issues, local session bundle export, local debug bundle export, experimental GitHub export, experimental Jira export, packaging scripts, and Windows signing/release documentation
+- Milestone 5 transcription and review is implemented, including DPAPI-backed AI provider credential storage, local provider/transcription settings, completed `session.json` plus `transcript.md` persistence, and a WPF session library with transcript, screenshot, summary, and extracted-issue review tabs
+- Milestone 6 is implemented, including AI provider issue extraction, editable/selectable draft issues, local session bundle export, local debug bundle export, experimental GitHub export, experimental Jira export, packaging scripts, and Windows signing/release documentation
 - the post-MVP macOS parity milestone for the session library is implemented, including `Today`, `Yesterday`, `Last 7 Days`, `Last 30 Days`, `All Sessions`, and `Custom Date Range` filters plus permanent local session deletion
 - the post-MVP Windows global hotkey parity milestone is implemented, including optional `Start Recording`, `Stop Recording`, and `Capture Screenshot` shortcuts that start as `Not Set`, save locally, register on app startup, and surface clear conflict/unavailable status in Settings
 - the post-MVP hardening milestone is implemented, including shared atomic file writes, root-bound session path validation, corrupted-secret tolerance, diagnostic redaction, safer export/session loading, friendlier network failure messages, and defensive screenshot preview handling
-- stopping a recording now saves the session even when no OpenAI API key is configured and preserves a clear failure state if transcription fails
-- automated coverage currently includes `9` core tests and `29` Windows tests
+- stopping a recording now saves the session even when required AI provider setup is missing and preserves a clear failure state if transcription fails
+- Windows AI provider setup parity is implemented, including provider selection for OpenAI, OpenAI-compatible hosted endpoints, and local-compatible endpoints, plus compatibility guidance for unsupported provider/model combinations
+- automated coverage currently includes `9` core tests and `44` Windows tests
 - `windows/scripts/package-windows.ps1` currently produces a zipped self-contained `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
 - `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then writes a structured package smoke report for CI/release evidence
 - CI now uploads `bugnarrator-windows-package` and `bugnarrator-windows-validation` artifacts from the Windows runner
-- manual validation is still required for live OpenAI transcription, live issue extraction, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
+- manual validation is still required for live AI provider transcription, live issue extraction, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
 
 Current follow-up parity tickets:
 
 - `RR-002` / #44 remains the real Windows desktop validation gate.
-- `WIN-007` / #73 tracks Windows AI provider setup parity with the current macOS provider model.
 - `WIN-008` / #74 tracks Windows system audio and mixed audio recording parity.
 - `WIN-009` / #75 tracks the signed Windows tester release path.

--- a/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
+++ b/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
@@ -20,7 +20,7 @@ Build a Windows desktop version of BugNarrator that allows a tester to:
 - open a small recording controls window
 - record microphone audio while continuing to use other apps
 - capture selected screenshot regions during a session
-- transcribe finished sessions with the user's own OpenAI API key
+- transcribe finished sessions with the user's own AI provider configuration
 - review transcript, screenshots, summary, and extracted issues
 - browse saved sessions with flexible date filters and delete local sessions when they are no longer needed
 - export a local session bundle
@@ -210,7 +210,7 @@ GitHub and Jira export should remain explicitly experimental.
 
 1. stop capture cleanly
 2. persist draft artifacts
-3. send audio to OpenAI transcription
+3. send audio to the configured AI provider for transcription
 4. build transcript and session metadata
 5. save completed session locally
 6. focus the session library
@@ -218,7 +218,7 @@ GitHub and Jira export should remain explicitly experimental.
 ### Issue Extraction Flow
 
 1. user requests issue extraction from the selected session
-2. send transcript context to OpenAI
+2. send transcript context to the configured AI provider
 3. parse extraction output into structured draft issues
 4. keep results editable before export
 5. if no issues are found, keep the workspace in a valid fallback state
@@ -350,13 +350,13 @@ Outcomes:
 
 Current implementation findings:
 
-- the active Windows branch now stores transcription settings in `settings.json` under `%LocalAppData%\BugNarrator` and encrypts the OpenAI API key per Windows user with DPAPI-backed local secret storage
-- stopping a recording now saves the draft, optionally sends audio to OpenAI transcription, then persists a completed `session.json` plus `transcript.md` in the same session folder before focusing the session library
+- the active Windows branch now stores transcription and AI provider settings in `settings.json` under `%LocalAppData%\BugNarrator` and encrypts the provider credential per Windows user with DPAPI-backed local secret storage
+- stopping a recording now saves the draft, optionally sends audio to the configured AI provider for transcription, then persists a completed `session.json` plus `transcript.md` in the same session folder before focusing the session library
 - the stop-recording flow survives both missing-key and transcription-failure paths by saving a completed review session with a clear fallback status instead of crashing or discarding the recording
 - the WPF session library now supports list browsing, search, newest/oldest sorting, Today/Yesterday/Last 7 Days/Last 30 Days/All Sessions/Custom Date Range filtering, transcript review, screenshot preview, a summary tab, and an extracted-issues tab that is ready for editable/selectable Milestone 6 draft issues
 - the current Windows branch now supports permanent local session deletion from the session library, including deleting the session folder and its locally stored screenshots after confirmation
 - automated coverage now includes core tests for session-library query logic and transcript markdown shaping plus Windows tests for completed-session persistence across success, missing-key, and transcription-failure paths
-- manual validation is still required on a real Windows desktop for live OpenAI requests, long recordings, screenshot preview fidelity across DPI and multi-monitor setups, and review-window ergonomics
+- manual validation is still required on a real Windows desktop for live AI provider requests, long recordings, screenshot preview fidelity across DPI and multi-monitor setups, and review-window ergonomics
 - OpenAI-generated summaries remain out of scope for the current Windows MVP and are not implemented on this branch
 
 ### Milestone 6: Issue Extraction, Exports, And Diagnostics
@@ -382,7 +382,7 @@ Outcomes:
 
 Current implementation findings:
 
-- the active Windows branch now includes a Windows issue extraction client that sends completed session transcript context to OpenAI chat completions, requests structured JSON output, and parses that response into `IssueExtractionResult` plus `ExtractedIssue` records in `BugNarrator.Core`
+- the active Windows branch now includes a Windows issue extraction client that sends completed session transcript context to the configured OpenAI-compatible chat completions endpoint, requests structured JSON output, and parses that response into `IssueExtractionResult` plus `ExtractedIssue` records in `BugNarrator.Core`
 - completed sessions now persist extracted issue results, searchable issue text, and extracted-issue markdown output through the same `session.json` plus `transcript.md` storage model used by earlier milestones
 - the WPF session library now allows draft issues to be edited and selected before export, then saves those edits back into the completed session metadata
 - local `Export Session Bundle` now writes `transcript.md` plus a copied `screenshots/` directory under `%LocalAppData%\BugNarrator\Exports\SessionBundles\`
@@ -391,13 +391,13 @@ Current implementation findings:
 - Jira export is implemented as an explicitly experimental direct API integration that creates Jira issues from the selected draft issues using locally stored base URL, email, API token, project key, and issue type settings
 - DPAPI-backed secret storage now covers OpenAI, GitHub, and Jira credentials for the current Windows user without storing raw secrets in `settings.json`
 - packaging/release scaffolding now exists via `windows/scripts/build-windows.ps1`, `windows/scripts/test-windows.ps1`, `windows/scripts/package-windows.ps1`, `windows/scripts/sign-windows.ps1`, and `windows/docs/WINDOWS_SIGNING_AND_RELEASE.md`
-- automated coverage now includes `9` core tests and `18` Windows tests, including structured issue parsing, OpenAI extraction client behavior, GitHub/Jira export request behavior, session bundle export, debug bundle export, review-action orchestration, and session-library parity coverage
+- automated coverage now includes `9` core tests and `18` Windows tests, including structured issue parsing, OpenAI-compatible extraction client behavior, GitHub/Jira export request behavior, session bundle export, debug bundle export, review-action orchestration, and session-library parity coverage
 - validation completed on this branch includes:
   - `powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Configuration Debug`
   - `powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug`
   - `powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release`
   - a smoke launch of `windows/artifacts/publish/win-x64/BugNarrator.Windows.exe`
-- manual validation is still required on a real Windows desktop for live OpenAI issue extraction, real GitHub/Jira credentials, overlay behavior under mixed DPI and multi-monitor layouts, and overall review-workspace ergonomics
+- manual validation is still required on a real Windows desktop for live AI provider issue extraction, real GitHub/Jira credentials, overlay behavior under mixed DPI and multi-monitor layouts, and overall review-workspace ergonomics
 
 ### Post-MVP Hardening Milestone: Reliability, Defensive Coding, And Security
 
@@ -427,7 +427,7 @@ Current implementation findings:
 - completed-session loading now normalizes session-local audio, transcript, metadata, and screenshot paths before the rest of the app consumes them, which means tampered metadata no longer causes bundle export or library review to touch arbitrary local files
 - DPAPI secret reads now tolerate corrupt or oversized secret blobs by returning a safe null result instead of breaking settings load for the whole window
 - diagnostics and debug bundles now redact common authorization headers and token patterns before writing or exporting log lines
-- OpenAI transcription, OpenAI issue extraction, GitHub export, and Jira export now map timeout and connectivity failures to clearer user-facing messages
+- AI provider transcription, AI provider issue extraction, GitHub export, and Jira export now map timeout and connectivity failures to clearer user-facing messages
 - screenshot preview loading in the WPF session library now fails closed with a warning message instead of throwing when a local image file is missing or invalid
 - automated coverage now includes `9` core tests and `22` Windows tests, with the new Windows coverage focused on corrupted secret handling, safe session-path normalization, debug-log redaction, safer bundle export behavior, and network-failure messaging
 
@@ -534,6 +534,15 @@ Deliverables:
 Tracking:
 
 - GitHub issue #73
+
+Current implementation findings:
+
+- the Windows Settings window now exposes explicit provider selection for `OpenAI`, `OpenAI-Compatible`, and `Local-Compatible`, with OpenAI remaining the default
+- provider credentials remain in DPAPI-backed secret storage, while `settings.json` stores only non-secret provider choice, base URL, and model settings
+- transcription and issue extraction use the configured OpenAI-compatible endpoint, and local-compatible providers can run without a credential when the endpoint does not require authentication
+- Windows now blocks unsupported provider/model combinations before transcription or issue extraction, including missing compatible-provider base URLs and local providers left on hosted OpenAI defaults
+- missing or invalid provider setup still preserves completed sessions with a retryable fallback state instead of discarding recordings
+- automated coverage now includes `9` core tests and `44` Windows tests, including provider selection defaults, compatibility guidance, endpoint construction, local-compatible no-key transcription, and network-failure messaging
 
 ### WIN-008: Windows System Audio And Mixed Audio Recording Parity
 

--- a/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
+++ b/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
@@ -42,10 +42,10 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 
 ## Automated Coverage Notes
 - `BugNarrator.Core.Tests` currently covers deterministic screenshot artifact naming, screenshot-linked timeline moment shaping, completed-session markdown output, session-library query behavior across `Yesterday`, `Last 30 Days`, and `Custom Date Range`, and structured issue-extraction parsing.
-- `BugNarrator.Windows.Tests` currently covers screenshot lifecycle orchestration, Milestone 5 stop-recording orchestration, OpenAI issue extraction behavior, GitHub/Jira export provider behavior, session bundle export, debug bundle export, Milestone 6 review-action orchestration, completed-session deletion, corrupted secret handling, session-path hardening, debug-log redaction, Windows hotkey validation, hotkey settings persistence, hotkey registration status, and hotkey-to-recording action routing.
+- `BugNarrator.Windows.Tests` currently covers screenshot lifecycle orchestration, Milestone 5 stop-recording orchestration, AI provider settings, OpenAI-compatible issue extraction behavior, GitHub/Jira export provider behavior, session bundle export, debug bundle export, Milestone 6 review-action orchestration, completed-session deletion, corrupted secret handling, session-path hardening, debug-log redaction, Windows hotkey validation, hotkey settings persistence, hotkey registration status, and hotkey-to-recording action routing.
 - CI now restores, builds, runs both Windows test projects, packages a `Release` zip, validates the packaged artifact contents on `windows-latest`, writes a structured package smoke report, and uploads package and validation artifacts from the Windows runner.
-- Current passing automated coverage on this branch is `9` core tests and `35` Windows tests when run on Windows.
-- Manual validation is still required for overlay rendering, region selection behavior, desktop capture fidelity, live OpenAI transcription, live OpenAI issue extraction, real GitHub/Jira credentials, DPI scaling, multi-monitor behavior, reserved Windows shortcuts, alternate keyboard layouts, and out-of-focus hotkey behavior against real desktop apps.
+- Current passing automated coverage on this branch is `9` core tests and `44` Windows tests when run on Windows.
+- Manual validation is still required for overlay rendering, region selection behavior, desktop capture fidelity, live AI provider transcription, live AI provider issue extraction, real GitHub/Jira credentials, DPI scaling, multi-monitor behavior, reserved Windows shortcuts, alternate keyboard layouts, and out-of-focus hotkey behavior against real desktop apps.
 
 ## Milestone 2: Tray Shell And Single Instance
 - Launch BugNarrator.
@@ -90,8 +90,8 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 
 ## Milestone 5: Transcription, Review, And Session Library
 - Open `Settings`.
-- Confirm the window loads the transcription model, language hint, prompt, and saved OpenAI API key state.
-- Save a valid OpenAI API key and confirm the status message reflects the save.
+- Confirm the window loads the AI provider, transcription model, language hint, prompt, and saved provider credential state.
+- Save a valid OpenAI API key or compatible-provider credential and confirm the status message reflects the save.
 - Click `Validate Key` and confirm the app reports success or a clear failure.
 - Start and stop a recording with an API key configured.
 - Confirm the status passes through a saving/transcribing step and then opens the session library.
@@ -154,7 +154,7 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 ## Milestone 6: Issue Extraction, Exports, And Diagnostics
 - Open `Settings`.
 - Confirm the issue extraction model, GitHub settings, and Jira settings all load and save.
-- Save an OpenAI API key, GitHub token, and Jira credentials if you have real test credentials available.
+- Save an AI provider credential, GitHub token, and Jira credentials if you have real test credentials available.
 - Open a completed session with transcript text.
 - Click `Extract Issues`.
 - Confirm the app reports progress and then renders editable draft issues in the `Extracted Issues` tab.
@@ -176,7 +176,11 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 
 ## WIN-007: AI Provider Setup Parity
 - Confirm OpenAI remains the default provider.
+- Confirm Settings offers OpenAI, OpenAI-Compatible, and Local-Compatible provider choices.
 - Configure an OpenAI-compatible enterprise or local endpoint when available.
+- Confirm OpenAI-Compatible requires a non-default base URL before validation, transcription, or issue extraction.
+- Confirm Local-Compatible requires a base URL plus local transcription and issue extraction model choices before validation, transcription, or issue extraction.
+- Confirm Local-Compatible can validate and run without a credential when the endpoint does not require authentication.
 - Validate that transcription and issue extraction use the configured provider endpoint.
 - Confirm unsupported provider/model combinations fail with clear setup guidance.
 - Confirm provider credentials are stored through Windows secret storage and do not appear in settings JSON, logs, or debug bundles.
@@ -234,7 +238,7 @@ For Milestone 6 completion paths, confirm:
 - exported session bundles contain `transcript.md`
 - exported session bundles contain a `screenshots\` directory and copy any existing screenshot files without leaking secrets
 - exported debug bundles contain `system-info.json`, `app-version.txt`, `windows-version.txt`, `recent-log.txt`, and `session-metadata.json`
-- exported debug bundles do not contain OpenAI, GitHub, or Jira secrets
+- exported debug bundles do not contain AI provider, GitHub, or Jira secrets
 - the package script outputs `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
 - the package validation script outputs `windows/artifacts/validation/BugNarrator-windows-win-x64-validation.json`
 
@@ -282,10 +286,10 @@ Confirm the log file includes useful entries for:
 - screenshot capture with no active session
 - screenshot selection cancel via `Esc`
 - tiny accidental screenshot drag region
-- stop recording with no OpenAI API key configured
-- invalid OpenAI API key
-- OpenAI network or service failure during transcription
-- OpenAI network or service failure during issue extraction
+- stop recording with no required AI provider credential configured
+- invalid AI provider credential
+- AI provider network or service failure during transcription
+- AI provider network or service failure during issue extraction
 - GitHub token rejected or repository not found
 - Jira credentials rejected or issue type invalid
 - corrupted `session.json` screenshot paths
@@ -324,6 +328,6 @@ Capture these details for each failure:
 - Windows version
 - whether microphone hardware was available
 - whether the screenshot overlay appeared
-- whether an OpenAI API key was configured
+- whether an AI provider credential was configured
 - exact user-facing error text
 - whether logs and session draft artifacts were written

--- a/windows/src/BugNarrator.Core/Extraction/IssueExtractionResponseParser.cs
+++ b/windows/src/BugNarrator.Core/Extraction/IssueExtractionResponseParser.cs
@@ -26,7 +26,7 @@ public static class IssueExtractionResponseParser
         }
 
         throw new InvalidOperationException(
-            $"OpenAI returned issue data in an unexpected format. {string.Join(" | ", errors)}");
+            $"The AI provider returned issue data in an unexpected format. {string.Join(" | ", errors)}");
     }
 
     private static IssueExtractionResult ParseCandidate(

--- a/windows/src/BugNarrator.Core/Workflow/CompletedSessionMarkdownBuilder.cs
+++ b/windows/src/BugNarrator.Core/Workflow/CompletedSessionMarkdownBuilder.cs
@@ -127,7 +127,7 @@ public static class CompletedSessionMarkdownBuilder
         return status switch
         {
             SessionTranscriptionStatus.Completed => "Completed",
-            SessionTranscriptionStatus.NotConfigured => "OpenAI Key Not Configured",
+            SessionTranscriptionStatus.NotConfigured => "AI Provider Not Configured",
             SessionTranscriptionStatus.Failed => "Failed",
             _ => status.ToString(),
         };

--- a/windows/src/BugNarrator.Core/Workflow/SessionSummaryBuilder.cs
+++ b/windows/src/BugNarrator.Core/Workflow/SessionSummaryBuilder.cs
@@ -25,7 +25,7 @@ public static class SessionSummaryBuilder
         return transcriptionStatus switch
         {
             SessionTranscriptionStatus.NotConfigured =>
-                $"Recording saved locally for {SessionTimeFormatter.FormatDuration(duration)} with {screenshotCount} screenshot artifacts. Add an OpenAI API key in Settings to transcribe future sessions.",
+                $"Recording saved locally for {SessionTimeFormatter.FormatDuration(duration)} with {screenshotCount} screenshot artifacts. Finish AI provider setup in Settings to transcribe future sessions.",
             SessionTranscriptionStatus.Failed =>
                 $"Recording saved locally for {SessionTimeFormatter.FormatDuration(duration)}, but transcription failed. {transcriptionFailureMessage ?? "Review the saved audio and logs for details."}",
             _ =>

--- a/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
@@ -410,10 +410,11 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
             settings.EffectiveTranscriptionPrompt,
             settings.EffectiveAiProviderBaseUrl);
         var apiKey = await secretStore.GetAsync(SecretKeys.OpenAiApiKey, cancellationToken);
+        var providerCredential = settings.AiProviderCredentialForWorkflow(apiKey);
 
-        if (string.IsNullOrWhiteSpace(apiKey))
+        if (providerCredential is null)
         {
-            diagnostics.Warning("transcription", "transcription skipped because the OpenAI API key is not configured");
+            diagnostics.Warning("transcription", "transcription skipped because the AI provider is not configured");
             return CreateCompletedSession(
                 draft,
                 request,
@@ -429,7 +430,7 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
                 CanStart: false,
                 CanStop: false,
                 CanCaptureScreenshot: false,
-                "Transcribing session with OpenAI...",
+                $"Transcribing session with {settings.EffectiveAiProviderProfile.DisplayName}...",
                 draft));
 
             diagnostics.Info(
@@ -437,7 +438,7 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
                 $"transcription requested using model {request.Model} and configured provider endpoint");
             var transcriptText = await transcriptionClient.TranscribeToTextAsync(
                 draft.AudioFilePath,
-                apiKey,
+                providerCredential,
                 request,
                 cancellationToken);
 
@@ -507,7 +508,7 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
             SessionTranscriptionStatus.Completed =>
                 $"Recording transcribed and saved to {session.SessionDirectory}",
             SessionTranscriptionStatus.NotConfigured =>
-                $"Recording saved to {session.SessionDirectory}. Add an OpenAI API key in Settings to enable transcription.",
+                $"Recording saved to {session.SessionDirectory}. Finish AI provider setup in Settings to enable transcription.",
             SessionTranscriptionStatus.Failed =>
                 $"Recording saved to {session.SessionDirectory}, but transcription failed: {session.TranscriptionFailureMessage}",
             _ => $"Recording saved to {session.SessionDirectory}",

--- a/windows/src/BugNarrator.Windows.Services/Extraction/OpenAiIssueExtractionService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Extraction/OpenAiIssueExtractionService.cs
@@ -77,12 +77,15 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
                 Encoding.UTF8,
                 "application/json"),
         };
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        }
 
         using var response = await RemoteServiceRequestGuard.SendAsync(
             httpClient,
             request,
-            "OpenAI issue extraction",
+            "AI provider issue extraction",
             cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -97,7 +100,7 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
         if (string.IsNullOrWhiteSpace(content))
         {
             diagnostics.Warning("issue-extraction", "issue extraction response was empty");
-            throw new InvalidOperationException("OpenAI returned an empty issue extraction response.");
+            throw new InvalidOperationException("The AI provider returned an empty issue extraction response.");
         }
 
         try
@@ -122,7 +125,7 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
         {
             diagnostics.Error("issue-extraction", "issue extraction response parsing failed", exception);
             throw new InvalidOperationException(
-                "OpenAI returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings.");
+                "The AI provider returned issue data in an unexpected format. Try again, or switch the issue extraction model in Settings.");
         }
     }
 
@@ -188,9 +191,9 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
 
         return statusCode switch
         {
-            HttpStatusCode.Unauthorized => "The OpenAI API key was rejected for issue extraction.",
-            HttpStatusCode.Forbidden => "The OpenAI issue extraction request was forbidden.",
-            _ => $"OpenAI issue extraction failed with HTTP {(int)statusCode}.",
+            HttpStatusCode.Unauthorized => "The AI provider credential was rejected for issue extraction.",
+            HttpStatusCode.Forbidden => "The AI provider issue extraction request was forbidden.",
+            _ => $"AI provider issue extraction failed with HTTP {(int)statusCode}.",
         };
     }
 
@@ -225,7 +228,7 @@ public sealed class OpenAiIssueExtractionService : IIssueExtractionService
             || choicesElement.ValueKind != JsonValueKind.Array
             || choicesElement.GetArrayLength() == 0)
         {
-            throw new InvalidOperationException("OpenAI returned an invalid issue extraction response.");
+            throw new InvalidOperationException("The AI provider returned an invalid issue extraction response.");
         }
 
         var messageElement = choicesElement[0].GetProperty("message");

--- a/windows/src/BugNarrator.Windows.Services/Review/ReviewSessionActionService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Review/ReviewSessionActionService.cs
@@ -65,17 +65,19 @@ public sealed class ReviewSessionActionService : IReviewSessionActionService
             throw new InvalidOperationException("Issue extraction requires a completed transcript.");
         }
 
+        var settings = await settingsStore.LoadAsync(cancellationToken);
         var apiKey = await secretStore.GetAsync(SecretKeys.OpenAiApiKey, cancellationToken);
-        if (string.IsNullOrWhiteSpace(apiKey))
+        var providerCredential = settings.AiProviderCredentialForWorkflow(apiKey);
+        if (providerCredential is null)
         {
             throw new InvalidOperationException(
-                "Add an OpenAI API key in Settings before running issue extraction.");
+                settings.AiProviderCompatibilityIssue
+                ?? "Finish AI provider setup in Settings before running issue extraction.");
         }
 
-        var settings = await settingsStore.LoadAsync(cancellationToken);
         var extraction = await issueExtractionService.ExtractAsync(
             session,
-            apiKey,
+            providerCredential,
             settings.EffectiveIssueExtractionModel,
             settings.EffectiveAiProviderBaseUrl,
             cancellationToken);

--- a/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
@@ -62,7 +62,8 @@ public sealed class FileWindowsAppSettingsStore : IWindowsAppSettingsStore
             settings.EffectiveJiraIssueType,
             settings.EffectiveStartRecordingHotkey.Normalize(),
             settings.EffectiveStopRecordingHotkey.Normalize(),
-            settings.EffectiveScreenshotHotkey.Normalize());
+            settings.EffectiveScreenshotHotkey.Normalize(),
+            settings.NormalizedAiProvider);
 
         var json = JsonSerializer.Serialize(normalizedSettings, JsonOptions);
         await AtomicFileOperations.WriteAllTextAsync(settingsFilePath, json, cancellationToken);

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAiProvider.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAiProvider.cs
@@ -1,0 +1,77 @@
+namespace BugNarrator.Windows.Services.Settings;
+
+public enum WindowsAiProvider
+{
+    OpenAI,
+    OpenAICompatible,
+    LocalCompatible,
+}
+
+public sealed record WindowsAiProviderProfile(
+    WindowsAiProvider Provider,
+    string StorageValue,
+    string DisplayName,
+    string SetupDescription,
+    string BaseUrlPlaceholder,
+    string BaseUrlHint,
+    string CredentialFieldTitle,
+    string ValidationActionTitle,
+    string SuccessMessage,
+    bool RequiresCredential)
+{
+    public static IReadOnlyList<WindowsAiProviderProfile> All { get; } =
+    [
+        new(
+            WindowsAiProvider.OpenAI,
+            "openAI",
+            "OpenAI",
+            "Use OpenAI-hosted transcription and issue extraction with your own API key.",
+            "https://api.openai.com/v1",
+            "Leave blank to use the default OpenAI API endpoint.",
+            "OpenAI API Key",
+            "Validate Key",
+            "OpenAI accepted this key.",
+            RequiresCredential: true),
+        new(
+            WindowsAiProvider.OpenAICompatible,
+            "openAICompatible",
+            "OpenAI-Compatible",
+            "Use an enterprise proxy or hosted provider that exposes OpenAI-compatible endpoints.",
+            "https://gateway.example.com/openai",
+            "Enter the enterprise or hosted OpenAI-compatible base URL.",
+            "Provider API Key",
+            "Validate Connection",
+            "The OpenAI-compatible provider accepted this configuration.",
+            RequiresCredential: true),
+        new(
+            WindowsAiProvider.LocalCompatible,
+            "localCompatible",
+            "Local-Compatible",
+            "Use a local or self-hosted endpoint such as LM Studio or Ollama when it exposes OpenAI-compatible APIs.",
+            "http://localhost:1234/v1",
+            "Enter the local-compatible base URL. BugNarrator will not assume api.openai.com for this provider.",
+            "Provider API Key (Optional)",
+            "Validate Connection",
+            "The local-compatible provider accepted this configuration.",
+            RequiresCredential: false),
+    ];
+
+    public static WindowsAiProviderProfile Default => All[0];
+
+    public static WindowsAiProviderProfile FromStorageValue(string? value)
+    {
+        return All.FirstOrDefault(profile =>
+            string.Equals(profile.StorageValue, value, StringComparison.OrdinalIgnoreCase))
+            ?? Default;
+    }
+
+    public static WindowsAiProviderProfile FromProvider(WindowsAiProvider provider)
+    {
+        return All.FirstOrDefault(profile => profile.Provider == provider) ?? Default;
+    }
+
+    public override string ToString()
+    {
+        return DisplayName;
+    }
+}

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
@@ -19,7 +19,8 @@ public sealed record WindowsAppSettings(
     string JiraIssueType,
     WindowsHotkeyShortcut StartRecordingHotkey = default,
     WindowsHotkeyShortcut StopRecordingHotkey = default,
-    WindowsHotkeyShortcut ScreenshotHotkey = default)
+    WindowsHotkeyShortcut ScreenshotHotkey = default,
+    string AiProvider = "openAI")
 {
     public static WindowsAppSettings Default { get; } = new(
         TranscriptionModel: "whisper-1",
@@ -36,7 +37,14 @@ public sealed record WindowsAppSettings(
         JiraIssueType: "Task",
         StartRecordingHotkey: WindowsHotkeyShortcut.NotSet,
         StopRecordingHotkey: WindowsHotkeyShortcut.NotSet,
-        ScreenshotHotkey: WindowsHotkeyShortcut.NotSet);
+        ScreenshotHotkey: WindowsHotkeyShortcut.NotSet,
+        AiProvider: WindowsAiProviderProfile.Default.StorageValue);
+
+    public WindowsAiProviderProfile EffectiveAiProviderProfile =>
+        WindowsAiProviderProfile.FromStorageValue(AiProvider);
+
+    public string NormalizedAiProvider =>
+        EffectiveAiProviderProfile.StorageValue;
 
     public string EffectiveTranscriptionModel =>
         string.IsNullOrWhiteSpace(TranscriptionModel)
@@ -62,6 +70,45 @@ public sealed record WindowsAppSettings(
         string.IsNullOrWhiteSpace(AiProviderBaseUrl)
             ? null
             : OpenAiCompatibleEndpoint.NormalizeForStorage(AiProviderBaseUrl);
+
+    public string? AiProviderCompatibilityIssue
+    {
+        get
+        {
+            var profile = EffectiveAiProviderProfile;
+            var hasBaseUrl = !string.IsNullOrWhiteSpace(AiProviderBaseUrl);
+
+            return profile.Provider switch
+            {
+                WindowsAiProvider.OpenAI => null,
+                WindowsAiProvider.OpenAICompatible when !hasBaseUrl =>
+                    "Choose a non-default API base URL for the OpenAI-Compatible provider.",
+                WindowsAiProvider.LocalCompatible when !hasBaseUrl =>
+                    "Choose your local-compatible base URL before validating or transcribing.",
+                WindowsAiProvider.LocalCompatible when EffectiveTranscriptionModel == Default.TranscriptionModel =>
+                    "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider.",
+                WindowsAiProvider.LocalCompatible when EffectiveIssueExtractionModel == Default.IssueExtractionModel =>
+                    "Choose a local issue extraction model instead of gpt-4.1-mini for the Local-Compatible provider.",
+                _ => null,
+            };
+        }
+    }
+
+    public string? AiProviderCredentialForWorkflow(string? credential)
+    {
+        if (AiProviderCompatibilityIssue is not null)
+        {
+            return null;
+        }
+
+        var trimmedCredential = credential?.Trim();
+        if (EffectiveAiProviderProfile.RequiresCredential)
+        {
+            return string.IsNullOrWhiteSpace(trimmedCredential) ? null : trimmedCredential;
+        }
+
+        return trimmedCredential ?? string.Empty;
+    }
 
     public string? EffectiveAudioInputDeviceName =>
         string.IsNullOrWhiteSpace(AudioInputDeviceName)

--- a/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionClient.cs
+++ b/windows/src/BugNarrator.Windows.Services/Transcription/OpenAiTranscriptionClient.cs
@@ -59,12 +59,15 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
         {
             Content = content,
         };
-        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        }
 
         using var response = await RemoteServiceRequestGuard.SendAsync(
             httpClient,
             message,
-            "OpenAI transcription",
+            "AI provider transcription",
             cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -75,13 +78,13 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
         using var document = JsonDocument.Parse(responseBody);
         if (!document.RootElement.TryGetProperty("text", out var textElement))
         {
-            throw new InvalidOperationException("OpenAI returned an invalid transcription response.");
+            throw new InvalidOperationException("The AI provider returned an invalid transcription response.");
         }
 
         var transcript = textElement.GetString()?.Trim();
         if (string.IsNullOrWhiteSpace(transcript))
         {
-            throw new InvalidOperationException("OpenAI returned an empty transcript.");
+            throw new InvalidOperationException("The AI provider returned an empty transcript.");
         }
 
         return transcript;
@@ -95,12 +98,15 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
         using var message = new HttpRequestMessage(
             HttpMethod.Get,
             OpenAiCompatibleEndpoint.Build(providerBaseUrl, "models"));
-        message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey.Trim());
+        }
 
         using var response = await RemoteServiceRequestGuard.SendAsync(
             httpClient,
             message,
-            "OpenAI API validation",
+            "AI provider validation",
             cancellationToken);
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -134,9 +140,9 @@ public sealed class OpenAiTranscriptionClient : ITranscriptionClient
 
         return statusCode switch
         {
-            System.Net.HttpStatusCode.Unauthorized => "The OpenAI API key was rejected.",
-            System.Net.HttpStatusCode.Forbidden => "The OpenAI API request was forbidden.",
-            _ => $"OpenAI request failed with HTTP {(int)statusCode}.",
+            System.Net.HttpStatusCode.Unauthorized => "The AI provider credential was rejected.",
+            System.Net.HttpStatusCode.Forbidden => "The AI provider request was forbidden.",
+            _ => $"AI provider request failed with HTTP {(int)statusCode}.",
         };
     }
 

--- a/windows/src/BugNarrator.Windows/Views/SessionLibraryWindow.cs
+++ b/windows/src/BugNarrator.Windows/Views/SessionLibraryWindow.cs
@@ -202,7 +202,7 @@ public sealed class SessionLibraryWindow : Window
 
         extractIssuesButton = BuildActionButton("Extract Issues");
         extractIssuesButton.Click += async (_, _) => await RunReviewActionAsync(
-            "Extracting draft issues with OpenAI...",
+            "Extracting draft issues with the configured AI provider...",
             ExtractIssuesAsync);
 
         saveReviewButton = BuildActionButton("Save Review");
@@ -838,7 +838,7 @@ public sealed class SessionLibraryWindow : Window
         if (session.IssueExtraction.Issues.Count == 0)
         {
             issuesEmptyStateTextBlock.Text =
-                "OpenAI returned no draft issues for this session. You can still export the session bundle or debug bundle.";
+                "The AI provider returned no draft issues for this session. You can still export the session bundle or debug bundle.";
             return;
         }
 
@@ -1148,7 +1148,7 @@ public sealed class SessionLibraryWindow : Window
         return session.TranscriptionStatus switch
         {
             SessionTranscriptionStatus.NotConfigured =>
-                "This recording was saved without a transcript because an OpenAI API key was not configured in Settings.",
+                "This recording was saved without a transcript because AI provider setup was not completed in Settings.",
             SessionTranscriptionStatus.Failed =>
                 $"Transcription failed for this session. {session.TranscriptionFailureMessage ?? "Check the Windows log for more detail."}",
             _ => "No transcript text was saved for this session.",

--- a/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
+++ b/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
@@ -14,6 +14,7 @@ public sealed class SettingsWindow : Window
 {
     private readonly PasswordBox apiKeyPasswordBox;
     private readonly TextBox aiProviderBaseUrlTextBox;
+    private readonly ComboBox aiProviderComboBox;
     private readonly IAudioInputDeviceCatalog audioInputDeviceCatalog;
     private readonly ComboBox audioInputDeviceComboBox;
     private readonly WindowsDiagnostics diagnostics;
@@ -76,6 +77,13 @@ public sealed class SettingsWindow : Window
         aiProviderBaseUrlTextBox = new TextBox
         {
             Margin = new Thickness(0, 0, 0, 14),
+        };
+
+        aiProviderComboBox = new ComboBox
+        {
+            Margin = new Thickness(0, 0, 0, 14),
+            DisplayMemberPath = nameof(WindowsAiProviderProfile.DisplayName),
+            ItemsSource = WindowsAiProviderProfile.All,
         };
 
         modelTextBox = new TextBox
@@ -265,9 +273,12 @@ public sealed class SettingsWindow : Window
             {
                 Children =
                 {
+                    BuildLabel("AI Provider"),
+                    aiProviderComboBox,
+                    BuildHint("Choose OpenAI, an OpenAI-compatible hosted endpoint, or a local-compatible endpoint."),
                     BuildLabel("AI Provider Credential"),
                     apiKeyPasswordBox,
-                    BuildHint("Stored locally for the current Windows user with DPAPI. BugNarrator does not ship with bundled AI provider access."),
+                    BuildHint("Stored locally for the current Windows user with DPAPI. Required for OpenAI and OpenAI-compatible providers; optional for local-compatible providers."),
                     BuildLabel("AI Provider Base URL"),
                     aiProviderBaseUrlTextBox,
                     BuildHint("Optional. Leave blank for OpenAI. Use an OpenAI-compatible base URL such as https://api.openai.com/v1 or a trusted enterprise/local endpoint."),
@@ -491,6 +502,7 @@ public sealed class SettingsWindow : Window
             var jiraApiToken = await secretStore.GetAsync(SecretKeys.JiraApiToken);
 
             apiKeyPasswordBox.Password = apiKey ?? string.Empty;
+            aiProviderComboBox.SelectedItem = settings.EffectiveAiProviderProfile;
             aiProviderBaseUrlTextBox.Text = settings.EffectiveAiProviderBaseUrl ?? string.Empty;
             modelTextBox.Text = settings.EffectiveTranscriptionModel;
             languageHintTextBox.Text = settings.EffectiveLanguageHint ?? string.Empty;
@@ -516,7 +528,7 @@ public sealed class SettingsWindow : Window
             RefreshHotkeyStatusText(hotkeyService.CurrentSnapshot);
 
             statusTextBlock.Text = string.IsNullOrWhiteSpace(apiKey)
-                ? "No OpenAI API key is saved yet. Global hotkeys remain optional and start as Not Set."
+                ? "No AI provider credential is saved yet. Global hotkeys remain optional and start as Not Set."
                 : BuildLoadStatusMessage(hotkeyService.CurrentSnapshot);
         }
         catch (Exception exception)
@@ -545,7 +557,14 @@ public sealed class SettingsWindow : Window
                 JiraIssueType: jiraIssueTypeTextBox.Text,
                 StartRecordingHotkey: draftHotkeys[WindowsHotkeyAction.StartRecording],
                 StopRecordingHotkey: draftHotkeys[WindowsHotkeyAction.StopRecording],
-                ScreenshotHotkey: draftHotkeys[WindowsHotkeyAction.CaptureScreenshot]);
+                ScreenshotHotkey: draftHotkeys[WindowsHotkeyAction.CaptureScreenshot],
+                AiProvider: GetSelectedAiProviderProfile().StorageValue);
+
+            if (settings.AiProviderCompatibilityIssue is { } aiProviderIssue)
+            {
+                statusTextBlock.Text = aiProviderIssue;
+                return;
+            }
 
             var validationIssues = WindowsHotkeySettingsValidator.Validate(settings);
             if (validationIssues.Count > 0)
@@ -579,23 +598,38 @@ public sealed class SettingsWindow : Window
     private async Task ValidateApiKeyAsync()
     {
         var apiKey = apiKeyPasswordBox.Password.Trim();
-        if (apiKey.Length == 0)
+        var providerProfile = GetSelectedAiProviderProfile();
+        var validationSettings = WindowsAppSettings.Default with
         {
-            statusTextBlock.Text = "Enter an OpenAI API key before running validation.";
+            AiProvider = providerProfile.StorageValue,
+            AiProviderBaseUrl = aiProviderBaseUrlTextBox.Text,
+            TranscriptionModel = modelTextBox.Text,
+            IssueExtractionModel = issueExtractionModelTextBox.Text,
+        };
+
+        if (validationSettings.AiProviderCompatibilityIssue is { } aiProviderIssue)
+        {
+            statusTextBlock.Text = aiProviderIssue;
             return;
         }
 
-        statusTextBlock.Text = "Validating the OpenAI API key...";
+        if (providerProfile.RequiresCredential && apiKey.Length == 0)
+        {
+            statusTextBlock.Text = $"Enter a {providerProfile.DisplayName} credential before running validation.";
+            return;
+        }
+
+        statusTextBlock.Text = $"Validating the {providerProfile.DisplayName} connection...";
 
         try
         {
             await transcriptionClient.ValidateApiKeyAsync(apiKey, aiProviderBaseUrlTextBox.Text);
-            statusTextBlock.Text = "The AI provider credential was accepted.";
+            statusTextBlock.Text = providerProfile.SuccessMessage;
         }
         catch (Exception exception)
         {
             diagnostics.Error("settings", "api key validation failed", exception);
-            statusTextBlock.Text = $"OpenAI key validation failed: {exception.Message}";
+            statusTextBlock.Text = $"AI provider validation failed: {exception.Message}";
         }
     }
 
@@ -733,7 +767,7 @@ public sealed class SettingsWindow : Window
     {
         return snapshot.HasProblems
             ? "Settings loaded. Some saved global hotkeys need attention in the optional hotkey section."
-            : "OpenAI, issue extraction, experimental export settings, and optional global hotkeys are loaded for this Windows user.";
+            : "AI provider, issue extraction, experimental export settings, and optional global hotkeys are loaded for this Windows user.";
     }
 
     private static string BuildSavedStatusMessage(WindowsHotkeyRuntimeSnapshot snapshot)
@@ -776,5 +810,11 @@ public sealed class SettingsWindow : Window
             FontWeight = FontWeights.SemiBold,
             Text = text,
         };
+    }
+
+    private WindowsAiProviderProfile GetSelectedAiProviderProfile()
+    {
+        return aiProviderComboBox.SelectedItem as WindowsAiProviderProfile
+            ?? WindowsAiProviderProfile.Default;
     }
 }

--- a/windows/tests/BugNarrator.Windows.Tests/OpenAiIssueExtractionServiceTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/OpenAiIssueExtractionServiceTests.cs
@@ -154,7 +154,7 @@ public sealed class OpenAiIssueExtractionServiceTests : IDisposable
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             service.ExtractAsync(session, "fixture-openai-key", "gpt-4.1-mini", providerBaseUrl: null));
 
-        Assert.Contains("could not reach OpenAI issue extraction", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("could not reach AI provider issue extraction", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     public void Dispose()

--- a/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
@@ -55,8 +55,34 @@ public sealed class RecordingLifecycleServiceMilestone5Tests
         Assert.Equal(string.Empty, session.TranscriptText);
         Assert.Equal(0, harness.TranscriptionClient.CallCount);
         Assert.Equal(RecordingWorkflowState.Completed, harness.Service.CurrentState.WorkflowState);
-        Assert.Contains("Add an OpenAI API key", harness.Service.CurrentState.StatusMessage);
+        Assert.Contains("Finish AI provider setup", harness.Service.CurrentState.StatusMessage);
         Assert.True(File.Exists(session.TranscriptMarkdownFilePath));
+    }
+
+    [Fact]
+    public async Task StopRecordingAsync_WithLocalCompatibleProviderAndNoApiKey_Transcribes()
+    {
+        using var harness = new TestHarness();
+        harness.SettingsStore.Settings = WindowsAppSettings.Default with
+        {
+            AiProvider = "localCompatible",
+            AiProviderBaseUrl = "http://localhost:1234/v1",
+            TranscriptionModel = "whisper-large-v3",
+            IssueExtractionModel = "local-qwen",
+        };
+        harness.TranscriptionClient.TranscriptText = "Local provider transcribed this session.";
+
+        await harness.Service.StartRecordingAsync();
+        await harness.Service.StopRecordingAsync();
+
+        var sessions = await harness.CompletedSessionStore.GetAllAsync();
+        var session = Assert.Single(sessions);
+
+        Assert.Equal(SessionTranscriptionStatus.Completed, session.TranscriptionStatus);
+        Assert.Equal("Local provider transcribed this session.", session.TranscriptText);
+        Assert.Equal(1, harness.TranscriptionClient.CallCount);
+        Assert.Equal(string.Empty, harness.TranscriptionClient.LastApiKey);
+        Assert.Equal("http://localhost:1234/v1", harness.TranscriptionClient.LastRequest?.ProviderBaseUrl);
     }
 
     [Fact]
@@ -275,6 +301,8 @@ public sealed class RecordingLifecycleServiceMilestone5Tests
     {
         public int CallCount { get; private set; }
         public Exception? ExceptionToThrow { get; set; }
+        public string? LastApiKey { get; private set; }
+        public OpenAiTranscriptionRequest? LastRequest { get; private set; }
         public string TranscriptText { get; set; } = "Example transcript.";
 
         public Task<string> TranscribeToTextAsync(
@@ -284,6 +312,8 @@ public sealed class RecordingLifecycleServiceMilestone5Tests
             CancellationToken cancellationToken = default)
         {
             CallCount++;
+            LastApiKey = apiKey;
+            LastRequest = request;
 
             if (ExceptionToThrow is not null)
             {

--- a/windows/tests/BugNarrator.Windows.Tests/WindowsAiProviderSettingsTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/WindowsAiProviderSettingsTests.cs
@@ -1,0 +1,74 @@
+using BugNarrator.Windows.Services.Settings;
+using Xunit;
+
+namespace BugNarrator.Windows.Tests;
+
+public sealed class WindowsAiProviderSettingsTests
+{
+    [Fact]
+    public void DefaultSettings_UseOpenAiProvider()
+    {
+        var settings = WindowsAppSettings.Default;
+
+        Assert.Equal("openAI", settings.NormalizedAiProvider);
+        Assert.Equal("OpenAI", settings.EffectiveAiProviderProfile.DisplayName);
+        Assert.Null(settings.AiProviderCompatibilityIssue);
+    }
+
+    [Fact]
+    public void OpenAiCompatibleProvider_RequiresNonDefaultBaseUrl()
+    {
+        var settings = WindowsAppSettings.Default with
+        {
+            AiProvider = "openAICompatible",
+            AiProviderBaseUrl = string.Empty,
+        };
+
+        Assert.Equal(
+            "Choose a non-default API base URL for the OpenAI-Compatible provider.",
+            settings.AiProviderCompatibilityIssue);
+        Assert.Null(settings.AiProviderCredentialForWorkflow("provider-key"));
+    }
+
+    [Fact]
+    public void LocalCompatibleProvider_RequiresBaseUrlAndLocalModels()
+    {
+        var missingBaseUrl = WindowsAppSettings.Default with
+        {
+            AiProvider = "localCompatible",
+        };
+        var defaultTranscriptionModel = missingBaseUrl with
+        {
+            AiProviderBaseUrl = "http://localhost:1234/v1",
+        };
+        var defaultIssueModel = defaultTranscriptionModel with
+        {
+            TranscriptionModel = "whisper-large-v3",
+        };
+
+        Assert.Equal(
+            "Choose your local-compatible base URL before validating or transcribing.",
+            missingBaseUrl.AiProviderCompatibilityIssue);
+        Assert.Equal(
+            "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider.",
+            defaultTranscriptionModel.AiProviderCompatibilityIssue);
+        Assert.Equal(
+            "Choose a local issue extraction model instead of gpt-4.1-mini for the Local-Compatible provider.",
+            defaultIssueModel.AiProviderCompatibilityIssue);
+    }
+
+    [Fact]
+    public void LocalCompatibleProvider_AllowsMissingCredentialWhenCompatible()
+    {
+        var settings = WindowsAppSettings.Default with
+        {
+            AiProvider = "localCompatible",
+            AiProviderBaseUrl = "http://localhost:1234/v1",
+            TranscriptionModel = "whisper-large-v3",
+            IssueExtractionModel = "local-qwen",
+        };
+
+        Assert.Null(settings.AiProviderCompatibilityIssue);
+        Assert.Equal(string.Empty, settings.AiProviderCredentialForWorkflow(null));
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit Windows AI provider selection for OpenAI, OpenAI-Compatible, and Local-Compatible providers
- enforce provider compatibility before transcription or issue extraction, including local-provider model guidance and required compatible base URLs
- allow local-compatible endpoints to run without credentials when they do not require authentication
- update AI provider terminology, docs, parity matrix, and validation checklist

## Validation
- powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
- powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64

Fixes #73