### PR TITLE
Add Windows system audio recording source

### DIFF
--- a/docs/architecture/parity-matrix.md
+++ b/docs/architecture/parity-matrix.md
@@ -25,7 +25,7 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 | Debug Bundle support export | Shipped | In Progress | Must remain aligned | Implemented on Windows with redaction/hardening coverage; real support-bundle validation remains in #44. |
 | Missing or invalid AI provider recovery | Shipped | In Progress | Must remain identical | Windows preserves completed sessions on missing, incompatible, or failed AI provider setup; real-provider validation remains in #44. |
 | Configurable AI provider setup | Shipped | In Progress | Must remain aligned | Windows supports OpenAI, OpenAI-compatible hosted endpoints, and local-compatible endpoints; real-provider validation remains in #44. |
-| Recording audio source selection | Shipped | Planned in `WIN-008` | Platform-native capture allowed | macOS supports microphone, system audio, and mic plus system audio; Windows follow-up is tracked in #74. |
+| Recording audio source selection | Shipped | In Progress | Platform-native capture allowed | Windows supports microphone and WASAPI loopback system audio. Mixed mic plus system audio is surfaced as an explicit tracked limitation until muxing is implemented. |
 | Experimental GitHub and Jira export | Shipped as experimental | In Progress | Experimental on both platforms | Windows implementation exists; real credential validation remains in #44. |
 | Keyboard-first accessibility | Shipped baseline, validated in RR-005 | In Progress | Native implementation allowed | The contract is clear keyboard and assistive-tech support, not identical widgets. |
 | Public release packaging | Shipped as signed, notarized DMG | Planned in `WIN-009` | Platform-native packaging allowed | Windows zip packaging exists; signed tester release work is tracked in #75. |
@@ -34,7 +34,7 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 
 - macOS is the only production platform today.
 - Windows implements the core `record -> review -> refine -> export` path, including session library, review workspace, extraction, export, hotkeys, and hardening coverage, but it still needs real Windows runtime validation in `RR-002` / #44.
-- macOS currently has newer audio-source surfaces; Windows follow-up parity is tracked in #74.
+- macOS currently has mixed microphone plus system audio capture beyond Windows; Windows surfaces the limitation explicitly while system-audio loopback support is available.
 - Windows public tester distribution is still blocked on signing/release packaging decisions tracked in #75.
 
 ## Update Rules

--- a/docs/architecture/product-spec.md
+++ b/docs/architecture/product-spec.md
@@ -76,7 +76,7 @@ Current scope boundaries:
 - no backend or cloud sync
 - no live dictation into the frontmost app
 - no automatic telemetry or remote log collection
-- no system audio capture
+- no hidden/background system audio capture without explicit user selection and consent
 - no requirement for Accessibility permission in the core workflow
 
 ## Core Workflow And Canonical Terminology

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -41,7 +41,7 @@ Automated coverage currently focuses on:
 - secure settings persistence
 - transcript export and debug bundle export
 - Windows core and service-layer compilation plus core tests
-- Windows service-layer tests, including AI provider compatibility coverage, plus packaged zip validation and packaged-app smoke execution on Windows CI
+- Windows service-layer tests, including AI provider compatibility and recording-source routing coverage, plus packaged zip validation and packaged-app smoke execution on Windows CI
 
 ## Manual Validation Still Required
 
@@ -50,6 +50,7 @@ Manual validation remains necessary for:
 - live microphone permission prompts
 - live Screen Recording prompts
 - real AI provider transcription and issue extraction
+- representative Windows system-audio output device capture
 - retrying a preserved session after restoring a rejected AI provider credential in Settings
 - real GitHub and Jira export
 - DMG install/Gatekeeper validation

--- a/windows/README.md
+++ b/windows/README.md
@@ -61,14 +61,14 @@ Current Windows milestone status:
 - the post-MVP hardening milestone is implemented, including shared atomic file writes, root-bound session path validation, corrupted-secret tolerance, diagnostic redaction, safer export/session loading, friendlier network failure messages, and defensive screenshot preview handling
 - stopping a recording now saves the session even when required AI provider setup is missing and preserves a clear failure state if transcription fails
 - Windows AI provider setup parity is implemented, including provider selection for OpenAI, OpenAI-compatible hosted endpoints, and local-compatible endpoints, plus compatibility guidance for unsupported provider/model combinations
-- automated coverage currently includes `9` core tests and `44` Windows tests
+- Windows audio-source parity now includes microphone recording and WASAPI loopback system-audio recording; microphone plus system audio is visible as an explicit tracked limitation until mixed-source muxing is implemented
+- automated coverage currently includes `9` core tests and `47` Windows tests
 - `windows/scripts/package-windows.ps1` currently produces a zipped self-contained `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
 - `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then writes a structured package smoke report for CI/release evidence
 - CI now uploads `bugnarrator-windows-package` and `bugnarrator-windows-validation` artifacts from the Windows runner
