### PR TITLE
Extract SessionLibraryController

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */; };
 		6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */; };
 		6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E006D3F529E46315F3585 /* HotkeyAction.swift */; };
+		89F4D0030000000000000003 /* SessionLibraryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */; };
+		89F4D0040000000000000004 /* SessionLibraryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4D0010000000000000001 /* SessionLibraryController.swift */; };
 		7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
@@ -222,6 +224,8 @@
 		85A1F6C9245B4A1F95C0A101 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		89F4D0010000000000000001 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
+		89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
 		8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUploadPolicy.swift; sourceTree = "<group>"; };
 		8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotAnnotationTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
@@ -313,6 +317,7 @@
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
 				20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
+				89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */,
 				D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */,
 				67770387C5BA986EEB40382E /* SessionLibraryTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
@@ -425,6 +430,7 @@
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
 				6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */,
 				9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */,
+				89F4D0010000000000000001 /* SessionLibraryController.swift */,
 				76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */,
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
@@ -633,6 +639,7 @@
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
 				6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
+				89F4D0030000000000000003 /* SessionLibraryControllerTests.swift in Sources */,
 				8E0DE1B3EABFCECD46EF5ED0 /* SessionDataProtectorTests.swift in Sources */,
 				8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
@@ -718,6 +725,7 @@
 				B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */,
 				3893EB325B3915242FBD4BA6 /* ServiceProtocols.swift in Sources */,
 				6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */,
