### PR TITLE
ARCH: Split AppState published UI state into focused view-facing models (#92)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
 		4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */; };
+		0B3F1B78C8A64B7AB6FD9221 /* AppPresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3F1B77C8A64B7AB6FD9221 /* AppPresentationState.swift */; };
 		5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */; };
 		5090A54144CACF59295F137C /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22447E5581818B8003AA49F8 /* TestSupport.swift */; };
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
@@ -151,6 +152,7 @@
 		04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspector.swift; sourceTree = "<group>"; };
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
+		0B3F1B77C8A64B7AB6FD9221 /* AppPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPresentationState.swift; sourceTree = "<group>"; };
 		0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingControlPanelView.swift; sourceTree = "<group>"; };
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			isa = PBXGroup;
 			children = (
 				28B463E2764267ED731EDB99 /* AppBootstrap.swift */,
+				0B3F1B77C8A64B7AB6FD9221 /* AppPresentationState.swift */,
 				1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */,
 				5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */,
 				60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */,
@@ -658,6 +661,7 @@
 				7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */,
 				85A1F6C9245B4A1F95C0A102 /* AIProviderSettingsController.swift in Sources */,
 				19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */,
+				0B3F1B78C8A64B7AB6FD9221 /* AppPresentationState.swift in Sources */,
 				CB9E1F15D2FB0B7CF38DD5F6 /* AppError.swift in Sources */,
 				5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */,
 				292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -4,9 +4,6 @@ import Foundation
 
 @MainActor
 final class AppState: ObservableObject {
-    @Published private(set) var status: AppStatus = .idle()
-    @Published private(set) var currentError: AppError?
-    @Published private(set) var transientToast: TransientToast?
     @Published var showDiscardConfirmation = false
     @Published var currentTranscript: TranscriptSession?
     @Published var selectedTranscriptID: UUID?
@@ -23,6 +20,7 @@ final class AppState: ObservableObject {
     let trackerIntegration: TrackerIntegrationController
     let aiProviderSettings: AIProviderSettingsController
     let recordingTimer: RecordingTimerViewModel
+    let presentationState: AppPresentationState
 
     private let runtimeEnvironment: AppRuntimeEnvironment
     var showTranscriptWindow: (() -> Void)?
@@ -102,6 +100,18 @@ final class AppState: ObservableObject {
         var session: TranscriptSession
         let pendingTranscription: PendingTranscription
         let audioFileURL: URL
+    }
+
+    var status: AppStatus {
+        presentationState.status
+    }
+
+    var currentError: AppError? {
+        presentationState.currentError
+    }
+
+    var transientToast: TransientToast? {
+        presentationState.transientToast
     }
 
     var gitHubValidationState: APIKeyValidationState {
@@ -218,6 +228,7 @@ final class AppState: ObservableObject {
         self.settingsStore = settingsStore
         self.transcriptStore = transcriptStore
         self.recordingTimer = recordingTimer
+        self.presentationState = AppPresentationState()
         self.runtimeEnvironment = runtimeEnvironment
         self.audioRecorder = audioRecorder
         self.microphonePermissionService = microphonePermissionService
@@ -269,6 +280,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         aiProviderSettings.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        presentationState.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -1681,15 +1698,14 @@ final class AppState: ObservableObject {
         }
 
         toastDismissTask?.cancel()
-        transientToast = nil
+        presentationState.dismissToast()
         hotkeyManager.unregisterAll()
         stopTimer(resetElapsed: false)
         endActivity()
     }
 
     private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {
-        status = newStatus
-        currentError = error
+        presentationState.setStatus(newStatus, error: error)
     }
 
     private func presentError(_ error: Error) {
@@ -2611,14 +2627,14 @@ final class AppState: ObservableObject {
 
     private func showToast(_ message: String, style: TransientToastStyle = .success) {
         toastDismissTask?.cancel()
-        transientToast = TransientToast(message: message, style: style)
+        presentationState.showToast(TransientToast(message: message, style: style))
         toastDismissTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard !Task.isCancelled else {
                 return
             }
 
-            self?.transientToast = nil
+            self?.presentationState.dismissToast()
         }
     }
 

--- a/Sources/BugNarrator/Utilities/AppPresentationState.swift
+++ b/Sources/BugNarrator/Utilities/AppPresentationState.swift
@@ -1,0 +1,32 @@
+import Combine
+import Foundation
+
+@MainActor
+final class AppPresentationState: ObservableObject {
+    @Published private(set) var status: AppStatus
+    @Published private(set) var currentError: AppError?
+    @Published private(set) var transientToast: TransientToast?
+
+    init(
+        status: AppStatus = .idle(),
+        currentError: AppError? = nil,
+        transientToast: TransientToast? = nil
+    ) {
+        self.status = status
+        self.currentError = currentError
+        self.transientToast = transientToast
+    }
+
+    func setStatus(_ status: AppStatus, error: AppError? = nil) {
+        self.status = status
+        currentError = error
+    }
+
+    func showToast(_ toast: TransientToast) {
+        transientToast = toast
+    }
+
+    func dismissToast() {
+        transientToast = nil
+    }
+}

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -1,9 +1,30 @@
 import AppKit
+import Combine
 import XCTest
 @testable import BugNarrator
 
 @MainActor
 final class AppStateTests: XCTestCase {
+    func testPresentationStateBacksAppStateStatusErrorAndToastFacade() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        var appStateChangeCount = 0
+        let cancellable = harness.appState.objectWillChange.sink {
+            appStateChangeCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        harness.appState.presentationState.setStatus(.error("Needs attention"), error: .missingAPIKey)
+        harness.appState.presentationState.showToast(TransientToast(message: "Saved", style: .success))
+
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertEqual(harness.appState.status.detail, "Needs attention")
+        XCTAssertEqual(harness.appState.currentError, .missingAPIKey)
+        XCTAssertEqual(harness.appState.transientToast?.message, "Saved")
+        XCTAssertGreaterThanOrEqual(appStateChangeCount, 2)
+    }
+
     func testRecordingControlsStartFlowShowsPanelAndStartsSession() async {
         let harness = AppStateHarness(apiKey: "")
         defer { harness.cleanup() }


### PR DESCRIPTION
Closes #92

## Summary
- Add `AppPresentationState` as a focused observable model for status, current error, and transient toast presentation.
- Replace three direct AppState `@Published` properties with facade accessors backed by the focused model.
- Forward `AppPresentationState.objectWillChange` through AppState so existing views continue observing the same facade without a broad UI rewrite.
- Add AppState coverage for the facade values and forwarded invalidation.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests`\n- `./scripts/validate.sh origin/main`\n\nNote: local validation reported Semgrep as NOT RUN because Docker is unavailable in this environment.