-- manual validation is still required for live AI provider transcription, live issue extraction, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
+- manual validation is still required for live AI provider transcription, live issue extraction, system-audio capture on representative output devices, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
 
 Current follow-up parity tickets:
 
 - `RR-002` / #44 remains the real Windows desktop validation gate.
-- `WIN-008` / #74 tracks Windows system audio and mixed audio recording parity.
 - `WIN-009` / #75 tracks the signed Windows tester release path.

--- a/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
+++ b/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
@@ -33,7 +33,7 @@ Build a Windows desktop version of BugNarrator that allows a tester to:
 - no cloud sync
 - no accessibility automation
 - no live dictation into other apps
-- no system audio capture unless explicitly added later
+- no hidden/background system audio capture without explicit user selection and consent
 - no attempt to share the macOS UI layer directly
 
 ## Product Principles
@@ -562,6 +562,15 @@ Deliverables:
 Tracking:
 
 - GitHub issue #74
+
+Current implementation findings:
+
+- Windows Settings now exposes a `Recording Audio Source` choice for `Microphone`, `System Audio`, and `Microphone + System Audio`
+- microphone recording remains the default and continues to use the selected Windows microphone input device
+- system audio recording is implemented with NAudio WASAPI loopback against the default Windows render/output device and writes the captured stream into the existing session WAV artifact path
+- system-audio capture requires an explicit Settings consent checkbox explaining that audio from other apps on the PC may be recorded
+- `Microphone + System Audio` is intentionally surfaced as a clear limitation for this build instead of silently producing an incomplete artifact; true mixed-source muxing remains a follow-up after tester distribution unless prioritized earlier
+- automated coverage now includes `9` core tests and `47` Windows tests, including recording-source routing, system-audio consent blocking, and the mixed-capture limitation state
 
 ### WIN-009: Signed Windows Tester Release
 

--- a/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
+++ b/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
@@ -42,10 +42,10 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 
 ## Automated Coverage Notes
 - `BugNarrator.Core.Tests` currently covers deterministic screenshot artifact naming, screenshot-linked timeline moment shaping, completed-session markdown output, session-library query behavior across `Yesterday`, `Last 30 Days`, and `Custom Date Range`, and structured issue-extraction parsing.
-- `BugNarrator.Windows.Tests` currently covers screenshot lifecycle orchestration, Milestone 5 stop-recording orchestration, AI provider settings, OpenAI-compatible issue extraction behavior, GitHub/Jira export provider behavior, session bundle export, debug bundle export, Milestone 6 review-action orchestration, completed-session deletion, corrupted secret handling, session-path hardening, debug-log redaction, Windows hotkey validation, hotkey settings persistence, hotkey registration status, and hotkey-to-recording action routing.
+- `BugNarrator.Windows.Tests` currently covers screenshot lifecycle orchestration, Milestone 5 stop-recording orchestration, AI provider settings, audio recording-source routing, OpenAI-compatible issue extraction behavior, GitHub/Jira export provider behavior, session bundle export, debug bundle export, Milestone 6 review-action orchestration, completed-session deletion, corrupted secret handling, session-path hardening, debug-log redaction, Windows hotkey validation, hotkey settings persistence, hotkey registration status, and hotkey-to-recording action routing.
 - CI now restores, builds, runs both Windows test projects, packages a `Release` zip, validates the packaged artifact contents on `windows-latest`, writes a structured package smoke report, and uploads package and validation artifacts from the Windows runner.
-- Current passing automated coverage on this branch is `9` core tests and `44` Windows tests when run on Windows.
-- Manual validation is still required for overlay rendering, region selection behavior, desktop capture fidelity, live AI provider transcription, live AI provider issue extraction, real GitHub/Jira credentials, DPI scaling, multi-monitor behavior, reserved Windows shortcuts, alternate keyboard layouts, and out-of-focus hotkey behavior against real desktop apps.
+- Current passing automated coverage on this branch is `9` core tests and `47` Windows tests when run on Windows.
+- Manual validation is still required for overlay rendering, region selection behavior, desktop capture fidelity, live AI provider transcription, live AI provider issue extraction, representative system-audio output devices, real GitHub/Jira credentials, DPI scaling, multi-monitor behavior, reserved Windows shortcuts, alternate keyboard layouts, and out-of-focus hotkey behavior against real desktop apps.
 
 ## Milestone 2: Tray Shell And Single Instance
 - Launch BugNarrator.
@@ -188,10 +188,12 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 
 ## WIN-008: System Audio And Mixed Audio Parity
 - Confirm microphone-only recording still works.
+- Confirm `Microphone` remains the default recording source in Settings.
+- Confirm the system-audio consent checkbox appears near the recording-source setting.
 - Select system audio recording when a loopback-capable output device exists.
 - Confirm system audio recording produces a non-empty artifact that can be transcribed.