+				89F4D0040000000000000004 /* SessionLibraryController.swift in Sources */,
 				A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */,
 				B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */,
 				6DDE29389B4D58A9BD6CD115 /* SessionMarker.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,8 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published var currentTranscript: TranscriptSession?
-    @Published var selectedTranscriptID: UUID?
     @Published private(set) var activeRecordingSession: RecordingSessionDraft?
     @Published private(set) var issueExtractionSessionID: UUID?
     @Published private(set) var exportDestinationInProgress: ExportDestination?
@@ -21,6 +19,7 @@ final class AppState: ObservableObject {
     let aiProviderSettings: AIProviderSettingsController
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
+    let sessionLibrary: SessionLibraryController
 
     private let runtimeEnvironment: AppRuntimeEnvironment
     var showTranscriptWindow: (() -> Void)?
@@ -134,6 +133,16 @@ final class AppState: ObservableObject {
 
     var transientToast: TransientToast? {
         presentationState.transientToast
+    }
+
+    var currentTranscript: TranscriptSession? {
+        get { sessionLibrary.currentTranscript }
+        set { sessionLibrary.currentTranscript = newValue }
+    }
+
+    var selectedTranscriptID: UUID? {
+        get { sessionLibrary.selectedTranscriptID }
+        set { sessionLibrary.selectedTranscriptID = newValue }
     }
 
     var gitHubValidationState: APIKeyValidationState {
@@ -251,6 +260,11 @@ final class AppState: ObservableObject {
         self.transcriptStore = transcriptStore
         self.recordingTimer = recordingTimer
         self.presentationState = AppPresentationState()
+        self.sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: clipboardService
+        )
         self.runtimeEnvironment = runtimeEnvironment
         self.audioRecorder = audioRecorder
         self.microphonePermissionService = microphonePermissionService
@@ -277,7 +291,6 @@ final class AppState: ObservableObject {
             settingsStore: settingsStore,
             transcriptionClient: transcriptionClient
         )
-        self.selectedTranscriptID = transcriptStore.libraryEntries.first?.id
 
         BugNarratorDiagnostics.setDebugModeEnabled(settingsStore.debugMode)
 
@@ -308,6 +321,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         presentationState.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        sessionLibrary.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -389,29 +408,11 @@ final class AppState: ObservableObject {
     }
 
     var displayedTranscript: TranscriptSession? {
-        if let selectedTranscriptID {
-            if currentTranscript?.id == selectedTranscriptID {
-                return currentTranscript
-            }
-
-            if let storedSession = transcriptStore.session(with: selectedTranscriptID) {
-                return storedSession
-            }
-        }
-
-        if let currentTranscript {
-            return currentTranscript
-        }
-
-        return transcriptStore.libraryEntries.first.flatMap { transcriptStore.session(with: $0.id) }
+        sessionLibrary.displayedTranscript
     }
 
     var currentTranscriptIsPersisted: Bool {
-        guard let currentTranscript else {
-            return false
-        }
-
-        return transcriptStore.session(with: currentTranscript.id) == currentTranscript
+        sessionLibrary.currentTranscriptIsPersisted
     }
 
     var needsAPIKeySetup: Bool {
@@ -1088,8 +1089,7 @@ final class AppState: ObservableObject {
 
         let request = makeTranscriptionRequest()
         retryingSessionID = sessionID
-        selectedTranscriptID = retryContext.session.id
-        currentTranscript = retryContext.session
+        sessionLibrary.stageCurrentTranscript(retryContext.session)
         setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
         swapActivity(reason: "Retrying transcription from preserved audio")
         logPendingTranscriptionRetryRequested(retryContext)
@@ -1139,73 +1139,34 @@ final class AppState: ObservableObject {
     }
 
     func saveCurrentTranscriptToHistory() {
-        guard let currentTranscript, !currentTranscriptIsPersisted else {
-            selectedTranscriptID = currentTranscript?.id
-            return
-        }
-
         do {
-            try transcriptStore.add(currentTranscript)
-            selectedTranscriptID = currentTranscript.id
-            sessionLibraryLogger.info(
-                "unsaved_transcript_persisted",
-                "Saved the in-memory transcript into local session history.",
-                metadata: ["session_id": currentTranscript.id.uuidString]
-            )
-            setStatus(.success("Transcript saved to session history."))
+            if try sessionLibrary.saveCurrentTranscriptToHistory() != nil {
+                setStatus(.success("Transcript saved to session history."))
+            }
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
     }
 
     func deleteDisplayedTranscript() {
-        guard let displayedTranscript else {
-            return
+        do {
+            presentDeletedSessionStatus(try sessionLibrary.deleteDisplayedTranscript())
+        } catch {
+            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
-
-        deleteSessions(withIDs: [displayedTranscript.id])
     }
 
     func deleteSessions(withIDs ids: Set<UUID>) {
-        guard !ids.isEmpty else {
-            return
-        }
-
-        let wasSelectedTranscriptDeleted = selectedTranscriptID.map(ids.contains) ?? false
-        let deletingUnsavedCurrentTranscript = currentTranscript
-            .map { ids.contains($0.id) && transcriptStore.session(with: $0.id) == nil }
-            ?? false
-
         do {
-            let removedSessions = try transcriptStore.removeSessions(withIDs: ids)
-            var sessionsToCleanup = removedSessions
-            if let currentTranscript,
-               ids.contains(currentTranscript.id),
-               !removedSessions.contains(where: { $0.id == currentTranscript.id }),
-               transcriptStore.session(with: currentTranscript.id) == nil {
-                sessionsToCleanup.append(currentTranscript)
-            }
-            sessionsToCleanup.forEach(cleanupArtifactsForDeletedSession)
-
-            if currentTranscript.map({ ids.contains($0.id) }) == true {
-                currentTranscript = nil
-            }
-
-            if wasSelectedTranscriptDeleted || selectedTranscriptID == nil {
-                selectedTranscriptID = preferredTranscriptSelection()
-            }
-
-            let deletedCount = removedSessions.count + (deletingUnsavedCurrentTranscript ? 1 : 0)
-            if deletedCount > 0 {
-                sessionLibraryLogger.info(
-                    "sessions_deleted_from_library",
-                    "Deleted sessions from the library.",
-                    metadata: ["deleted_count": "\(deletedCount)"]
-                )
-                setStatus(.success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions."))
-            }
+            presentDeletedSessionStatus(try sessionLibrary.deleteSessions(withIDs: ids))
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+        }
+    }
+
+    private func presentDeletedSessionStatus(_ deletedCount: Int) {
+        if deletedCount > 0 {
+            setStatus(.success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions."))
         }
     }
 
@@ -2005,7 +1966,7 @@ final class AppState: ObservableObject {
             return
         }
 
-        currentTranscript = session
+        sessionLibrary.setCurrentTranscript(session)
         activeRecordingSession = nil
         showTranscriptWindow?()
     }
@@ -2065,8 +2026,7 @@ final class AppState: ObservableObject {
         _ error: Error,
         session: TranscriptSession
     ) {
-        currentTranscript = session
-        selectedTranscriptID = session.id
+        sessionLibrary.stageCurrentTranscript(session)
         activeRecordingSession = nil
 
         if settingsStore.autoCopyTranscript {
@@ -2237,8 +2197,7 @@ final class AppState: ObservableObject {
         do {
             try persistUpdatedSession(session)
         } catch {
-            currentTranscript = session
-            selectedTranscriptID = session.id
+            sessionLibrary.stageCurrentTranscript(session)
         }
 
         retryingSessionID = nil
@@ -2301,10 +2260,9 @@ final class AppState: ObservableObject {
             )
 
             do {
-                try transcriptStore.add(retryableSession)
+                try sessionLibrary.persistRetryableSession(retryableSession)
             } catch {
-                currentTranscript = retryableSession
-                selectedTranscriptID = retryableSession.id
+                sessionLibrary.stageCurrentTranscript(retryableSession)
                 activeRecordingSession = nil
                 cleanupPendingRecordedAudioIfNeeded()
                 endActivity()
@@ -2334,8 +2292,6 @@ final class AppState: ObservableObject {
                 return
             }
 
-            currentTranscript = retryableSession
-            selectedTranscriptID = retryableSession.id
             activeRecordingSession = nil
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
@@ -2415,40 +2371,14 @@ final class AppState: ObservableObject {
     }
 
     private func persistCompletedTranscript(_ session: TranscriptSession) throws {
-        try transcriptStore.add(session)
-        selectedTranscriptID = session.id
-
-        if settingsStore.autoCopyTranscript {
-            clipboardService.copy(session.transcript)
-        }
-
-        sessionLibraryLogger.info(
-            "transcript_persisted",
-            "Persisted a completed transcript session.",
-            metadata: [
-                "session_id": session.id.uuidString,
-                "auto_saved": "required",
-                "auto_copied": settingsStore.autoCopyTranscript ? "yes" : "no"
-            ]
+        try sessionLibrary.persistCompletedTranscript(
+            session,
+            autoCopyTranscript: settingsStore.autoCopyTranscript
         )
     }
 
     private func persistUpdatedSession(_ session: TranscriptSession) throws {
-        var session = session
-        session.updatedAt = Date()
-
-        currentTranscript = session
-
-        if transcriptStore.session(with: session.id) != nil {
-            try transcriptStore.add(session)
-        }
-
-        selectedTranscriptID = session.id
-        sessionLibraryLogger.debug(
-            "session_updated",
-            "Updated a transcript session in memory or local storage.",
-            metadata: ["session_id": session.id.uuidString]
-        )
+        try sessionLibrary.persistUpdatedSession(session)
     }
 
     private func preflightForSessionStart() async -> RecordingStartPreflightResult {
@@ -2578,40 +2508,11 @@ final class AppState: ObservableObject {
     }
 
     private func editableSession(with sessionID: UUID) -> TranscriptSession? {
-        sessionSnapshot(with: sessionID)
-    }
-
-    private func preferredTranscriptSelection() -> UUID? {
-        if let currentTranscript, !currentTranscriptIsPersisted {
-            return currentTranscript.id
-        }
-
-        return transcriptStore.libraryEntries.first?.id
+        sessionLibrary.editableSession(with: sessionID)
     }
 
     private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {
-        if currentTranscript?.id == sessionID {
-            return currentTranscript
-        }
-
-        return transcriptStore.session(with: sessionID)
-    }
-
-    private func cleanupArtifactsForDeletedSession(_ session: TranscriptSession) {
-        if let artifactsDirectoryURL = session.artifactsDirectoryURL {
-            artifactsService.removeArtifactsDirectory(at: artifactsDirectoryURL)
-            return
-        }
-
-        let directories = Set(
-            session.screenshots.map { screenshot in
-                screenshot.fileURL.deletingLastPathComponent()
-            }
-        )
-
-        directories.forEach { directoryURL in
-            artifactsService.removeArtifactsDirectory(at: directoryURL)
-        }
+        sessionLibrary.sessionSnapshot(with: sessionID)
     }
 
     private func makePrivacyDataExportSettingsSnapshot() -> PrivacyDataExportSettingsSnapshot {
@@ -2960,7 +2861,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            selectedTranscriptID = transcriptStore.latestPendingTranscriptionSession?.id
+            sessionLibrary.selectLatestPendingTranscriptionSession()
             sessionLibraryLogger.warning(
                 "recovered_recordings_imported",
                 "Imported recovered recordings as retryable transcript sessions.",

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -1,0 +1,224 @@
+import Combine
+import Foundation
+
+@MainActor
+final class SessionLibraryController: ObservableObject {
+    @Published var currentTranscript: TranscriptSession?
+    @Published var selectedTranscriptID: UUID?
+
+    private let transcriptStore: TranscriptStore
+    private let artifactsService: any SessionArtifactsManaging
+    private let clipboardService: any ClipboardWriting
+    private let logger: DiagnosticsLogger
+
+    init(
+        transcriptStore: TranscriptStore,
+        artifactsService: any SessionArtifactsManaging,
+        clipboardService: any ClipboardWriting,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .sessionLibrary)
+    ) {
+        self.transcriptStore = transcriptStore
+        self.artifactsService = artifactsService
+        self.clipboardService = clipboardService
+        self.logger = logger
+        self.selectedTranscriptID = transcriptStore.libraryEntries.first?.id
+    }
+
+    var displayedTranscript: TranscriptSession? {
+        if let selectedTranscriptID {
+            if currentTranscript?.id == selectedTranscriptID {
+                return currentTranscript
+            }
+
+            if let storedSession = transcriptStore.session(with: selectedTranscriptID) {
+                return storedSession
+            }
+        }
+
+        if let currentTranscript {
+            return currentTranscript
+        }
+
+        return transcriptStore.libraryEntries.first.flatMap { transcriptStore.session(with: $0.id) }
+    }
+
+    var currentTranscriptIsPersisted: Bool {
+        guard let currentTranscript else {
+            return false
+        }
+
+        return transcriptStore.session(with: currentTranscript.id) == currentTranscript
+    }
+
+    func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {
+        if currentTranscript?.id == sessionID {
+            return currentTranscript
+        }
+
+        return transcriptStore.session(with: sessionID)
+    }
+
+    func editableSession(with sessionID: UUID) -> TranscriptSession? {
+        sessionSnapshot(with: sessionID)
+    }
+
+    func refreshSelectionAfterLibraryReload() {
+        if let selectedTranscriptID, sessionSnapshot(with: selectedTranscriptID) != nil {
+            return
+        }
+
+        selectedTranscriptID = preferredTranscriptSelection()
+    }
+
+    func setCurrentTranscript(_ session: TranscriptSession?) {
+        currentTranscript = session
+    }
+
+    func stageCurrentTranscript(_ session: TranscriptSession) {
+        currentTranscript = session
+        selectedTranscriptID = session.id
+    }
+
+    func selectLatestPendingTranscriptionSession() {
+        selectedTranscriptID = transcriptStore.latestPendingTranscriptionSession?.id
+    }
+
+    @discardableResult
+    func saveCurrentTranscriptToHistory() throws -> TranscriptSession? {
+        guard let currentTranscript, !currentTranscriptIsPersisted else {
+            selectedTranscriptID = currentTranscript?.id
+            return nil
+        }
+
+        try transcriptStore.add(currentTranscript)
+        selectedTranscriptID = currentTranscript.id
+        logger.info(
+            "unsaved_transcript_persisted",
+            "Saved the in-memory transcript into local session history.",
+            metadata: ["session_id": currentTranscript.id.uuidString]
+        )
+        return currentTranscript
+    }
+
+    @discardableResult
+    func deleteDisplayedTranscript() throws -> Int {
+        guard let displayedTranscript else {
+            return 0
+        }
+
+        return try deleteSessions(withIDs: [displayedTranscript.id])
+    }
+
+    @discardableResult
+    func deleteSessions(withIDs ids: Set<UUID>) throws -> Int {
+        guard !ids.isEmpty else {
+            return 0
+        }
+
+        let wasSelectedTranscriptDeleted = selectedTranscriptID.map(ids.contains) ?? false
+        let deletingUnsavedCurrentTranscript = currentTranscript
+            .map { ids.contains($0.id) && transcriptStore.session(with: $0.id) == nil }
+            ?? false
+
+        let removedSessions = try transcriptStore.removeSessions(withIDs: ids)
+        var sessionsToCleanup = removedSessions
+        if let currentTranscript,
+           ids.contains(currentTranscript.id),
+           !removedSessions.contains(where: { $0.id == currentTranscript.id }),
+           transcriptStore.session(with: currentTranscript.id) == nil {
+            sessionsToCleanup.append(currentTranscript)
+        }
+        sessionsToCleanup.forEach(cleanupArtifactsForDeletedSession)
+
+        if currentTranscript.map({ ids.contains($0.id) }) == true {
+            currentTranscript = nil
+        }
+
+        if wasSelectedTranscriptDeleted || selectedTranscriptID == nil {
+            selectedTranscriptID = preferredTranscriptSelection()
+        }
+
+        let deletedCount = removedSessions.count + (deletingUnsavedCurrentTranscript ? 1 : 0)
+        if deletedCount > 0 {
+            logger.info(
+                "sessions_deleted_from_library",
+                "Deleted sessions from the library.",
+                metadata: ["deleted_count": "\(deletedCount)"]
+            )
+        }
+        return deletedCount
+    }
+
+    func persistCompletedTranscript(
+        _ session: TranscriptSession,
+        autoCopyTranscript: Bool
+    ) throws {
+        try transcriptStore.add(session)
+        selectedTranscriptID = session.id
+
+        if autoCopyTranscript {
+            clipboardService.copy(session.transcript)
+        }
+
+        logger.info(
+            "transcript_persisted",
+            "Persisted a completed transcript session.",
+            metadata: [
+                "session_id": session.id.uuidString,
+                "auto_saved": "required",
+                "auto_copied": autoCopyTranscript ? "yes" : "no"
+            ]
+        )
+    }
+
+    func persistRetryableSession(_ session: TranscriptSession) throws {
+        try transcriptStore.add(session)
+        stageCurrentTranscript(session)
+    }
+
+    func persistUpdatedSession(
+        _ session: TranscriptSession,
+        updatedAt: Date = Date()
+    ) throws {
+        var session = session
+        session.updatedAt = updatedAt
+
+        currentTranscript = session
+
+        if transcriptStore.session(with: session.id) != nil {
+            try transcriptStore.add(session)
+        }
+
+        selectedTranscriptID = session.id
+        logger.debug(
+            "session_updated",
+            "Updated a transcript session in memory or local storage.",
+            metadata: ["session_id": session.id.uuidString]
+        )
+    }
+
+    private func preferredTranscriptSelection() -> UUID? {
+        if let currentTranscript, !currentTranscriptIsPersisted {
+            return currentTranscript.id
+        }
+
+        return transcriptStore.libraryEntries.first?.id
+    }
+
+    private func cleanupArtifactsForDeletedSession(_ session: TranscriptSession) {
+        if let artifactsDirectoryURL = session.artifactsDirectoryURL {
+            artifactsService.removeArtifactsDirectory(at: artifactsDirectoryURL)
+            return
+        }
+
+        let directories = Set(
+            session.screenshots.map { screenshot in
+                screenshot.fileURL.deletingLastPathComponent()
+            }
+        )
+
+        directories.forEach { directoryURL in
+            artifactsService.removeArtifactsDirectory(at: directoryURL)
+        }
+    }
+}

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class SessionLibraryControllerTests: XCTestCase {
+    func testSelectAndRefreshSelectionAfterMissingStoredSessionFallsBackToLatest() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let older = makeSession(index: 1)
+        let newer = makeSession(index: 2)
+        try harness.transcriptStore.add(older)
+        try harness.transcriptStore.add(newer)
+
+        harness.controller.selectedTranscriptID = older.id
+        XCTAssertEqual(harness.controller.displayedTranscript?.id, older.id)
+
+        _ = try harness.transcriptStore.removeSessions(withIDs: [older.id])
+        harness.controller.refreshSelectionAfterLibraryReload()
+
+        XCTAssertEqual(harness.controller.selectedTranscriptID, newer.id)
+        XCTAssertEqual(harness.controller.displayedTranscript?.id, newer.id)
+    }
+
+    func testSaveCurrentTranscriptPersistsAndSelectsCurrentTranscript() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let unsaved = makeSession(index: 1)
+        harness.controller.stageCurrentTranscript(unsaved)
+
+        let saved = try harness.controller.saveCurrentTranscriptToHistory()
+
+        XCTAssertEqual(saved?.id, unsaved.id)
+        XCTAssertEqual(harness.transcriptStore.session(with: unsaved.id), unsaved)
+        XCTAssertEqual(harness.controller.selectedTranscriptID, unsaved.id)
+        XCTAssertTrue(harness.controller.currentTranscriptIsPersisted)
+    }
+
+    func testDeleteSessionsRemovesStoredSessionCleansArtifactsAndSelectsNextSession() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let older = makeSession(index: 1)
+        let artifactsDirectoryURL = harness.rootDirectoryURL.appendingPathComponent("session-artifacts", isDirectory: true)
+        try FileManager.default.createDirectory(at: artifactsDirectoryURL, withIntermediateDirectories: true)
+        let newer = makeSession(index: 2, artifactsDirectoryPath: artifactsDirectoryURL.path)
+        try harness.transcriptStore.add(older)
+        try harness.transcriptStore.add(newer)
+        harness.controller.selectedTranscriptID = newer.id
+
+        let deletedCount = try harness.controller.deleteSessions(withIDs: [newer.id])
+
+        XCTAssertEqual(deletedCount, 1)
+        XCTAssertNil(harness.transcriptStore.session(with: newer.id))
+        XCTAssertEqual(harness.controller.selectedTranscriptID, older.id)
+        XCTAssertEqual(harness.artifactsService.removedDirectories, [artifactsDirectoryURL])
+    }
+
+    func testPersistUpdatedSessionUpdatesStoredSessionAndCurrentTranscript() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        var session = makeSession(index: 1)
+        try harness.transcriptStore.add(session)
+        session.issueExtraction = IssueExtractionResult(
+            summary: "Updated summary",
+            issues: [
+                ExtractedIssue(
+                    title: "Updated issue",
+                    category: .bug,
+                    summary: "Summary",
+                    evidenceExcerpt: "Evidence",
+                    timestamp: 4
+                )
+            ]
+        )
+
+        try harness.controller.persistUpdatedSession(session, updatedAt: Date(timeIntervalSince1970: 100))
+
+        XCTAssertEqual(
+            harness.transcriptStore.session(with: session.id)?.issueExtraction?.summary,
+            "Updated summary"
+        )
+        XCTAssertEqual(harness.controller.currentTranscript?.issueExtraction?.issues.first?.title, "Updated issue")
+        XCTAssertEqual(harness.controller.selectedTranscriptID, session.id)
+    }
+
+    func testDeleteDisplayedTranscriptDeletesUnsavedCurrentAndFallsBackToStoredSelection() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let stored = makeSession(index: 1)
+        try harness.transcriptStore.add(stored)
+
+        let artifactsDirectoryURL = harness.rootDirectoryURL.appendingPathComponent("unsaved-artifacts", isDirectory: true)
+        try FileManager.default.createDirectory(at: artifactsDirectoryURL, withIntermediateDirectories: true)
+        let unsaved = makeSession(index: 2, artifactsDirectoryPath: artifactsDirectoryURL.path)
+        harness.controller.stageCurrentTranscript(unsaved)
+
+        let deletedCount = try harness.controller.deleteDisplayedTranscript()
+
+        XCTAssertEqual(deletedCount, 1)
+        XCTAssertNil(harness.controller.currentTranscript)
+        XCTAssertEqual(harness.controller.selectedTranscriptID, stored.id)
+        XCTAssertEqual(harness.controller.displayedTranscript?.id, stored.id)
+        XCTAssertEqual(harness.artifactsService.removedDirectories, [artifactsDirectoryURL])
+    }
+
+    func testPersistCompletedTranscriptCopiesWhenRequested() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = makeSession(index: 1, transcript: "Copy me")
+
+        try harness.controller.persistCompletedTranscript(session, autoCopyTranscript: true)
+
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id), session)
+        XCTAssertEqual(harness.controller.selectedTranscriptID, session.id)
+        XCTAssertEqual(harness.clipboardService.copiedStrings, ["Copy me"])
+    }
+
+    private func makeSession(
+        index: Int,
+        transcript: String? = nil,
+        artifactsDirectoryPath: String? = nil
+    ) -> TranscriptSession {
+        TranscriptSession(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+            transcript: transcript ?? "Transcript \(index)",
+            duration: TimeInterval(index),
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            artifactsDirectoryPath: artifactsDirectoryPath
+        )
+    }
+}
+
+@MainActor
+private struct SessionLibraryControllerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let artifactsService: MockArtifactsService
+    let clipboardService: MockClipboardService
+    let controller: SessionLibraryController
+
+    init() throws {
+        rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionLibraryControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        transcriptStore = TranscriptStore(
+            fileManager: .default,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        clipboardService = MockClipboardService()
+        controller = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: clipboardService
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- add SessionLibraryController to own transcript selection, save/update/delete, reload fallback, and artifact cleanup orchestration
- keep AppState as a facade for transcript library state and user-facing status presentation
- add focused SessionLibraryController tests for selection, reload fallback, delete cleanup, update, unsaved-current deletion, and copy-on-persist

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests -only-testing:BugNarratorTests/SessionArtifactsServiceTests -only-testing:BugNarratorTests/TranscriptStoreTests\n- ./scripts/validate.sh origin/main\n\nCloses #89