### PR TITLE
ARCH: Inject remaining directly-constructed helpers (#82)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -47,10 +47,10 @@ final class AppState: ObservableObject {
     private let artifactsService: any SessionArtifactsManaging
     private let clipboardService: any ClipboardWriting
     private let urlHandler: any URLOpening
-    private let debugBundleExporter = DebugBundleExporter()
-    private let privacyDataExporter = PrivacyDataExporter()
-    private let telemetryRecorder = OperationalTelemetryRecorder()
-    private let localPrivacyDataManager = LocalPrivacyDataManager()
+    private let debugBundleExporter: any DebugBundleExporting
+    private let privacyDataExporter: any PrivacyDataExporting
+    private let telemetryRecorder: any OperationalTelemetryRecording
+    private let localPrivacyDataManager: any LocalPrivacyDataManaging
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
@@ -148,6 +148,10 @@ final class AppState: ObservableObject {
             artifactsService: services.artifactsService,
             clipboardService: services.clipboardService,
             urlHandler: services.urlHandler,
+            debugBundleExporter: services.debugBundleExporter,
+            privacyDataExporter: services.privacyDataExporter,
+            telemetryRecorder: services.telemetryRecorder,
+            localPrivacyDataManager: services.localPrivacyDataManager,
             recordingTimer: services.recordingTimer,
             runtimeEnvironment: runtimeEnvironment
         )
@@ -169,6 +173,10 @@ final class AppState: ObservableObject {
         artifactsService: any SessionArtifactsManaging,
         clipboardService: any ClipboardWriting,
         urlHandler: any URLOpening,
+        debugBundleExporter: any DebugBundleExporting,
+        privacyDataExporter: any PrivacyDataExporting,
+        telemetryRecorder: any OperationalTelemetryRecording,
+        localPrivacyDataManager: any LocalPrivacyDataManaging,
         recordingTimer: RecordingTimerViewModel,
         runtimeEnvironment: AppRuntimeEnvironment = AppRuntimeEnvironment()
     ) {
@@ -189,6 +197,10 @@ final class AppState: ObservableObject {
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
         self.urlHandler = urlHandler
+        self.debugBundleExporter = debugBundleExporter
+        self.privacyDataExporter = privacyDataExporter
+        self.telemetryRecorder = telemetryRecorder
+        self.localPrivacyDataManager = localPrivacyDataManager
         self.trackerIntegration = TrackerIntegrationController(
             settingsStore: settingsStore,
             exportService: exportService

--- a/Sources/BugNarrator/Services/DebugBundleExporter.swift
+++ b/Sources/BugNarrator/Services/DebugBundleExporter.swift
@@ -254,6 +254,8 @@ struct DebugBundleExporter {
     }
 }
 
+extension DebugBundleExporter: DebugBundleExporting {}
+
 enum SystemDiagnosticsInfo {
     static func currentArchitecture() -> String {
         var systemInfo = utsname()

--- a/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
+++ b/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
@@ -85,3 +85,5 @@ struct OperationalTelemetryRecorder {
         try fileManager.removeItem(at: storageURL)
     }
 }
+
+extension OperationalTelemetryRecorder: OperationalTelemetryRecording {}

--- a/Sources/BugNarrator/Services/PrivacyDataExporter.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExporter.swift
@@ -150,6 +150,8 @@ struct PrivacyDataExporter {
     }
 }
 
+extension PrivacyDataExporter: PrivacyDataExporting {}
+
 struct LocalPrivacyDataManager: @unchecked Sendable {
     private let fileManager: FileManager
     private let appSupportURL: URL
@@ -182,3 +184,5 @@ struct LocalPrivacyDataManager: @unchecked Sendable {
         }
     }
 }
+
+extension LocalPrivacyDataManager: LocalPrivacyDataManaging {}

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -249,6 +249,31 @@ protocol ClipboardWriting {
     func copy(_ string: String)
 }
 
+@MainActor
+protocol DebugBundleExporting {
+    func export(snapshot: DebugBundleSnapshot) throws -> URL?
+}
+
+@MainActor
+protocol PrivacyDataExporting {
+    func export(
+        sessions: [TranscriptSession],
+        settings: PrivacyDataExportSettingsSnapshot,
+        diagnostics: PrivacyDataExportDiagnosticsSnapshot
+    ) throws -> URL?
+}
+
+protocol OperationalTelemetryRecording {
+    func record(_ name: String, metadata: [String: String])
+    func recentEvents(limit: Int) -> [OperationalTelemetryEvent]
+    func clear() throws
+}
+
+@MainActor
+protocol LocalPrivacyDataManaging {
+    func clearLocalSupportArtifacts() async
+}
+
 protocol KeychainServicing {
     func string(forService service: String, account: String, allowInteraction: Bool) throws -> String?
     func setString(_ value: String, service: String, account: String) throws

--- a/Sources/BugNarrator/Utilities/AppBootstrap.swift
+++ b/Sources/BugNarrator/Utilities/AppBootstrap.swift
@@ -104,6 +104,10 @@ enum UITestRuntimeSupport {
             artifactsService: SessionArtifactsService(rootDirectoryURL: artifactsRootURL),
             clipboardService: UITestClipboardService(),
             urlHandler: UITestURLHandler(),
+            debugBundleExporter: DebugBundleExporter(),
+            privacyDataExporter: PrivacyDataExporter(),
+            telemetryRecorder: OperationalTelemetryRecorder(),
+            localPrivacyDataManager: LocalPrivacyDataManager(),
             recordingTimer: RecordingTimerViewModel(),
             runtimeEnvironment: runtimeEnvironment
         )

--- a/Sources/BugNarrator/Utilities/AppServiceContainer.swift
+++ b/Sources/BugNarrator/Utilities/AppServiceContainer.swift
@@ -15,6 +15,10 @@ struct AppServiceContainer {
     let artifactsService: any SessionArtifactsManaging
     let clipboardService: any ClipboardWriting
     let urlHandler: any URLOpening
+    let debugBundleExporter: any DebugBundleExporting
+    let privacyDataExporter: any PrivacyDataExporting
+    let telemetryRecorder: any OperationalTelemetryRecording
+    let localPrivacyDataManager: any LocalPrivacyDataManaging
     let recordingTimer: RecordingTimerViewModel
 
     static func production(settingsStore: SettingsStore) -> AppServiceContainer {
@@ -32,6 +36,10 @@ struct AppServiceContainer {
             artifactsService: SessionArtifactsService(),
             clipboardService: SystemClipboardService(),
             urlHandler: WorkspaceURLHandler(),
+            debugBundleExporter: DebugBundleExporter(),
+            privacyDataExporter: PrivacyDataExporter(),
+            telemetryRecorder: OperationalTelemetryRecorder(),
+            localPrivacyDataManager: LocalPrivacyDataManager(),
             recordingTimer: RecordingTimerViewModel()
         )
     }

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -417,6 +417,21 @@ final class AppStateTests: XCTestCase {
         XCTAssertFalse(copied.contains(harness.settingsStore.trimmedAPIKey))
     }
 
+    func testDeleteAllLocalDataUsesInjectedPrivacyDataManager() async {
+        let localPrivacyDataManager = MockLocalPrivacyDataManager()
+        let harness = AppStateHarness(localPrivacyDataManager: localPrivacyDataManager)
+        defer { harness.cleanup() }
+
+        await harness.appState.deleteAllLocalData()
+
+        XCTAssertEqual(localPrivacyDataManager.clearCallCount, 1)
+        XCTAssertEqual(harness.appState.status.phase, .success)
+        XCTAssertEqual(
+            harness.appState.status.detail,
+            "Cleared local diagnostics and export history."
+        )
+    }
+
     func testSuccessfulSessionSavesCopiesAndDeletesTemporaryAudioFile() async throws {
         let harness = AppStateHarness()
         defer { harness.cleanup() }

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -581,6 +581,76 @@ final class MockClipboardService: ClipboardWriting {
     }
 }
 
+@MainActor
+final class MockDebugBundleExporter: DebugBundleExporting {
+    var exportResult: Result<URL?, Error> = .success(nil)
+    private(set) var exportedSnapshots: [DebugBundleSnapshot] = []
+
+    func export(snapshot: DebugBundleSnapshot) throws -> URL? {
+        exportedSnapshots.append(snapshot)
+        return try exportResult.get()
+    }
+}
+
+@MainActor
+final class MockPrivacyDataExporter: PrivacyDataExporting {
+    struct ExportRequest {
+        let sessions: [TranscriptSession]
+        let settings: PrivacyDataExportSettingsSnapshot
+        let diagnostics: PrivacyDataExportDiagnosticsSnapshot
+    }
+
+    var exportResult: Result<URL?, Error> = .success(nil)
+    private(set) var exportRequests: [ExportRequest] = []
+
+    func export(
+        sessions: [TranscriptSession],
+        settings: PrivacyDataExportSettingsSnapshot,
+        diagnostics: PrivacyDataExportDiagnosticsSnapshot
+    ) throws -> URL? {
+        exportRequests.append(
+            ExportRequest(
+                sessions: sessions,
+                settings: settings,
+                diagnostics: diagnostics
+            )
+        )
+        return try exportResult.get()
+    }
+}
+
+final class MockOperationalTelemetryRecorder: OperationalTelemetryRecording {
+    private(set) var recordedEvents: [(name: String, metadata: [String: String])] = []
+    var recentEventsResult: [OperationalTelemetryEvent] = []
+    private(set) var recentEventsLimits: [Int] = []
+    private(set) var clearCallCount = 0
+    var clearError: Error?
+
+    func record(_ name: String, metadata: [String: String] = [:]) {
+        recordedEvents.append((name: name, metadata: metadata))
+    }
+
+    func recentEvents(limit: Int) -> [OperationalTelemetryEvent] {
+        recentEventsLimits.append(limit)
+        return Array(recentEventsResult.suffix(limit))
+    }
+
+    func clear() throws {
+        clearCallCount += 1
+        if let clearError {
+            throw clearError
+        }
+    }
+}
+
+final class MockLocalPrivacyDataManager: LocalPrivacyDataManaging {
+    private(set) var clearCallCount = 0
+
+    func clearLocalSupportArtifacts() async {
+        clearCallCount += 1
+    }
+}
+
 final class MockURLHandler: URLOpening {
     private(set) var openedURLs: [URL] = []
     var shouldSucceed = true
@@ -688,6 +758,10 @@ struct AppStateHarness {
     let artifactsService: MockArtifactsService
     let clipboardService: MockClipboardService
     let urlHandler: MockURLHandler
+    let debugBundleExporter: MockDebugBundleExporter
+    let privacyDataExporter: MockPrivacyDataExporter
+    let telemetryRecorder: MockOperationalTelemetryRecorder
+    let localPrivacyDataManager: MockLocalPrivacyDataManager
     let issueExtractionService: MockIssueExtractionService
     let exportService: MockExportService
     let recoveredRecordingImporter: MockRecoveredRecordingImporter
@@ -704,6 +778,10 @@ struct AppStateHarness {
         launchAtLoginStatus: LaunchAtLoginStatus = .disabled,
         screenshotCaptureService: MockScreenshotCaptureService = MockScreenshotCaptureService(),
         screenshotSelectionService: MockScreenshotSelectionService = MockScreenshotSelectionService(),
+        debugBundleExporter: MockDebugBundleExporter = MockDebugBundleExporter(),
+        privacyDataExporter: MockPrivacyDataExporter = MockPrivacyDataExporter(),
+        telemetryRecorder: MockOperationalTelemetryRecorder = MockOperationalTelemetryRecorder(),
+        localPrivacyDataManager: MockLocalPrivacyDataManager = MockLocalPrivacyDataManager(),
         recoveredImportResult: Result<Int, Error> = .success(0),
         runtimeEnvironment: AppRuntimeEnvironment = AppRuntimeEnvironment(bundlePath: "/Applications/BugNarrator.app")
     ) {
@@ -757,6 +835,10 @@ struct AppStateHarness {
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
         self.urlHandler = urlHandler
+        self.debugBundleExporter = debugBundleExporter
+        self.privacyDataExporter = privacyDataExporter
+        self.telemetryRecorder = telemetryRecorder
+        self.localPrivacyDataManager = localPrivacyDataManager
         self.issueExtractionService = issueExtractionService
         self.exportService = exportService
         self.recoveredRecordingImporter = recoveredRecordingImporter
@@ -778,6 +860,10 @@ struct AppStateHarness {
             artifactsService: artifactsService,
             clipboardService: clipboardService,
             urlHandler: urlHandler,
+            debugBundleExporter: debugBundleExporter,
+            privacyDataExporter: privacyDataExporter,
+            telemetryRecorder: telemetryRecorder,
+            localPrivacyDataManager: localPrivacyDataManager,
             recordingTimer: RecordingTimerViewModel(),
             runtimeEnvironment: runtimeEnvironment
         )


### PR DESCRIPTION
Closes #82

## Summary
- Add protocols for debug bundle export, privacy export, operational telemetry, and local privacy data cleanup
- Inject those helpers through AppServiceContainer and the AppState initializer
- Add AppStateHarness test doubles and an AppState test covering injected local privacy cleanup

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/DebugBundleExporterTests -only-testing:BugNarratorTests/PrivacyDataExporterTests -only-testing:BugNarratorTests/OperationalTelemetryRecorderTests
- ./scripts/validate.sh origin/main