### PR TITLE
Extract TranscriptionRecoveryController

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */; };
 		6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */; };
 		6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E006D3F529E46315F3585 /* HotkeyAction.swift */; };
+		88F4D0030000000000000003 /* TranscriptionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */; };
+		88F4D0040000000000000004 /* TranscriptionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */; };
 		89F4D0030000000000000003 /* SessionLibraryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */; };
 		89F4D0040000000000000004 /* SessionLibraryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4D0010000000000000001 /* SessionLibraryController.swift */; };
 		7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */; };
@@ -224,6 +226,8 @@
 		85A1F6C9245B4A1F95C0A101 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
+		88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		89F4D0010000000000000001 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
 		89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
 		8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUploadPolicy.swift; sourceTree = "<group>"; };
@@ -324,6 +328,7 @@
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
 				22447E5581818B8003AA49F8 /* TestSupport.swift */,
 				7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */,
+				88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */,
 				F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */,
 				8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */,
 				BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */,
@@ -437,6 +442,7 @@
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
 				BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */,
+				88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */,
 				800BFCC6407B534886C65D77 /* TranscriptionClient.swift */,
 				04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */,
 				7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */,
@@ -648,6 +654,7 @@
 				683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */,
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
 				38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */,
+				88F4D0030000000000000003 /* TranscriptionRecoveryControllerTests.swift in Sources */,
 				0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -741,6 +748,7 @@
 				7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */,
 				AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */,
 				6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */,