-- Select microphone plus system audio recording when supported.
-- Confirm the resulting artifact contains both sources or records an explicit unsupported/follow-up limitation.
+- Select microphone plus system audio recording.
+- Confirm the app records an explicit unsupported/follow-up limitation instead of creating an incomplete mixed artifact.
 - Confirm system audio consent and privacy messaging appears before capture.
 - Probe silent output, Bluetooth/headset output, device changes, and unavailable loopback devices.
 

--- a/windows/src/BugNarrator.Windows.Services/Audio/AudioRecordingRequest.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/AudioRecordingRequest.cs
@@ -1,0 +1,16 @@
+namespace BugNarrator.Windows.Services.Audio;
+
+public sealed record AudioRecordingRequest(
+    AudioRecordingSource Source,
+    int? MicrophoneDeviceNumber)
+{
+    public static AudioRecordingRequest ForMicrophone(int deviceNumber)
+    {
+        return new AudioRecordingRequest(AudioRecordingSource.Microphone, deviceNumber);
+    }
+
+    public static AudioRecordingRequest ForSystemAudio()
+    {
+        return new AudioRecordingRequest(AudioRecordingSource.SystemAudio, MicrophoneDeviceNumber: null);
+    }
+}

--- a/windows/src/BugNarrator.Windows.Services/Audio/AudioRecordingSource.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/AudioRecordingSource.cs
@@ -1,0 +1,56 @@
+namespace BugNarrator.Windows.Services.Audio;
+
+public enum AudioRecordingSource
+{
+    Microphone,
+    SystemAudio,
+    MicrophoneAndSystemAudio,
+}
+
+public sealed record AudioRecordingSourceProfile(
+    AudioRecordingSource Source,
+    string StorageValue,
+    string DisplayName,
+    string Description,
+    bool UsesMicrophone,
+    bool UsesSystemAudio)
+{
+    public static IReadOnlyList<AudioRecordingSourceProfile> All { get; } =
+    [
+        new(
+            AudioRecordingSource.Microphone,
+            "microphone",
+            "Microphone",
+            "Record the selected microphone only.",
+            UsesMicrophone: true,
+            UsesSystemAudio: false),
+        new(
+            AudioRecordingSource.SystemAudio,
+            "systemAudio",
+            "System Audio",
+            "Record audio currently playing through the default Windows output device.",
+            UsesMicrophone: false,
+            UsesSystemAudio: true),
+        new(
+            AudioRecordingSource.MicrophoneAndSystemAudio,
+            "microphoneAndSystemAudio",
+            "Microphone + System Audio",
+            "Mixed capture is tracked as a follow-up; choose this to see the explicit limitation.",
+            UsesMicrophone: true,
+            UsesSystemAudio: true),
+    ];
+
+    public static AudioRecordingSourceProfile Default => All[0];
+
+    public static AudioRecordingSourceProfile FromStorageValue(string? value)
+    {
+        return All.FirstOrDefault(profile =>
+            string.Equals(profile.StorageValue, value, StringComparison.OrdinalIgnoreCase))
+            ?? Default;
+    }
+
+    public override string ToString()
+    {
+        return DisplayName;
+    }
+}

--- a/windows/src/BugNarrator.Windows.Services/Audio/IAudioRecorderService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/IAudioRecorderService.cs
@@ -3,6 +3,6 @@ namespace BugNarrator.Windows.Services.Audio;
 public interface IAudioRecorderService : IDisposable
 {
     bool IsRecording { get; }
-    Task StartAsync(string audioFilePath, int deviceNumber, CancellationToken cancellationToken = default);
+    Task StartAsync(string audioFilePath, AudioRecordingRequest request, CancellationToken cancellationToken = default);
     Task StopAsync(CancellationToken cancellationToken = default);
 }

--- a/windows/src/BugNarrator.Windows.Services/Audio/NAudioRecorderService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/NAudioRecorderService.cs
@@ -6,7 +6,7 @@ public sealed class NAudioRecorderService : IAudioRecorderService
 {
     private readonly object syncRoot = new();
     private TaskCompletionSource? stopCompletionSource;
-    private WaveInEvent? waveInEvent;
+    private IWaveIn? activeCapture;
     private WaveFileWriter? waveWriter;
 
     public bool IsRecording { get; private set; }
@@ -16,7 +16,7 @@ public sealed class NAudioRecorderService : IAudioRecorderService
         CleanupRecorder();
     }
 
