### PR TITLE
ARCH: Introduce typed diagnostics and telemetry event names (#91)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -574,10 +574,10 @@ final class AppState: ObservableObject {
     }
 
     func startSession() async {
-        recordingLogger.info("session_start_requested", "A feedback session start was requested.")
+        recordingLogger.info(.sessionStartRequested, "A feedback session start was requested.")
 
         guard recordingTransition == .idle else {
-            recordingLogger.debug("session_start_ignored", "The start request was ignored because another recording transition is already in progress.")
+            recordingLogger.debug(.sessionStartIgnored, "The start request was ignored because another recording transition is already in progress.")
             return
         }
 
@@ -585,7 +585,7 @@ final class AppState: ObservableObject {
         defer { recordingTransition = .idle }
 
         if status.phase == .recording || status.phase == .transcribing {
-            recordingLogger.warning("session_start_rejected", "The start request was rejected because BugNarrator is already busy.")
+            recordingLogger.warning(.sessionStartRejected, "The start request was rejected because BugNarrator is already busy.")
             return
         }
 
@@ -603,7 +603,7 @@ final class AppState: ObservableObject {
 
         let preflightResult = await preflightForSessionStart()
         if let preflightError = preflightResult.error {
-            permissionsLogger.warning("session_start_preflight_failed", preflightError.userMessage)
+            permissionsLogger.warning(.sessionStartPreflightFailed, preflightError.userMessage)
             presentError(preflightError)
             return
         }
@@ -625,7 +625,7 @@ final class AppState: ObservableObject {
                 beginActivity(reason: recordingActivityReason())
                 startTimer()
                 recordingLogger.info(
-                    "session_started",
+                    .sessionStarted,
                     "A feedback session started successfully.",
                     metadata: [
                         "session_id": sessionID.uuidString,
@@ -635,7 +635,7 @@ final class AppState: ObservableObject {
                     ]
                 )
                 telemetryRecorder.record(
-                    "recording_started",
+                    .recordingStarted,
                     metadata: [
                         "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
                         "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
@@ -950,7 +950,7 @@ final class AppState: ObservableObject {
                 metadata: ["session_count": "\(transcriptStore.sessionCount)"]
             )
             telemetryRecorder.record(
-                "privacy_data_exported",
+                .privacyDataExported,
                 metadata: ["session_count": "\(transcriptStore.sessionCount)"]
             )
             NSWorkspace.shared.activateFileViewerSelecting([bundleURL])
@@ -1774,7 +1774,7 @@ final class AppState: ObservableObject {
 
     private func logSessionStopRequested(_ recordingSession: RecordingSessionDraft) {
         recordingLogger.info(
-            "session_stop_requested",
+            .sessionStopRequested,
             "Stopping the active feedback session.",
             metadata: ["session_id": recordingSession.sessionID.uuidString]
         )
@@ -1782,12 +1782,12 @@ final class AppState: ObservableObject {
 
     private func beginStoppingSession() -> RecordingSessionDraft? {
         guard recordingTransition == .idle else {
-            recordingLogger.debug("session_stop_ignored", "The stop request was ignored because another recording transition is already in progress.")
+            recordingLogger.debug(.sessionStopIgnored, "The stop request was ignored because another recording transition is already in progress.")
             return nil
         }
 
         guard status.phase == .recording else {
-            recordingLogger.warning("session_stop_rejected", "The stop request was rejected because no recording session is active.")
+            recordingLogger.warning(.sessionStopRejected, "The stop request was rejected because no recording session is active.")
             return nil
         }
 
@@ -1906,7 +1906,7 @@ final class AppState: ObservableObject {
         }
 
         transcriptionLogger.info(
-            "transcription_completed",
+            .transcriptionCompleted,
             "BugNarrator finished transcription and created a transcript session.",
             metadata: [
                 "session_id": session.id.uuidString,
@@ -1915,7 +1915,7 @@ final class AppState: ObservableObject {
             ]
         )
         telemetryRecorder.record(
-            "transcription_completed",
+            .transcriptionCompleted,
             metadata: [
                 "marker_count": "\(session.markerCount)",
                 "screenshot_count": "\(session.screenshotCount)",
@@ -2644,7 +2644,7 @@ final class AppState: ObservableObject {
             "error_type": telemetryErrorType(for: error)
         ]
 
-        telemetryRecorder.record("app_error", metadata: metadata)
+        telemetryRecorder.record(.appError, metadata: metadata)
 
         switch error {
         case .microphonePermissionDenied,
@@ -2654,23 +2654,23 @@ final class AppState: ObservableObject {
              .systemAudioConsentRequired,
              .systemAudioUnavailable,
              .screenRecordingPermissionDenied:
-            permissionsLogger.warning("app_error", error.userMessage, metadata: metadata)
+            permissionsLogger.warning(.appError, error.userMessage, metadata: metadata)
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
-            settingsLogger.warning("app_error", error.userMessage, metadata: metadata)
+            settingsLogger.warning(.appError, error.userMessage, metadata: metadata)
         case .recordingFailure:
-            recordingLogger.error("app_error", error.userMessage, metadata: metadata)
+            recordingLogger.error(.appError, error.userMessage, metadata: metadata)
         case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure, .rateLimited:
-            transcriptionLogger.error("app_error", error.userMessage, metadata: metadata)
+            transcriptionLogger.error(.appError, error.userMessage, metadata: metadata)
         case .screenshotCaptureFailure:
-            screenshotLogger.error("app_error", error.userMessage, metadata: metadata)
+            screenshotLogger.error(.appError, error.userMessage, metadata: metadata)
         case .exportConfigurationMissing, .exportFailure:
-            exportLogger.error("app_error", error.userMessage, metadata: metadata)
+            exportLogger.error(.appError, error.userMessage, metadata: metadata)
         case .storageFailure:
-            sessionLibraryLogger.error("app_error", error.userMessage, metadata: metadata)
+            sessionLibraryLogger.error(.appError, error.userMessage, metadata: metadata)
         case .noActiveSession:
-            recordingLogger.warning("app_error", error.userMessage, metadata: metadata)
+            recordingLogger.warning(.appError, error.userMessage, metadata: metadata)
         case .diagnosticsFailure:
-            settingsLogger.error("app_error", error.userMessage, metadata: metadata)
+            settingsLogger.error(.appError, error.userMessage, metadata: metadata)
         }
     }
 

--- a/Sources/BugNarrator/Services/AIProviderSettingsController.swift
+++ b/Sources/BugNarrator/Services/AIProviderSettingsController.swift
@@ -52,7 +52,7 @@ final class AIProviderSettingsController: ObservableObject {
             )
             apiKeyValidationState = .success(settingsStore.aiProvider.successMessage)
             logger.info(
-                "validate_ai_provider_succeeded",
+                .validateAIProviderSucceeded,
                 "The AI provider validation flow succeeded.",
                 metadata: ["provider": settingsStore.aiProvider.rawValue]
             )
@@ -60,7 +60,7 @@ final class AIProviderSettingsController: ObservableObject {
             let appError = (error as? AppError) ?? .transcriptionFailure(error.localizedDescription)
             apiKeyValidationState = .failure(appError.userMessage)
             logger.warning(
-                "validate_ai_provider_failed",
+                .validateAIProviderFailed,
                 appError.userMessage,
                 metadata: ["provider": settingsStore.aiProvider.rawValue]
             )
@@ -71,7 +71,7 @@ final class AIProviderSettingsController: ObservableObject {
         settingsStore.removeAPIKey()
         apiKeyValidationState = .idle
         logger.info(
-            "remove_ai_provider_credential",
+            .removeAIProviderCredential,
             "The AI provider credential was removed from local storage.",
             metadata: ["provider": settingsStore.aiProvider.rawValue]
         )

--- a/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
+++ b/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
@@ -12,6 +12,36 @@ struct OperationalTelemetryEvent: Codable, Equatable {
     }
 }
 
+struct TelemetryEventName: RawRepresentable, ExpressibleByStringLiteral, Equatable, Hashable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(stringLiteral value: String) {
+        self.rawValue = value
+    }
+}
+
+enum TelemetryEvent {
+    static let appError = TelemetryEventName("app_error")
+    static let recordingStarted = TelemetryEventName("recording_started")
+    static let transcriptionCompleted = TelemetryEventName("transcription_completed")
+    static let privacyDataExported = TelemetryEventName("privacy_data_exported")
+}
+
+extension TelemetryEventName {
+    static let appError = TelemetryEvent.appError
+    static let recordingStarted = TelemetryEvent.recordingStarted
+    static let transcriptionCompleted = TelemetryEvent.transcriptionCompleted
+    static let privacyDataExported = TelemetryEvent.privacyDataExported
+}
+
 struct OperationalTelemetryRecorder {
     private let fileManager: FileManager
     private let storageURL: URL
@@ -53,6 +83,10 @@ struct OperationalTelemetryRecorder {
                 metadata: ["event": name]
             )
         }
+    }
+
+    func record(_ event: TelemetryEventName, metadata: [String: String] = [:]) {
+        record(event.rawValue, metadata: metadata)
     }
 
     func recentEvents(limit: Int = 200) -> [OperationalTelemetryEvent] {

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -269,6 +269,12 @@ protocol OperationalTelemetryRecording {
     func clear() throws
 }
 
+extension OperationalTelemetryRecording {
+    func record(_ event: TelemetryEventName, metadata: [String: String] = [:]) {
+        record(event.rawValue, metadata: metadata)
+    }
+}
+
 @MainActor
 protocol LocalPrivacyDataManaging {
     func clearLocalSupportArtifacts() async

--- a/Sources/BugNarrator/Services/TrackerIntegrationController.swift
+++ b/Sources/BugNarrator/Services/TrackerIntegrationController.swift
@@ -68,7 +68,7 @@ final class TrackerIntegrationController: ObservableObject {
                 "GitHub accepted this token for \(configurationSnapshot.owner)/\(configurationSnapshot.repository)."
             )
             exportLogger.info(
-                "validate_github_configuration_succeeded",
+                .validateGitHubConfigurationSucceeded,
                 "GitHub export configuration validation succeeded.",
                 metadata: ["repository": "\(configurationSnapshot.owner)/\(configurationSnapshot.repository)"]
             )
@@ -81,7 +81,7 @@ final class TrackerIntegrationController: ObservableObject {
 
             let appError = (error as? AppError) ?? .exportFailure(error.localizedDescription)
             gitHubValidationState = .failure(appError.userMessage)
-            exportLogger.warning("validate_github_configuration_failed", appError.userMessage)
+            exportLogger.warning(.validateGitHubConfigurationFailed, appError.userMessage)
         }
     }
 
@@ -258,7 +258,7 @@ final class TrackerIntegrationController: ObservableObject {
                     projectCount: projects.count
                 )
                 self.exportLogger.info(
-                    "validate_jira_configuration_succeeded",
+                    .validateJiraConfigurationSucceeded,
                     "Jira export configuration validation succeeded.",
                     metadata: [
                         "project_count": "\(projects.count)",
@@ -283,7 +283,7 @@ final class TrackerIntegrationController: ObservableObject {
             jiraIssueTypeMetadataIsStale = !jiraIssueTypes.isEmpty
             let appError = (error as? AppError) ?? .exportFailure(error.localizedDescription)
             jiraValidationState = .failure(appError.userMessage)
-            exportLogger.warning("validate_jira_configuration_failed", appError.userMessage)
+            exportLogger.warning(.validateJiraConfigurationFailed, appError.userMessage)
         }
     }
 

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -35,6 +35,62 @@ enum DiagnosticsLogLevel: String, Codable, CaseIterable {
     }
 }
 
+struct DiagnosticsEventName: RawRepresentable, ExpressibleByStringLiteral, Equatable, Hashable {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(stringLiteral value: String) {
+        self.rawValue = value
+    }
+}
+
+enum DiagnosticsEvent {
+    static let appError = DiagnosticsEventName("app_error")
+    static let sessionStartRequested = DiagnosticsEventName("session_start_requested")
+    static let sessionStartIgnored = DiagnosticsEventName("session_start_ignored")
+    static let sessionStartRejected = DiagnosticsEventName("session_start_rejected")
+    static let sessionStartPreflightFailed = DiagnosticsEventName("session_start_preflight_failed")
+    static let sessionStarted = DiagnosticsEventName("session_started")
+    static let sessionStopRequested = DiagnosticsEventName("session_stop_requested")
+    static let sessionStopIgnored = DiagnosticsEventName("session_stop_ignored")
+    static let sessionStopRejected = DiagnosticsEventName("session_stop_rejected")
+    static let transcriptionCompleted = DiagnosticsEventName("transcription_completed")
+    static let validateAIProviderSucceeded = DiagnosticsEventName("validate_ai_provider_succeeded")
+    static let validateAIProviderFailed = DiagnosticsEventName("validate_ai_provider_failed")
+    static let removeAIProviderCredential = DiagnosticsEventName("remove_ai_provider_credential")
+    static let validateGitHubConfigurationSucceeded = DiagnosticsEventName("validate_github_configuration_succeeded")
+    static let validateGitHubConfigurationFailed = DiagnosticsEventName("validate_github_configuration_failed")
+    static let validateJiraConfigurationSucceeded = DiagnosticsEventName("validate_jira_configuration_succeeded")
+    static let validateJiraConfigurationFailed = DiagnosticsEventName("validate_jira_configuration_failed")
+}
+
+extension DiagnosticsEventName {
+    static let appError = DiagnosticsEvent.appError
+    static let sessionStartRequested = DiagnosticsEvent.sessionStartRequested
+    static let sessionStartIgnored = DiagnosticsEvent.sessionStartIgnored
+    static let sessionStartRejected = DiagnosticsEvent.sessionStartRejected
+    static let sessionStartPreflightFailed = DiagnosticsEvent.sessionStartPreflightFailed
+    static let sessionStarted = DiagnosticsEvent.sessionStarted
+    static let sessionStopRequested = DiagnosticsEvent.sessionStopRequested
+    static let sessionStopIgnored = DiagnosticsEvent.sessionStopIgnored
+    static let sessionStopRejected = DiagnosticsEvent.sessionStopRejected
+    static let transcriptionCompleted = DiagnosticsEvent.transcriptionCompleted
+    static let validateAIProviderSucceeded = DiagnosticsEvent.validateAIProviderSucceeded
+    static let validateAIProviderFailed = DiagnosticsEvent.validateAIProviderFailed
+    static let removeAIProviderCredential = DiagnosticsEvent.removeAIProviderCredential
+    static let validateGitHubConfigurationSucceeded = DiagnosticsEvent.validateGitHubConfigurationSucceeded
+    static let validateGitHubConfigurationFailed = DiagnosticsEvent.validateGitHubConfigurationFailed
+    static let validateJiraConfigurationSucceeded = DiagnosticsEvent.validateJiraConfigurationSucceeded
+    static let validateJiraConfigurationFailed = DiagnosticsEvent.validateJiraConfigurationFailed
+}
+
 struct DiagnosticsLogEntry: Codable, Equatable {
     let timestamp: Date
     let level: DiagnosticsLogLevel
@@ -202,16 +258,32 @@ struct DiagnosticsLogger: Sendable {
         log(.debug, event, message, metadata: metadata)
     }
 
+    func debug(_ event: DiagnosticsEventName, _ message: String, metadata: [String: String] = [:]) {
+        debug(event.rawValue, message, metadata: metadata)
+    }
+
     func info(_ event: String, _ message: String, metadata: [String: String] = [:]) {
         log(.info, event, message, metadata: metadata)
+    }
+
+    func info(_ event: DiagnosticsEventName, _ message: String, metadata: [String: String] = [:]) {
+        info(event.rawValue, message, metadata: metadata)
     }
 
     func warning(_ event: String, _ message: String, metadata: [String: String] = [:]) {
         log(.warning, event, message, metadata: metadata)
     }
 
+    func warning(_ event: DiagnosticsEventName, _ message: String, metadata: [String: String] = [:]) {
+        warning(event.rawValue, message, metadata: metadata)
+    }
+
     func error(_ event: String, _ message: String, metadata: [String: String] = [:]) {
         log(.error, event, message, metadata: metadata)
+    }
+
+    func error(_ event: DiagnosticsEventName, _ message: String, metadata: [String: String] = [:]) {
+        error(event.rawValue, message, metadata: metadata)
     }
 
     private func log(

--- a/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
+++ b/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
@@ -11,7 +11,7 @@ final class DiagnosticsLoggerTests: XCTestCase {
         let logger = DiagnosticsLogger(category: .settings, store: store)
 
         logger.info(
-            "credential_event",
+            .validateAIProviderSucceeded,
             "Validation failed for fixture-openai-key and Bearer fixture-github-pat",
             metadata: [
                 "apiKey": "fixture-openai-key",
@@ -26,6 +26,7 @@ final class DiagnosticsLoggerTests: XCTestCase {
         XCTAssertEqual(entry?.metadata["apiKey"], "<redacted>")
         XCTAssertEqual(entry?.metadata["githubToken"], "<redacted>")
         XCTAssertEqual(entry?.metadata["note"], "<redacted>")
+        XCTAssertEqual(entry?.event, DiagnosticsEvent.validateAIProviderSucceeded.rawValue)
         XCTAssertFalse(entry?.message.contains("fixture-openai-key") ?? true)
         XCTAssertFalse(entry?.message.contains("fixture-github-pat") ?? true)
 
@@ -41,18 +42,18 @@ final class DiagnosticsLoggerTests: XCTestCase {
         let logger = DiagnosticsLogger(category: .settings, store: store)
 
         BugNarratorDiagnostics.setDebugModeEnabled(false)
-        logger.debug("suppressed_debug", "This should not be recorded.")
+        logger.debug(.sessionStartIgnored, "This should not be recorded.")
 
         try? await Task.sleep(nanoseconds: 50_000_000)
         let suppressedEntries = await store.recentEntries()
         XCTAssertTrue(suppressedEntries.isEmpty)
 
         BugNarratorDiagnostics.setDebugModeEnabled(true)
-        logger.debug("allowed_debug", "This should be recorded.")
+        logger.debug(.sessionStartIgnored, "This should be recorded.")
 
         try? await Task.sleep(nanoseconds: 100_000_000)
         let recordedEntries = await store.recentEntries()
-        XCTAssertEqual(recordedEntries.first?.event, "allowed_debug")
+        XCTAssertEqual(recordedEntries.first?.event, DiagnosticsEvent.sessionStartIgnored.rawValue)
 
         await store.clear()
         BugNarratorDiagnostics.setDebugModeEnabled(false)

--- a/Tests/BugNarratorTests/OperationalTelemetryRecorderTests.swift
+++ b/Tests/BugNarratorTests/OperationalTelemetryRecorderTests.swift
@@ -12,14 +12,14 @@ final class OperationalTelemetryRecorderTests: XCTestCase {
         let storageURL = rootDirectoryURL.appendingPathComponent("telemetry.jsonl")
         let recorder = OperationalTelemetryRecorder(storageURL: storageURL)
 
-        recorder.record("recording_started", metadata: ["has_openai_key": "yes"])
-        recorder.record("transcription_completed", metadata: ["model": "whisper-1"])
+        recorder.record(.recordingStarted, metadata: ["has_openai_key": "yes"])
+        recorder.record(.transcriptionCompleted, metadata: ["model": "whisper-1"])
 
         let lines = try String(contentsOf: storageURL, encoding: .utf8)
             .split(separator: "\n")
         XCTAssertEqual(lines.count, 2)
-        XCTAssertTrue(lines[0].contains("recording_started"))
-        XCTAssertTrue(lines[1].contains("transcription_completed"))
+        XCTAssertTrue(lines[0].contains(TelemetryEvent.recordingStarted.rawValue))
+        XCTAssertTrue(lines[1].contains(TelemetryEvent.transcriptionCompleted.rawValue))
     }
 
     func testRecorderRedactsSensitiveMetadataBeforePersisting() throws {


### PR DESCRIPTION
Closes #91

## Summary
- Add typed `DiagnosticsEventName` and `TelemetryEventName` wrappers with stable event namespaces.
- Convert covered AppState diagnostics/telemetry, AI provider validation logs, and tracker validation logs to typed event-name calls.
- Keep serialized event names unchanged; this is not a telemetry schema migration.
- Update diagnostics and telemetry tests to assert through typed constants.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/DiagnosticsLoggerTests -only-testing:BugNarratorTests/OperationalTelemetryRecorderTests`\n- `./scripts/validate.sh origin/main`\n\nNote: local validation reported Semgrep as NOT RUN because Docker is unavailable in this environment.