+				88F4D0040000000000000004 /* TranscriptionRecoveryController.swift in Sources */,
 				6E7D93B7718A9340695B3B76 /* TranscriptSection.swift in Sources */,
 				05FAED3D483F3C16AEFFB7A5 /* TranscriptSectionBuilder.swift in Sources */,
 				9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -11,7 +11,6 @@ final class AppState: ObservableObject {
     @Published private(set) var pendingExportReview: IssueExportReview?
     @Published private(set) var exportHistory: [ExportReceipt] = []
     @Published private(set) var recoveredRecordingImportCount = 0
-    @Published private(set) var retryingSessionID: UUID?
 
     let settingsStore: SettingsStore
     let transcriptStore: TranscriptStore
@@ -20,6 +19,7 @@ final class AppState: ObservableObject {
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
     let sessionLibrary: SessionLibraryController
+    let transcriptionRecovery: TranscriptionRecoveryController
 
     private let runtimeEnvironment: AppRuntimeEnvironment
     var showTranscriptWindow: (() -> Void)?
@@ -117,12 +117,6 @@ final class AppState: ObservableObject {
         case postTranscriptionFailure(Error)
     }
 
-    private struct PendingTranscriptionRetryContext {
-        var session: TranscriptSession
-        let pendingTranscription: PendingTranscription
-        let audioFileURL: URL
-    }
-
     var status: AppStatus {
         presentationState.status
     }
@@ -143,6 +137,10 @@ final class AppState: ObservableObject {
     var selectedTranscriptID: UUID? {
         get { sessionLibrary.selectedTranscriptID }
         set { sessionLibrary.selectedTranscriptID = newValue }
+    }
+
+    var retryingSessionID: UUID? {
+        transcriptionRecovery.retryingSessionID
     }
 
     var gitHubValidationState: APIKeyValidationState {
@@ -265,6 +263,10 @@ final class AppState: ObservableObject {
             artifactsService: artifactsService,
             clipboardService: clipboardService
         )
+        self.transcriptionRecovery = TranscriptionRecoveryController(
+            sessionLibrary: self.sessionLibrary,
+            artifactsService: artifactsService
+        )
         self.runtimeEnvironment = runtimeEnvironment
         self.audioRecorder = audioRecorder
         self.microphonePermissionService = microphonePermissionService
@@ -327,6 +329,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         sessionLibrary.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        transcriptionRecovery.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -1083,12 +1091,34 @@ final class AppState: ObservableObject {
     }
 
     func retryPendingTranscription(for sessionID: UUID) async {
-        guard let retryContext = pendingTranscriptionRetryContext(for: sessionID) else {
+        let retryContext: PendingTranscriptionRetryContext
+        switch transcriptionRecovery.retryContext(
+            for: sessionID,
+            isRecording: status.phase == .recording,
+            hasUsableAIProviderCredential: settingsStore.hasUsableAIProviderCredential,
+            aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue
+        ) {
+        case .ready(let context):
+            retryContext = context
+        case .duplicate:
+            return
+        case .failure(let appError, let opensSettings, let statusMessage):
+            if let statusMessage {
+                setStatus(.error(statusMessage), error: appError)
+            } else {
+                presentError(appError, operation: .retryTranscription)
+            }
+            if opensSettings {
+                showSettingsWindow?()
+            }
+            return
+        }
+
+        guard transcriptionRecovery.beginRetry(for: sessionID) else {
             return
         }
 
         let request = makeTranscriptionRequest()
-        retryingSessionID = sessionID
         sessionLibrary.stageCurrentTranscript(retryContext.session)
         setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
         swapActivity(reason: "Retrying transcription from preserved audio")
@@ -1116,15 +1146,21 @@ final class AppState: ObservableObject {
                 mode: .retry
             ) {
             case .success:
-                cleanupPreservedRetryAudioIfNeeded(at: retryContext.audioFileURL)
-                retryingSessionID = nil
+                transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
+                    at: retryContext.audioFileURL,
+                    debugMode: settingsStore.debugMode
+                )
+                transcriptionRecovery.finishRetry()
                 finishSuccessfulTranscription(showTranscriptWindow: true)
             case .persistenceFailure(_, let error):
-                retryingSessionID = nil
+                transcriptionRecovery.finishRetry()
                 presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
             case .postTranscriptionFailure(let error):
-                cleanupPreservedRetryAudioIfNeeded(at: retryContext.audioFileURL)
-                retryingSessionID = nil
+                transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
+                    at: retryContext.audioFileURL,
+                    debugMode: settingsStore.debugMode
+                )
+                transcriptionRecovery.finishRetry()
                 endActivity()
                 presentPostTranscriptionError(error, operation: .retryTranscription)
             }
@@ -1133,7 +1169,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            retryingSessionID = nil
+            transcriptionRecovery.finishRetry()
             presentError(error, operation: .retryTranscription)
         }
     }
@@ -2075,7 +2111,7 @@ final class AppState: ObservableObject {
         recordingSession: RecordingSessionDraft,
         request: TranscriptionRequest
     ) {
-        if let failureReason = recoverablePendingTranscriptionReason(for: error),
+        if let failureReason = transcriptionRecovery.recoverablePendingTranscriptionReason(for: error),
            let recordedAudio = pendingRecordedAudio {
             preserveRetryableSession(
                 from: recordingSession,
@@ -2097,72 +2133,6 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func pendingTranscriptionRetryContext(
-        for sessionID: UUID
-    ) -> PendingTranscriptionRetryContext? {
-        guard status.phase != .recording else {
-            presentError(
-                AppError.recordingFailure("Stop the current recording before retrying transcription."),
-                operation: .retryTranscription
-            )
-            return nil
-        }
-
-        guard retryingSessionID == nil else {
-            logDuplicatePendingTranscriptionRetryRequest(for: sessionID)
-            return nil
-        }
-
-        guard let session = sessionSnapshot(with: sessionID),
-              let pendingTranscription = session.pendingTranscription,
-              let audioFileURL = session.pendingTranscriptionAudioURL else {
-            presentError(
-                AppError.transcriptionFailure("The saved retry session is unavailable."),
-                operation: .retryTranscription
-            )
-            return nil
-        }
-
-        if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-            setStatus(.error(compatibilityIssue), error: .transcriptionFailure(compatibilityIssue))
-            showSettingsWindow?()
-            return nil
-        }
-
-        guard settingsStore.hasUsableAIProviderCredential else {
-            setStatus(.error(
-                session.transcriptionRecoveryMessage ?? AppError.missingAPIKey.userMessage
-            ), error: .missingAPIKey)
-            showSettingsWindow?()
-            return nil
-        }
-
-        guard FileManager.default.fileExists(atPath: audioFileURL.path) else {
-            presentError(
-                AppError.transcriptionFailure("The preserved audio file could not be found."),
-                operation: .retryTranscription
-            )
-            return nil
-        }
-
-        return PendingTranscriptionRetryContext(
-            session: session,
-            pendingTranscription: pendingTranscription,
-            audioFileURL: audioFileURL
-        )
-    }
-
-    private func logDuplicatePendingTranscriptionRetryRequest(for sessionID: UUID) {
-        transcriptionLogger.warning(
-            "transcription_retry_already_in_progress",
-            "Ignoring duplicate retry request while a retry is already in progress.",
-            metadata: [
-                "requested_session_id": sessionID.uuidString,
-                "active_retry_session_id": retryingSessionID?.uuidString ?? "unknown"
-            ]
-        )
-    }
-
     private func logPendingTranscriptionRetryRequested(
         _ context: PendingTranscriptionRetryContext
     ) {
@@ -2181,47 +2151,18 @@ final class AppState: ObservableObject {
         _ error: Error,
         context: PendingTranscriptionRetryContext
     ) -> Bool {
-        guard let failureReason = recoverablePendingTranscriptionReason(for: error) else {
+        guard let retryFailure = transcriptionRecovery.recordRetryableFailure(error, context: context) else {
             return false
         }
 
-        var session = context.session
-        let pendingTranscription = context.pendingTranscription
-        session.pendingTranscription = PendingTranscription(
-            audioFileName: pendingTranscription.audioFileName,
-            failureReason: failureReason,
-            preservedAt: pendingTranscription.preservedAt,
-            attemptCount: pendingTranscription.attemptCount + 1
-        )
-
-        do {
-            try persistUpdatedSession(session)
-        } catch {
-            sessionLibrary.stageCurrentTranscript(session)
-        }
-
-        retryingSessionID = nil
         endActivity()
 
-        let appError = failureReason.appError
+        let appError = retryFailure.appError
         logAppError(appError, context: "retry_pending_transcription", operation: .retryTranscription)
-        let attemptMessage = pendingTranscription.attemptCount >= 2
-            ? " This session has been retried \(pendingTranscription.attemptCount + 1) times."
-            : ""
-        setStatus(.error(
-            (session.transcriptionRecoveryMessage ?? appError.userMessage) + attemptMessage
-        ), error: appError)
+        setStatus(.error(retryFailure.statusMessage), error: appError)
         showTranscriptWindow?()
         showSettingsWindow?()
         return true
-    }
-
-    private func recoverablePendingTranscriptionReason(for error: Error) -> PendingTranscriptionFailureReason? {
-        guard let appError = error as? AppError else {
-            return nil
-        }
-
-        return PendingTranscriptionFailureReason(appError: appError)
     }
 
     private func preserveRetryableSession(
@@ -2230,144 +2171,58 @@ final class AppState: ObservableObject {
         request: TranscriptionRequest,
         failureReason: PendingTranscriptionFailureReason
     ) {
-        let appError = failureReason.appError
-
-        do {
-            let preservedAudioURL = try preserveRecordedAudioForRetry(
-                recordedAudio,
-                in: recordingSession.artifactsDirectoryURL
-            )
-
-            let retryableSession = TranscriptSession(
-                id: recordingSession.sessionID,
-                createdAt: Date(),
-                transcript: "",
-                duration: recordedAudio.duration,
-                model: request.model,
-                languageHint: request.languageHint,
-                prompt: request.prompt,
-                markers: recordingSession.markers,
-                screenshots: recordingSession.screenshots,
-                sections: [],
-                issueExtraction: nil,
-                pendingTranscription: PendingTranscription(
-                    audioFileName: preservedAudioURL.lastPathComponent,
-                    failureReason: failureReason,
-                    preservedAt: Date()
-                ),
-                updatedAt: Date(),
-                artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
-            )
-
-            do {
-                try sessionLibrary.persistRetryableSession(retryableSession)
-            } catch {
-                sessionLibrary.stageCurrentTranscript(retryableSession)
-                activeRecordingSession = nil
-                cleanupPendingRecordedAudioIfNeeded()
-                endActivity()
-
-                let normalizedError = normalizeError(
-                    error,
-                    operation: .sessionLibrary,
-                    fallback: { .storageFailure($0) }
-                )
-                let persistenceError = normalizedError.appError
-                logAppError(normalizedError, context: "retryable_session_persist_failed")
-                var metadata = appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
-                metadata["session_id"] = retryableSession.id.uuidString
-                sessionLibraryLogger.error(
-                    "retryable_session_persist_failed",
-                    "The preserved recording could not be saved into local session history.",
-                    metadata: metadata
-                )
-                setStatus(
-                    .error("Recording preserved, but \(persistenceError.userMessage)"),
-                    error: persistenceError
-                )
-                showTranscriptWindow?()
-                if appError.suggestsOpenAISettings {
-                    showSettingsWindow?()
-                }
-                return
-            }
-
+        switch transcriptionRecovery.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: request,
+            failureReason: failureReason
+        ) {
+        case .preserved(let retryableSession, let appError):
             activeRecordingSession = nil
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
-            transcriptionLogger.warning(
-                "transcription_deferred_for_retry",
-                "Recording finished and was preserved for a later transcription retry.",
-                metadata: [
-                    "session_id": retryableSession.id.uuidString,
-                    "failure_reason": failureReason.rawValue
-                ]
-            )
             logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
             setStatus(.error(retryableSession.transcriptionRecoveryMessage ?? appError.userMessage), error: appError)
             showTranscriptWindow?()
             if appError.suggestsOpenAISettings {
                 showSettingsWindow?()
             }
-        } catch {
+
+        case .persistenceFailure(let retryableSession, let error):
+            activeRecordingSession = nil
+            cleanupPendingRecordedAudioIfNeeded()
+            endActivity()
+
+            let normalizedError = normalizeError(
+                error,
+                operation: .sessionLibrary,
+                fallback: { .storageFailure($0) }
+            )
+            let persistenceError = normalizedError.appError
+            logAppError(normalizedError, context: "retryable_session_persist_failed")
+            var metadata = appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
+            metadata["session_id"] = retryableSession.id.uuidString
+            sessionLibraryLogger.error(
+                "retryable_session_persist_failed",
+                "The preserved recording could not be saved into local session history.",
+                metadata: metadata
+            )
+            setStatus(
+                .error("Recording preserved, but \(persistenceError.userMessage)"),
+                error: persistenceError
+            )
+            showTranscriptWindow?()
+            if failureReason.appError.suggestsOpenAISettings {
+                showSettingsWindow?()
+            }
+
+        case .preservationFailure(let error):
             if !settingsStore.debugMode {
                 artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
             }
             activeRecordingSession = nil
             presentError(error, operation: .recordingStop)
         }
-    }
-
-    private func preserveRecordedAudioForRetry(
-        _ recordedAudio: RecordedAudio,
-        in artifactsDirectoryURL: URL
-    ) throws -> URL {
-        let fileManager = FileManager.default
-        let preservedAudioURL = artifactsService.makeRecordedAudioURL(
-            in: artifactsDirectoryURL,
-            sourceFileURL: recordedAudio.fileURL
-        )
-
-        if fileManager.fileExists(atPath: preservedAudioURL.path) {
-            try fileManager.removeItem(at: preservedAudioURL)
-        }
-
-        if recordedAudio.fileURL.standardizedFileURL == preservedAudioURL.standardizedFileURL {
-            return preservedAudioURL
-        }
-
-        try fileManager.copyItem(at: recordedAudio.fileURL, to: preservedAudioURL)
-
-        let attributes = try fileManager.attributesOfItem(atPath: preservedAudioURL.path)
-        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
-        guard fileSize > 0 else {
-            throw AppError.recordingFailure("The preserved audio file was empty.")
-        }
-
-        recordingLogger.info(
-            "recorded_audio_preserved_for_retry",
-            "Preserved the finished recording for a later transcription retry.",
-            metadata: ["file_name": preservedAudioURL.lastPathComponent]
-        )
-        return preservedAudioURL
-    }
-
-    private func cleanupPreservedRetryAudioIfNeeded(at audioFileURL: URL) {
-        guard !settingsStore.debugMode else {
-            recordingLogger.debug(
-                "preserved_retry_audio_retained",
-                "Kept the preserved retry audio because debug mode is enabled.",
-                metadata: ["file_name": audioFileURL.lastPathComponent]
-            )
-            return
-        }
-
-        try? FileManager.default.removeItem(at: audioFileURL)
-        recordingLogger.debug(
-            "preserved_retry_audio_removed",
-            "Removed the preserved retry audio after transcription succeeded.",
-            metadata: ["file_name": audioFileURL.lastPathComponent]
-        )
     }
 
     private func persistCompletedTranscript(_ session: TranscriptSession) throws {

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -1,0 +1,297 @@
+import Combine
+import Foundation
+
+@MainActor
+final class TranscriptionRecoveryController: ObservableObject {
+    @Published private(set) var retryingSessionID: UUID?
+
+    private let sessionLibrary: SessionLibraryController
+    private let artifactsService: any SessionArtifactsManaging
+    private let fileManager: FileManager
+    private let recordingLogger: DiagnosticsLogger
+    private let transcriptionLogger: DiagnosticsLogger
+
+    init(
+        sessionLibrary: SessionLibraryController,
+        artifactsService: any SessionArtifactsManaging,
+        fileManager: FileManager = .default,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording),
+        transcriptionLogger: DiagnosticsLogger = DiagnosticsLogger(category: .transcription)
+    ) {
+        self.sessionLibrary = sessionLibrary
+        self.artifactsService = artifactsService
+        self.fileManager = fileManager
+        self.recordingLogger = recordingLogger
+        self.transcriptionLogger = transcriptionLogger
+    }
+
+    func beginRetry(for sessionID: UUID) -> Bool {
+        guard retryingSessionID == nil else {
+            transcriptionLogger.warning(
+                "transcription_retry_already_in_progress",
+                "Ignoring duplicate retry request while a retry is already in progress.",
+                metadata: [
+                    "requested_session_id": sessionID.uuidString,
+                    "active_retry_session_id": retryingSessionID?.uuidString ?? "unknown"
+                ]
+            )
+            return false
+        }
+
+        retryingSessionID = sessionID
+        return true
+    }
+
+    func finishRetry() {
+        retryingSessionID = nil
+    }
+
+    func retryContext(
+        for sessionID: UUID,
+        isRecording: Bool,
+        hasUsableAIProviderCredential: Bool,
+        aiProviderCompatibilityIssue: String?
+    ) -> PendingTranscriptionRetryResolution {
+        guard !isRecording else {
+            return .failure(
+                .recordingFailure("Stop the current recording before retrying transcription."),
+                opensSettings: false,
+                statusMessage: nil
+            )
+        }
+
+        guard retryingSessionID == nil else {
+            _ = beginRetry(for: sessionID)
+            return .duplicate
+        }
+
+        guard let session = sessionLibrary.sessionSnapshot(with: sessionID),
+              let pendingTranscription = session.pendingTranscription,
+              let audioFileURL = session.pendingTranscriptionAudioURL else {
+            return .failure(
+                .transcriptionFailure("The saved retry session is unavailable."),
+                opensSettings: false,
+                statusMessage: nil
+            )
+        }
+
+        if let aiProviderCompatibilityIssue {
+            return .failure(
+                .transcriptionFailure(aiProviderCompatibilityIssue),
+                opensSettings: true,
+                statusMessage: aiProviderCompatibilityIssue
+            )
+        }
+
+        guard hasUsableAIProviderCredential else {
+            return .failure(
+                .missingAPIKey,
+                opensSettings: true,
+                statusMessage: session.transcriptionRecoveryMessage ?? AppError.missingAPIKey.userMessage
+            )
+        }
+
+        guard fileManager.fileExists(atPath: audioFileURL.path) else {
+            return .failure(
+                .transcriptionFailure("The preserved audio file could not be found."),
+                opensSettings: false,
+                statusMessage: nil
+            )
+        }
+
+        return .ready(
+            PendingTranscriptionRetryContext(
+                session: session,
+                pendingTranscription: pendingTranscription,
+                audioFileURL: audioFileURL
+            )
+        )
+    }
+
+    func recoverablePendingTranscriptionReason(for error: Error) -> PendingTranscriptionFailureReason? {
+        guard let appError = error as? AppError else {
+            return nil
+        }
+
+        return PendingTranscriptionFailureReason(appError: appError)
+    }
+
+    func recordRetryableFailure(
+        _ error: Error,
+        context: PendingTranscriptionRetryContext
+    ) -> PendingTranscriptionRetryFailure? {
+        guard let failureReason = recoverablePendingTranscriptionReason(for: error) else {
+            return nil
+        }
+
+        var session = context.session
+        let pendingTranscription = context.pendingTranscription
+        session.pendingTranscription = PendingTranscription(
+            audioFileName: pendingTranscription.audioFileName,
+            failureReason: failureReason,
+            preservedAt: pendingTranscription.preservedAt,
+            attemptCount: pendingTranscription.attemptCount + 1
+        )
+
+        do {
+            try sessionLibrary.persistUpdatedSession(session)
+        } catch {
+            sessionLibrary.stageCurrentTranscript(session)
+        }
+
+        finishRetry()
+
+        let attemptMessage = pendingTranscription.attemptCount >= 2
+            ? " This session has been retried \(pendingTranscription.attemptCount + 1) times."
+            : ""
+        return PendingTranscriptionRetryFailure(
+            session: session,
+            appError: failureReason.appError,
+            statusMessage: (session.transcriptionRecoveryMessage ?? failureReason.appError.userMessage) + attemptMessage
+        )
+    }
+
+    func preserveRetryableSession(
+        from recordingSession: RecordingSessionDraft,
+        recordedAudio: RecordedAudio,
+        request: TranscriptionRequest,
+        failureReason: PendingTranscriptionFailureReason
+    ) -> RetryableSessionPreservationResult {
+        do {
+            let preservedAudioURL = try preserveRecordedAudioForRetry(
+                recordedAudio,
+                in: recordingSession.artifactsDirectoryURL
+            )
+            let retryableSession = makeRetryableSession(
+                from: recordingSession,
+                recordedAudio: recordedAudio,
+                request: request,
+                failureReason: failureReason,
+                preservedAudioURL: preservedAudioURL
+            )
+
+            do {
+                try sessionLibrary.persistRetryableSession(retryableSession)
+            } catch {
+                sessionLibrary.stageCurrentTranscript(retryableSession)
+                return .persistenceFailure(session: retryableSession, error: error)
+            }
+
+            transcriptionLogger.warning(
+                "transcription_deferred_for_retry",
+                "Recording finished and was preserved for a later transcription retry.",
+                metadata: [
+                    "session_id": retryableSession.id.uuidString,
+                    "failure_reason": failureReason.rawValue
+                ]
+            )
+            return .preserved(session: retryableSession, appError: failureReason.appError)
+        } catch {
+            return .preservationFailure(error)
+        }
+    }
+
+    func cleanupPreservedRetryAudioIfNeeded(at audioFileURL: URL, debugMode: Bool) {
+        guard !debugMode else {
+            recordingLogger.debug(
+                "preserved_retry_audio_retained",
+                "Kept the preserved retry audio because debug mode is enabled.",
+                metadata: ["file_name": audioFileURL.lastPathComponent]
+            )
+            return
+        }
+
+        try? fileManager.removeItem(at: audioFileURL)
+        recordingLogger.debug(
+            "preserved_retry_audio_removed",
+            "Removed the preserved retry audio after transcription succeeded.",
+            metadata: ["file_name": audioFileURL.lastPathComponent]
+        )
+    }
+
+    private func preserveRecordedAudioForRetry(
+        _ recordedAudio: RecordedAudio,
+        in artifactsDirectoryURL: URL
+    ) throws -> URL {
+        let preservedAudioURL = artifactsService.makeRecordedAudioURL(
+            in: artifactsDirectoryURL,
+            sourceFileURL: recordedAudio.fileURL
+        )
+
+        if fileManager.fileExists(atPath: preservedAudioURL.path) {
+            try fileManager.removeItem(at: preservedAudioURL)
+        }
+
+        if recordedAudio.fileURL.standardizedFileURL == preservedAudioURL.standardizedFileURL {
+            return preservedAudioURL
+        }
+
+        try fileManager.copyItem(at: recordedAudio.fileURL, to: preservedAudioURL)
+
+        let attributes = try fileManager.attributesOfItem(atPath: preservedAudioURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            throw AppError.recordingFailure("The preserved audio file was empty.")
+        }
+
+        recordingLogger.info(
+            "recorded_audio_preserved_for_retry",
+            "Preserved the finished recording for a later transcription retry.",
+            metadata: ["file_name": preservedAudioURL.lastPathComponent]
+        )
+        return preservedAudioURL
+    }
+
+    private func makeRetryableSession(
+        from recordingSession: RecordingSessionDraft,
+        recordedAudio: RecordedAudio,
+        request: TranscriptionRequest,
+        failureReason: PendingTranscriptionFailureReason,
+        preservedAudioURL: URL
+    ) -> TranscriptSession {
+        TranscriptSession(
+            id: recordingSession.sessionID,
+            createdAt: Date(),
+            transcript: "",
+            duration: recordedAudio.duration,
+            model: request.model,
+            languageHint: request.languageHint,
+            prompt: request.prompt,
+            markers: recordingSession.markers,
+            screenshots: recordingSession.screenshots,
+            sections: [],
+            issueExtraction: nil,
+            pendingTranscription: PendingTranscription(
+                audioFileName: preservedAudioURL.lastPathComponent,
+                failureReason: failureReason,
+                preservedAt: Date()
+            ),
+            updatedAt: Date(),
+            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
+        )
+    }
+}
+
+struct PendingTranscriptionRetryContext {
+    let session: TranscriptSession
+    let pendingTranscription: PendingTranscription
+    let audioFileURL: URL
+}
+
+enum PendingTranscriptionRetryResolution {
+    case ready(PendingTranscriptionRetryContext)
+    case duplicate
+    case failure(AppError, opensSettings: Bool, statusMessage: String?)
+}
+
+struct PendingTranscriptionRetryFailure {
+    let session: TranscriptSession
+    let appError: AppError
+    let statusMessage: String
+}
+
+enum RetryableSessionPreservationResult {
+    case preserved(session: TranscriptSession, appError: AppError)
+    case persistenceFailure(session: TranscriptSession, error: Error)
+    case preservationFailure(Error)
+}

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class TranscriptionRecoveryControllerTests: XCTestCase {
+    func testRetryContextReadyAndRetryStateTracksActiveSession() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = try harness.addPendingSession()
+
+        let resolution = harness.controller.retryContext(
+            for: session.id,
+            isRecording: false,
+            hasUsableAIProviderCredential: true,
+            aiProviderCompatibilityIssue: nil
+        )
+
+        guard case .ready(let context) = resolution else {
+            return XCTFail("Expected ready retry context.")
+        }
+        XCTAssertEqual(context.session.id, session.id)
+        XCTAssertTrue(harness.controller.beginRetry(for: session.id))
+        XCTAssertEqual(harness.controller.retryingSessionID, session.id)
+        XCTAssertFalse(harness.controller.beginRetry(for: UUID()))
+        harness.controller.finishRetry()
+        XCTAssertNil(harness.controller.retryingSessionID)
+    }
+
+    func testRetryContextWithoutCredentialReturnsRecoveryMessage() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = try harness.addPendingSession(failureReason: .missingAPIKey)
+
+        let resolution = harness.controller.retryContext(
+            for: session.id,
+            isRecording: false,
+            hasUsableAIProviderCredential: false,
+            aiProviderCompatibilityIssue: nil
+        )
+
+        guard case .failure(let appError, let opensSettings, let statusMessage) = resolution else {
+            return XCTFail("Expected missing credential failure.")
+        }
+        XCTAssertEqual(appError, .missingAPIKey)
+        XCTAssertTrue(opensSettings)
+        XCTAssertEqual(statusMessage, session.transcriptionRecoveryMessage)
+    }
+
+    func testPreserveRetryableSessionCopiesAudioAndStoresPendingSession() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "source", contents: "audio")
+        let recordingSession = try harness.makeRecordingSession()
+
+        let result = harness.controller.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: harness.request,
+            failureReason: .invalidAPIKey
+        )
+
+        guard case .preserved(let session, let appError) = result else {
+            return XCTFail("Expected retryable session preservation.")
+        }
+        XCTAssertEqual(appError, .invalidAPIKey)
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id)?.pendingTranscription?.failureReason, .invalidAPIKey)
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: try XCTUnwrap(session.pendingTranscriptionAudioURL).path))
+    }
+
+    func testPreserveRetryableSessionPersistenceFailureStagesCurrentTranscript() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let indexURL = harness.rootDirectoryURL.appendingPathComponent("sessions.index.json")
+        try FileManager.default.createDirectory(at: indexURL, withIntermediateDirectories: true)
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "source", contents: "audio")
+        let recordingSession = try harness.makeRecordingSession()
+
+        let result = harness.controller.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: harness.request,
+            failureReason: .missingAPIKey
+        )
+
+        guard case .persistenceFailure(let session, _) = result else {
+            return XCTFail("Expected persistence failure.")
+        }
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+        XCTAssertEqual(harness.sessionLibrary.selectedTranscriptID, session.id)
+        XCTAssertEqual(session.pendingTranscription?.failureReason, .missingAPIKey)
+    }
+
+    func testRecordRetryableFailureIncrementsAttemptCountAndFinishesRetry() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = try harness.addPendingSession(failureReason: .missingAPIKey, attemptCount: 2)
+        guard case .ready(let context) = harness.controller.retryContext(
+            for: session.id,
+            isRecording: false,
+            hasUsableAIProviderCredential: true,
+            aiProviderCompatibilityIssue: nil
+        ) else {
+            return XCTFail("Expected ready retry context.")
+        }
+        XCTAssertTrue(harness.controller.beginRetry(for: session.id))
+
+        let failure = try XCTUnwrap(
+            harness.controller.recordRetryableFailure(AppError.invalidAPIKey, context: context)
+        )
+
+        XCTAssertNil(harness.controller.retryingSessionID)
+        XCTAssertEqual(failure.appError, .invalidAPIKey)
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id)?.pendingTranscription?.attemptCount, 3)
+        XCTAssertTrue(failure.statusMessage.contains("retried 3 times"))
+    }
+
+    func testCleanupPreservedRetryAudioHonorsDebugMode() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let retainedAudio = try harness.makeRecordedAudio(fileName: "retained", contents: "audio")
+        harness.controller.cleanupPreservedRetryAudioIfNeeded(at: retainedAudio.fileURL, debugMode: true)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: retainedAudio.fileURL.path))
+
+        let removedAudio = try harness.makeRecordedAudio(fileName: "removed", contents: "audio")
+        harness.controller.cleanupPreservedRetryAudioIfNeeded(at: removedAudio.fileURL, debugMode: false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: removedAudio.fileURL.path))
+    }
+}
+
+@MainActor
+private struct TranscriptionRecoveryControllerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let artifactsService: MockArtifactsService
+    let sessionLibrary: SessionLibraryController
+    let controller: TranscriptionRecoveryController
+    let request = TranscriptionRequest(model: "whisper-1", languageHint: nil, prompt: nil)
+
+    init() throws {
+        rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionRecoveryControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        transcriptStore = TranscriptStore(
+            fileManager: .default,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: MockClipboardService()
+        )
+        controller = TranscriptionRecoveryController(
+            sessionLibrary: sessionLibrary,
+            artifactsService: artifactsService
+        )
+    }
+
+    func addPendingSession(
+        failureReason: PendingTranscriptionFailureReason = .missingAPIKey,
+        attemptCount: Int = 0
+    ) throws -> TranscriptSession {
+        let recordingSession = try makeRecordingSession()
+        let audioURL = recordingSession.artifactsDirectoryURL
+            .appendingPathComponent("recording")
+            .appendingPathExtension("m4a")
+        try Data("audio".utf8).write(to: audioURL)
+        let session = TranscriptSession(
+            id: recordingSession.sessionID,
+            createdAt: Date(),
+            transcript: "",
+            duration: 3,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            pendingTranscription: PendingTranscription(
+                audioFileName: audioURL.lastPathComponent,
+                failureReason: failureReason,
+                preservedAt: Date(),
+                attemptCount: attemptCount
+            ),
+            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
+        )
+        try transcriptStore.add(session)
+        return session
+    }
+
+    func makeRecordingSession() throws -> RecordingSessionDraft {
+        let sessionID = UUID()
+        let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
+        return RecordingSessionDraft(sessionID: sessionID, artifactsDirectoryURL: artifactsDirectoryURL)
+    }
+
+    func makeRecordedAudio(fileName: String, contents: String) throws -> RecordedAudio {
+        let fileURL = rootDirectoryURL.appendingPathComponent(fileName).appendingPathExtension("m4a")
+        try Data(contents.utf8).write(to: fileURL)
+        return RecordedAudio(fileURL: fileURL, duration: 3)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- add TranscriptionRecoveryController to own retry state, retry context validation, retryable-session preservation, and preserved-audio cleanup
- keep AppState focused on applying controller outcomes to UI state
- add focused recovery controller tests for retry state, retry context, preservation, persistence failure, retry failure, and cleanup

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests -only-testing:BugNarratorTests/RecoveredRecordingImporterTests -only-testing:BugNarratorTests/TranscriptionClientTests (108 tests, 0 failures)
- ./scripts/validate.sh origin/main

Closes #88