-    public Task StartAsync(string audioFilePath, int deviceNumber, CancellationToken cancellationToken = default)
+    public Task StartAsync(string audioFilePath, AudioRecordingRequest request, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -29,21 +29,16 @@ public sealed class NAudioRecorderService : IAudioRecorderService
 
             Directory.CreateDirectory(Path.GetDirectoryName(audioFilePath)!);
 
-            waveInEvent = new WaveInEvent
-            {
-                BufferMilliseconds = 125,
-                DeviceNumber = deviceNumber,
-                WaveFormat = new WaveFormat(16000, 16, 1),
-            };
-            waveInEvent.DataAvailable += OnDataAvailable;
-            waveInEvent.RecordingStopped += OnRecordingStopped;
+            activeCapture = CreateCapture(request);
+            activeCapture.DataAvailable += OnDataAvailable;
+            activeCapture.RecordingStopped += OnRecordingStopped;
 
-            waveWriter = new WaveFileWriter(audioFilePath, waveInEvent.WaveFormat);
+            waveWriter = new WaveFileWriter(audioFilePath, activeCapture.WaveFormat);
             stopCompletionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             try
             {
-                waveInEvent.StartRecording();
+                activeCapture.StartRecording();
                 IsRecording = true;
             }
             catch
@@ -62,26 +57,54 @@ public sealed class NAudioRecorderService : IAudioRecorderService
 
         lock (syncRoot)
         {
-            if (!IsRecording || waveInEvent is null)
+            if (!IsRecording || activeCapture is null)
             {
                 return Task.CompletedTask;
             }
 
-            waveInEvent.StopRecording();
+            activeCapture.StopRecording();
             return stopCompletionSource?.Task ?? Task.CompletedTask;
         }
+    }
+
+    private static IWaveIn CreateCapture(AudioRecordingRequest request)
+    {
+        return request.Source switch
+        {
+            AudioRecordingSource.Microphone => CreateMicrophoneCapture(request),
+            AudioRecordingSource.SystemAudio => new WasapiLoopbackCapture(),
+            AudioRecordingSource.MicrophoneAndSystemAudio =>
+                throw new NotSupportedException(
+                    "Microphone plus system audio recording is not implemented yet. Choose Microphone or System Audio for this build."),
+            _ => throw new InvalidOperationException("Unsupported recording source."),
+        };
+    }
+
+    private static WaveInEvent CreateMicrophoneCapture(AudioRecordingRequest request)
+    {
+        if (request.MicrophoneDeviceNumber is null)
+        {
+            throw new InvalidOperationException("A microphone device is required for microphone recording.");
+        }
+
+        return new WaveInEvent
+        {
+            BufferMilliseconds = 125,
+            DeviceNumber = request.MicrophoneDeviceNumber.Value,
+            WaveFormat = new WaveFormat(16000, 16, 1),
+        };
     }
 
     private void CleanupRecorder()
     {
         lock (syncRoot)
         {
-            if (waveInEvent is not null)
+            if (activeCapture is not null)
             {
-                waveInEvent.DataAvailable -= OnDataAvailable;
-                waveInEvent.RecordingStopped -= OnRecordingStopped;
-                waveInEvent.Dispose();
-                waveInEvent = null;
+                activeCapture.DataAvailable -= OnDataAvailable;
+                activeCapture.RecordingStopped -= OnRecordingStopped;
+                activeCapture.Dispose();
+                activeCapture = null;
             }
 
             waveWriter?.Dispose();

--- a/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
+++ b/windows/src/BugNarrator.Windows.Services/Audio/RecordingLifecycleService.cs
@@ -98,35 +98,63 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
         }
 
         var settings = await settingsStore.LoadAsync(cancellationToken);
-        var deviceSelection = AudioInputDeviceSelection.Resolve(
-            settings.EffectiveAudioInputDeviceName,
-            audioInputDeviceCatalog.GetAvailableInputDevices());
-
-        if (!deviceSelection.IsResolved)
+        var recordingSource = settings.EffectiveRecordingAudioSourceProfile;
+        if (settings.RecordingAudioSourceCompatibilityIssue is { } sourceIssue)
         {
             PublishState(new RecordingControlState(
                 RecordingWorkflowState.Failed,
                 CanStart: true,
                 CanStop: false,
                 CanCaptureScreenshot: false,
-                deviceSelection.ErrorMessage ?? "No microphone device is available.",
+                sourceIssue,
                 ActiveSession: null));
             return;
         }
 
-        var preflightResult = microphonePreflightService.CheckReadyToRecord(
-            audioRecorderService.IsRecording,
-            deviceSelection.DeviceNumber);
-        diagnostics.Info("recording", $"microphone preflight result: {preflightResult.Status}");
+        AudioInputDeviceSelection? deviceSelection = null;
+        if (recordingSource.UsesMicrophone)
+        {
+            deviceSelection = AudioInputDeviceSelection.Resolve(
+                settings.EffectiveAudioInputDeviceName,
+                audioInputDeviceCatalog.GetAvailableInputDevices());
 
-        if (!preflightResult.CanStart)
+            if (!deviceSelection.IsResolved)
+            {
+                PublishState(new RecordingControlState(
+                    RecordingWorkflowState.Failed,
+                    CanStart: true,
+                    CanStop: false,
+                    CanCaptureScreenshot: false,
+                    deviceSelection.ErrorMessage ?? "No microphone device is available.",
+                    ActiveSession: null));
+                return;
+            }
+
+            var preflightResult = microphonePreflightService.CheckReadyToRecord(
+                audioRecorderService.IsRecording,
+                deviceSelection.DeviceNumber);
+            diagnostics.Info("recording", $"microphone preflight result: {preflightResult.Status}");
+
+            if (!preflightResult.CanStart)
+            {
+                PublishState(new RecordingControlState(
+                    RecordingWorkflowState.Failed,
+                    CanStart: true,
+                    CanStop: false,
+                    CanCaptureScreenshot: false,
+                    preflightResult.Message,
+                    ActiveSession: null));
+                return;
+            }
+        }
+        else if (audioRecorderService.IsRecording)
         {
             PublishState(new RecordingControlState(
                 RecordingWorkflowState.Failed,
                 CanStart: true,
                 CanStop: false,
                 CanCaptureScreenshot: false,
-                preflightResult.Message,
+                "A recording session is already active.",
                 ActiveSession: null));
             return;
         }
@@ -139,7 +167,10 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
             createdDraft = await sessionDraftStore.CreateDraftAsync(startedAt, cancellationToken);
             activeSession = createdDraft;
 
-            await audioRecorderService.StartAsync(createdDraft.AudioFilePath, deviceSelection.DeviceNumber, cancellationToken);
+            var recordingRequest = new AudioRecordingRequest(
+                recordingSource.Source,
+                deviceSelection?.DeviceNumber);
+            await audioRecorderService.StartAsync(createdDraft.AudioFilePath, recordingRequest, cancellationToken);
 
             var recordingDraft = createdDraft with
             {
@@ -148,13 +179,13 @@ public sealed class RecordingLifecycleService : IRecordingLifecycleService
             activeSession = recordingDraft;
             await sessionDraftStore.SaveAsync(recordingDraft, cancellationToken);
 
-            diagnostics.Info("recording", "recording started");
+            diagnostics.Info("recording", $"recording started with source {recordingSource.StorageValue}");
             PublishState(new RecordingControlState(
                 RecordingWorkflowState.Recording,
                 CanStart: false,
                 CanStop: true,
                 CanCaptureScreenshot: true,
-                $"Recording started. Draft folder: {recordingDraft.SessionDirectory}",
+                $"{recordingSource.DisplayName} recording started. Draft folder: {recordingDraft.SessionDirectory}",
                 recordingDraft));
         }
         catch (Exception exception)

--- a/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/FileWindowsAppSettingsStore.cs
@@ -63,7 +63,9 @@ public sealed class FileWindowsAppSettingsStore : IWindowsAppSettingsStore
             settings.EffectiveStartRecordingHotkey.Normalize(),
             settings.EffectiveStopRecordingHotkey.Normalize(),
             settings.EffectiveScreenshotHotkey.Normalize(),
-            settings.NormalizedAiProvider);
+            settings.NormalizedAiProvider,
+            settings.NormalizedRecordingAudioSource,
+            settings.HasAcceptedSystemAudioRecordingConsent);
 
         var json = JsonSerializer.Serialize(normalizedSettings, JsonOptions);
         await AtomicFileOperations.WriteAllTextAsync(settingsFilePath, json, cancellationToken);

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
@@ -1,4 +1,5 @@
 using BugNarrator.Core.Models;
+using BugNarrator.Windows.Services.Audio;
 using BugNarrator.Windows.Services.Http;
 using BugNarrator.Windows.Services.Hotkeys;
 
@@ -20,7 +21,9 @@ public sealed record WindowsAppSettings(
     WindowsHotkeyShortcut StartRecordingHotkey = default,
     WindowsHotkeyShortcut StopRecordingHotkey = default,
     WindowsHotkeyShortcut ScreenshotHotkey = default,
-    string AiProvider = "openAI")
+    string AiProvider = "openAI",
+    string RecordingAudioSource = "microphone",
+    bool HasAcceptedSystemAudioRecordingConsent = false)
 {
     public static WindowsAppSettings Default { get; } = new(
         TranscriptionModel: "whisper-1",
@@ -38,13 +41,42 @@ public sealed record WindowsAppSettings(
         StartRecordingHotkey: WindowsHotkeyShortcut.NotSet,
         StopRecordingHotkey: WindowsHotkeyShortcut.NotSet,
         ScreenshotHotkey: WindowsHotkeyShortcut.NotSet,
-        AiProvider: WindowsAiProviderProfile.Default.StorageValue);
+        AiProvider: WindowsAiProviderProfile.Default.StorageValue,
+        RecordingAudioSource: AudioRecordingSourceProfile.Default.StorageValue,
+        HasAcceptedSystemAudioRecordingConsent: false);
 
     public WindowsAiProviderProfile EffectiveAiProviderProfile =>
         WindowsAiProviderProfile.FromStorageValue(AiProvider);
 
     public string NormalizedAiProvider =>
         EffectiveAiProviderProfile.StorageValue;
+
+    public AudioRecordingSourceProfile EffectiveRecordingAudioSourceProfile =>
+        AudioRecordingSourceProfile.FromStorageValue(RecordingAudioSource);
+
+    public string NormalizedRecordingAudioSource =>
+        EffectiveRecordingAudioSourceProfile.StorageValue;
+
+    public string? RecordingAudioSourceCompatibilityIssue
+    {
+        get
+        {
+            var source = EffectiveRecordingAudioSourceProfile.Source;
+
+            if (source == AudioRecordingSource.MicrophoneAndSystemAudio)
+            {
+                return "Microphone plus system audio recording is not implemented yet. Choose Microphone or System Audio for this build.";
+            }
+
+            if (EffectiveRecordingAudioSourceProfile.UsesSystemAudio
+                && !HasAcceptedSystemAudioRecordingConsent)
+            {
+                return "Accept the system audio recording notice in Settings before recording system audio.";
+            }
+
+            return null;
+        }
+    }
 
     public string EffectiveTranscriptionModel =>
         string.IsNullOrWhiteSpace(TranscriptionModel)

--- a/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
+++ b/windows/src/BugNarrator.Windows/Views/SettingsWindow.cs
@@ -17,6 +17,7 @@ public sealed class SettingsWindow : Window
     private readonly ComboBox aiProviderComboBox;
     private readonly IAudioInputDeviceCatalog audioInputDeviceCatalog;
     private readonly ComboBox audioInputDeviceComboBox;
+    private readonly ComboBox audioRecordingSourceComboBox;
     private readonly WindowsDiagnostics diagnostics;
     private readonly Dictionary<WindowsHotkeyAction, WindowsHotkeyShortcut> draftHotkeys = [];
     private readonly TextBox gitHubDefaultLabelsTextBox;
@@ -39,6 +40,7 @@ public sealed class SettingsWindow : Window
     private readonly ISecretStore secretStore;
     private readonly IWindowsAppSettingsStore settingsStore;
     private readonly TextBlock statusTextBlock;
+    private readonly CheckBox systemAudioConsentCheckBox;
     private readonly ITranscriptionClient transcriptionClient;
 
     public SettingsWindow(
@@ -114,6 +116,19 @@ public sealed class SettingsWindow : Window
         {
             Margin = new Thickness(0, 0, 0, 14),
             DisplayMemberPath = nameof(AudioInputDeviceOption.DisplayName),
+        };
+
+        audioRecordingSourceComboBox = new ComboBox
+        {
+            Margin = new Thickness(0, 0, 0, 14),
+            DisplayMemberPath = nameof(AudioRecordingSourceProfile.DisplayName),
+            ItemsSource = AudioRecordingSourceProfile.All,
+        };
+
+        systemAudioConsentCheckBox = new CheckBox
+        {
+            Margin = new Thickness(0, -4, 0, 14),
+            Content = "I understand system audio recording captures audio playing from other apps on this PC.",
         };
 
         gitHubTokenPasswordBox = new PasswordBox
@@ -294,9 +309,13 @@ public sealed class SettingsWindow : Window
                     BuildLabel("Issue Extraction Model"),
                     issueExtractionModelTextBox,
                     BuildHint("Defaults to gpt-4.1-mini for structured draft issue extraction after transcription."),
+                    BuildLabel("Recording Audio Source"),
+                    audioRecordingSourceComboBox,
+                    BuildHint("Choose Microphone for normal narration, System Audio for app/computer playback, or Microphone + System Audio to see the currently tracked mixed-capture limitation."),
+                    systemAudioConsentCheckBox,
                     BuildLabel("Microphone Input Device"),
                     audioInputDeviceComboBox,
-                    BuildHint("Choose a specific Windows microphone if you use more than one. If the saved device disappears, BugNarrator will ask you to choose another instead of silently using the wrong microphone."),
+                    BuildHint("Choose a specific Windows microphone when recording from the microphone. If the saved device disappears, BugNarrator will ask you to choose another instead of silently using the wrong microphone."),
                     statusTextBlock,
                 },
             },
@@ -508,6 +527,8 @@ public sealed class SettingsWindow : Window
             languageHintTextBox.Text = settings.EffectiveLanguageHint ?? string.Empty;
             promptTextBox.Text = settings.EffectiveTranscriptionPrompt ?? string.Empty;
             issueExtractionModelTextBox.Text = settings.EffectiveIssueExtractionModel;
+            audioRecordingSourceComboBox.SelectedItem = settings.EffectiveRecordingAudioSourceProfile;
+            systemAudioConsentCheckBox.IsChecked = settings.HasAcceptedSystemAudioRecordingConsent;
             PopulateAudioInputDevices(settings.EffectiveAudioInputDeviceName);
             gitHubTokenPasswordBox.Password = gitHubToken ?? string.Empty;
             gitHubOwnerTextBox.Text = settings.NormalizedGitHubRepositoryOwner;
@@ -558,7 +579,9 @@ public sealed class SettingsWindow : Window
                 StartRecordingHotkey: draftHotkeys[WindowsHotkeyAction.StartRecording],
                 StopRecordingHotkey: draftHotkeys[WindowsHotkeyAction.StopRecording],
                 ScreenshotHotkey: draftHotkeys[WindowsHotkeyAction.CaptureScreenshot],
-                AiProvider: GetSelectedAiProviderProfile().StorageValue);
+                AiProvider: GetSelectedAiProviderProfile().StorageValue,
+                RecordingAudioSource: GetSelectedRecordingAudioSourceProfile().StorageValue,
+                HasAcceptedSystemAudioRecordingConsent: systemAudioConsentCheckBox.IsChecked == true);
 
             if (settings.AiProviderCompatibilityIssue is { } aiProviderIssue)
             {
@@ -816,5 +839,11 @@ public sealed class SettingsWindow : Window
     {
         return aiProviderComboBox.SelectedItem as WindowsAiProviderProfile
             ?? WindowsAiProviderProfile.Default;
+    }
+
+    private AudioRecordingSourceProfile GetSelectedRecordingAudioSourceProfile()
+    {
+        return audioRecordingSourceComboBox.SelectedItem as AudioRecordingSourceProfile
+            ?? AudioRecordingSourceProfile.Default;
     }
 }

--- a/windows/tests/BugNarrator.Windows.Tests/AudioInputDeviceSelectionTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/AudioInputDeviceSelectionTests.cs
@@ -61,6 +61,60 @@ public sealed class AudioInputDeviceSelectionTests
         Assert.False(harness.AudioRecorderService.IsRecording);
     }
 
+    [Fact]
+    public async Task StartRecordingAsync_WithSystemAudioAndConsent_StartsLoopbackWithoutMicrophone()
+    {
+        using var harness = new RecordingHarness();
+        harness.SettingsStore.Settings = WindowsAppSettings.Default with
+        {
+            RecordingAudioSource = "systemAudio",
+            HasAcceptedSystemAudioRecordingConsent = true,
+        };
+        harness.AudioInputDeviceCatalog.Devices = [];
+
+        await harness.Service.StartRecordingAsync();
+
+        Assert.Equal(RecordingWorkflowState.Recording, harness.Service.CurrentState.WorkflowState);
+        Assert.True(harness.AudioRecorderService.IsRecording);
+        Assert.Equal(AudioRecordingSource.SystemAudio, harness.AudioRecorderService.LastRequest?.Source);
+        Assert.Null(harness.AudioRecorderService.LastRequest?.MicrophoneDeviceNumber);
+        Assert.Equal(0, harness.MicrophonePreflightService.CallCount);
+    }
+
+    [Fact]
+    public async Task StartRecordingAsync_WithSystemAudioWithoutConsent_FailsBeforeCapture()
+    {
+        using var harness = new RecordingHarness();
+        harness.SettingsStore.Settings = WindowsAppSettings.Default with
+        {
+            RecordingAudioSource = "systemAudio",
+            HasAcceptedSystemAudioRecordingConsent = false,
+        };
+
+        await harness.Service.StartRecordingAsync();
+
+        Assert.Equal(RecordingWorkflowState.Failed, harness.Service.CurrentState.WorkflowState);
+        Assert.Contains("Accept the system audio recording notice", harness.Service.CurrentState.StatusMessage);
+        Assert.False(harness.AudioRecorderService.IsRecording);
+    }
+
+    [Fact]
+    public async Task StartRecordingAsync_WithMixedAudio_ReportsTrackedLimitation()
+    {
+        using var harness = new RecordingHarness();
+        harness.SettingsStore.Settings = WindowsAppSettings.Default with
+        {
+            RecordingAudioSource = "microphoneAndSystemAudio",
+            HasAcceptedSystemAudioRecordingConsent = true,
+        };
+
+        await harness.Service.StartRecordingAsync();
+
+        Assert.Equal(RecordingWorkflowState.Failed, harness.Service.CurrentState.WorkflowState);
+        Assert.Contains("Microphone plus system audio recording is not implemented yet", harness.Service.CurrentState.StatusMessage);
+        Assert.False(harness.AudioRecorderService.IsRecording);
+    }
+
     private sealed class RecordingHarness : IDisposable
     {
         private readonly string rootDirectory;
@@ -137,8 +191,11 @@ public sealed class AudioInputDeviceSelectionTests
         {
         }
 
-        public Task StartAsync(string audioFilePath, int deviceNumber, CancellationToken cancellationToken = default)
+        public AudioRecordingRequest? LastRequest { get; private set; }
+
+        public Task StartAsync(string audioFilePath, AudioRecordingRequest request, CancellationToken cancellationToken = default)
         {
+            LastRequest = request;
             IsRecording = true;
             return Task.CompletedTask;
         }
@@ -162,8 +219,11 @@ public sealed class AudioInputDeviceSelectionTests
 
     private sealed class FakeMicrophonePreflightService : IMicrophonePreflightService
     {
+        public int CallCount { get; private set; }
+
         public RecordingPreflightResult CheckReadyToRecord(bool isAlreadyRecording, int deviceNumber)
         {
+            CallCount++;
             return new RecordingPreflightResult(
                 RecordingPreflightStatus.Ready,
                 CanStart: true,

--- a/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceMilestone5Tests.cs
@@ -184,13 +184,13 @@ public sealed class RecordingLifecycleServiceMilestone5Tests
         {
         }
 
-        public int? LastDeviceNumber { get; private set; }
+        public AudioRecordingRequest? LastRequest { get; private set; }
 
-        public Task StartAsync(string audioFilePath, int deviceNumber, CancellationToken cancellationToken = default)
+        public Task StartAsync(string audioFilePath, AudioRecordingRequest request, CancellationToken cancellationToken = default)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(audioFilePath)!);
             File.WriteAllText(audioFilePath, "fake audio");
-            LastDeviceNumber = deviceNumber;
+            LastRequest = request;
             IsRecording = true;
             return Task.CompletedTask;
         }

--- a/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceScreenshotTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/RecordingLifecycleServiceScreenshotTests.cs
@@ -195,10 +195,13 @@ public sealed class RecordingLifecycleServiceScreenshotTests
         {
         }
 
-        public Task StartAsync(string audioFilePath, int deviceNumber, CancellationToken cancellationToken = default)
+        public AudioRecordingRequest? LastRequest { get; private set; }
+
+        public Task StartAsync(string audioFilePath, AudioRecordingRequest request, CancellationToken cancellationToken = default)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(audioFilePath)!);
             File.WriteAllText(audioFilePath, string.Empty);
+            LastRequest = request;
             IsRecording = true;
             return Task.CompletedTask;
         }

--- a/windows/tests/BugNarrator.Windows.Tests/WindowsHotkeySettingsTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/WindowsHotkeySettingsTests.cs
@@ -65,7 +65,7 @@ public sealed class WindowsHotkeySettingsTests : IDisposable
     }
 
     [Fact]
-    public async Task FileWindowsAppSettingsStore_RoundTripsHotkeyAssignments()
+    public async Task FileWindowsAppSettingsStore_RoundTripsWorkflowSettings()
     {
         var store = new FileWindowsAppSettingsStore(storagePaths);
         var settings = WindowsAppSettings.Default with
@@ -73,6 +73,8 @@ public sealed class WindowsHotkeySettingsTests : IDisposable
             StartRecordingHotkey = new WindowsHotkeyShortcut(0x46, WindowsHotkeyModifiers.Control | WindowsHotkeyModifiers.Alt),
             StopRecordingHotkey = new WindowsHotkeyShortcut(0x47, WindowsHotkeyModifiers.Control | WindowsHotkeyModifiers.Shift),
             ScreenshotHotkey = new WindowsHotkeyShortcut(0x53, WindowsHotkeyModifiers.Control | WindowsHotkeyModifiers.Shift),
+            RecordingAudioSource = "systemAudio",
+            HasAcceptedSystemAudioRecordingConsent = true,
         };
 
         await store.SaveAsync(settings);
@@ -81,6 +83,8 @@ public sealed class WindowsHotkeySettingsTests : IDisposable
         Assert.Equal(settings.StartRecordingHotkey.Normalize(), loaded.EffectiveStartRecordingHotkey);
         Assert.Equal(settings.StopRecordingHotkey.Normalize(), loaded.EffectiveStopRecordingHotkey);
         Assert.Equal(settings.ScreenshotHotkey.Normalize(), loaded.EffectiveScreenshotHotkey);
+        Assert.Equal("systemAudio", loaded.NormalizedRecordingAudioSource);
+        Assert.True(loaded.HasAcceptedSystemAudioRecordingConsent);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add Windows recording-source settings for Microphone, System Audio, and Microphone + System Audio
- implement System Audio capture with NAudio WASAPI loopback into the existing session WAV artifact path
- add explicit system-audio consent messaging before capture
- surface Microphone + System Audio as an explicit tracked limitation instead of creating an incomplete mixed artifact
- update validation docs, roadmap, product boundaries, and parity matrix

## Validation
- powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
  - BugNarrator.Core.Tests: 9 passed
  - BugNarrator.Windows.Tests: 47 passed
- powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
- powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64
- packaged runtime launch probe: app stayed alive for initialization with one BugNarrator.Windows process; recent log included tray shell initialized and hotkey settings load

Fixes #74
Refs #44