### PR TITLE
Extract ScreenshotCoordinator

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */; };
 		6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */; };
 		6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E006D3F529E46315F3585 /* HotkeyAction.swift */; };
+		87F4D0030000000000000003 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F4D0020000000000000002 /* ScreenshotCoordinatorTests.swift */; };
+		87F4D0040000000000000004 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F4D0010000000000000001 /* ScreenshotCoordinator.swift */; };
 		88F4D0030000000000000003 /* TranscriptionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */; };
 		88F4D0040000000000000004 /* TranscriptionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */; };
 		89F4D0030000000000000003 /* SessionLibraryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */; };
@@ -226,6 +228,8 @@
 		85A1F6C9245B4A1F95C0A101 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		87F4D0010000000000000001 /* ScreenshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinator.swift; sourceTree = "<group>"; };
+		87F4D0020000000000000002 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
 		88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		89F4D0010000000000000001 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
@@ -319,6 +323,7 @@
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
 				8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */,
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
+				87F4D0020000000000000002 /* ScreenshotCoordinatorTests.swift */,
 				20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
 				89F4D0020000000000000002 /* SessionLibraryControllerTests.swift */,
@@ -432,6 +437,7 @@
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
+				87F4D0010000000000000001 /* ScreenshotCoordinator.swift */,
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
 				6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */,
 				9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */,
@@ -643,6 +649,7 @@
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
 				28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */,
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
+				87F4D0030000000000000003 /* ScreenshotCoordinatorTests.swift in Sources */,
 				6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
 				89F4D0030000000000000003 /* SessionLibraryControllerTests.swift in Sources */,
@@ -728,6 +735,7 @@
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,
 				6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */,
+				87F4D0040000000000000004 /* ScreenshotCoordinator.swift in Sources */,
 				CBE08ABB1F52871FE33471BA /* ScreenshotPreviewCache.swift in Sources */,
 				B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */,
 				3893EB325B3915242FBD4BA6 /* ServiceProtocols.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -20,6 +20,7 @@ final class AppState: ObservableObject {
     let presentationState: AppPresentationState
     let sessionLibrary: SessionLibraryController
     let transcriptionRecovery: TranscriptionRecoveryController
+    let screenshotCoordinator: ScreenshotCoordinator
 
     private let runtimeEnvironment: AppRuntimeEnvironment
     var showTranscriptWindow: (() -> Void)?
@@ -36,8 +37,6 @@ final class AppState: ObservableObject {
     private let screenCapturePermissionService: any ScreenCapturePermissionServicing
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
-    private let screenshotCaptureService: any ScreenshotCapturing
-    private let screenshotSelectionService: any ScreenshotSelecting
     private let issueExtractionService: any IssueExtracting
     private let exportService: any IssueExporting
     private let recoveredRecordingImporter: any RecoveredRecordingImporting
@@ -61,7 +60,6 @@ final class AppState: ObservableObject {
     private var pendingRecordedAudio: RecordedAudio?
     private var cancellables = Set<AnyCancellable>()
     private var recordingTransition: RecordingTransition = .idle
-    @Published private(set) var isScreenshotCaptureInProgress = false
     private var toastDismissTask: Task<Void, Never>?
 
     private enum RecordingTransition {
@@ -267,14 +265,18 @@ final class AppState: ObservableObject {
             sessionLibrary: self.sessionLibrary,
             artifactsService: artifactsService
         )
+        self.screenshotCoordinator = ScreenshotCoordinator(
+            screenCapturePermissionService: screenCapturePermissionService,
+            screenshotCaptureService: screenshotCaptureService,
+            screenshotSelectionService: screenshotSelectionService,
+            artifactsService: artifactsService
+        )
         self.runtimeEnvironment = runtimeEnvironment
         self.audioRecorder = audioRecorder
         self.microphonePermissionService = microphonePermissionService
         self.screenCapturePermissionService = screenCapturePermissionService
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
-        self.screenshotCaptureService = screenshotCaptureService
-        self.screenshotSelectionService = screenshotSelectionService
         self.issueExtractionService = issueExtractionService
         self.exportService = exportService
         self.recoveredRecordingImporter = recoveredRecordingImporter
@@ -335,6 +337,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         transcriptionRecovery.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        screenshotCoordinator.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -455,6 +463,10 @@ final class AppState: ObservableObject {
         transcriptStore.pendingTranscriptionSessions.contains {
             $0.pendingTranscription?.failureReason == .crashRecovery
         }
+    }
+
+    var isScreenshotCaptureInProgress: Bool {
+        screenshotCoordinator.isCaptureInProgress
     }
 
     func isExtractingIssues(for session: TranscriptSession) -> Bool {
@@ -1228,14 +1240,27 @@ final class AppState: ObservableObject {
         let markerTitle = "Screenshot \(screenshotIndex)"
 
         do {
-            let screenshot = try await performScreenshotCapture(
+            let captureResult = try await screenshotCoordinator.captureScreenshot(
                 in: recordingSession,
                 prefix: "capture",
                 index: screenshotIndex,
                 elapsedTime: elapsedTime,
-                associatedMarkerID: markerID
+                associatedMarkerID: markerID,
+                onSelectionWillBegin: { [weak self] in
+                    self?.setStatus(.recording("Drag to select a screenshot region. Press Esc to cancel."))
+                    self?.prepareForScreenshotSelection?()
+                },
+                onSelectionDidEnd: { [weak self] in
+                    self?.restoreAfterScreenshotSelection?()
+                },
+                isSessionActive: { [weak self] sessionID in
+                    guard let self else {
+                        return false
+                    }
+                    return status.phase == .recording && activeRecordingSession?.sessionID == sessionID
+                }
             )
-            guard let screenshot else {
+            guard case let .captured(screenshot) = captureResult else {
                 guard status.phase == .recording,
                       activeRecordingSession?.sessionID == recordingSession.sessionID else {
                     return
@@ -2399,73 +2424,8 @@ final class AppState: ObservableObject {
         await refreshExportHistory()
     }
 
-    private func performScreenshotCapture(
-        in recordingSession: RecordingSessionDraft,
-        prefix: String,
-        index: Int,
-        elapsedTime: TimeInterval,
-        associatedMarkerID: UUID?
-    ) async throws -> SessionScreenshot? {
-        guard !isScreenshotCaptureInProgress else {
-            throw AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
-        }
-
-        isScreenshotCaptureInProgress = true
-        defer { isScreenshotCaptureInProgress = false }
-
-        let preflightResult = await screenCapturePermissionService.preflightForScreenshotCapture(
-            screenshotCaptureService: screenshotCaptureService,
-            hasActiveRecordingSession: true
-        )
-        if let preflightError = preflightResult.error {
-            throw preflightError
-        }
-
-        setStatus(.recording("Drag to select a screenshot region. Press Esc to cancel."))
-        prepareForScreenshotSelection?()
-        defer {
-            restoreAfterScreenshotSelection?()
-        }
-
-        let selectionResult = try await screenshotSelectionService.selectRegion()
-        guard case let .selected(selectionRect) = selectionResult else {
-            return nil
-        }
-
-        let screenshotURL = artifactsService.makeScreenshotURL(
-            in: recordingSession.artifactsDirectoryURL,
-            prefix: prefix,
-            index: index,
-            elapsedTime: elapsedTime
-        )
-
-        do {
-            try await screenshotCaptureService.captureScreenshot(in: selectionRect, to: screenshotURL)
-        } catch {
-            try? FileManager.default.removeItem(at: screenshotURL)
-            throw error
-        }
-
-        guard status.phase == .recording,
-              activeRecordingSession?.sessionID == recordingSession.sessionID else {
-            try? FileManager.default.removeItem(at: screenshotURL)
-            throw AppError.screenshotCaptureFailure("The session ended before the screenshot finished saving.")
-        }
-
-        return SessionScreenshot(
-            elapsedTime: elapsedTime,
-            filePath: screenshotURL.path,
-            associatedMarkerID: associatedMarkerID
-        )
-    }
-
     private func cancelPendingScreenshotSelection(reason: String) {
-        guard isScreenshotCaptureInProgress else {
-            return
-        }
-
-        screenshotLogger.info("screenshot_selection_cancel_requested", reason)
-        screenshotSelectionService.cancelActiveSelection()
+        screenshotCoordinator.cancelPendingSelection(reason: reason)
     }
 
     private func showToast(_ message: String, style: TransientToastStyle = .success) {

--- a/Sources/BugNarrator/Services/ScreenshotCoordinator.swift
+++ b/Sources/BugNarrator/Services/ScreenshotCoordinator.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@MainActor
+final class ScreenshotCoordinator: ObservableObject {
+    @Published private(set) var isCaptureInProgress = false
+
+    private let screenCapturePermissionService: any ScreenCapturePermissionServicing
+    private let screenshotCaptureService: any ScreenshotCapturing
+    private let screenshotSelectionService: any ScreenshotSelecting
+    private let artifactsService: any SessionArtifactsManaging
+    private let fileManager: FileManager
+    private let logger: DiagnosticsLogger
+
+    init(
+        screenCapturePermissionService: any ScreenCapturePermissionServicing,
+        screenshotCaptureService: any ScreenshotCapturing,
+        screenshotSelectionService: any ScreenshotSelecting,
+        artifactsService: any SessionArtifactsManaging,
+        fileManager: FileManager = .default,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .screenshots)
+    ) {
+        self.screenCapturePermissionService = screenCapturePermissionService
+        self.screenshotCaptureService = screenshotCaptureService
+        self.screenshotSelectionService = screenshotSelectionService
+        self.artifactsService = artifactsService
+        self.fileManager = fileManager
+        self.logger = logger
+    }
+
+    func captureScreenshot(
+        in recordingSession: RecordingSessionDraft,
+        prefix: String,
+        index: Int,
+        elapsedTime: TimeInterval,
+        associatedMarkerID: UUID?,
+        onSelectionWillBegin: () -> Void,
+        onSelectionDidEnd: () -> Void,
+        isSessionActive: (UUID) -> Bool
+    ) async throws -> ScreenshotCoordinatorResult {
+        guard !isCaptureInProgress else {
+            throw AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+        }
+
+        isCaptureInProgress = true
+        defer { isCaptureInProgress = false }
+
+        let preflightResult = await screenCapturePermissionService.preflightForScreenshotCapture(
+            screenshotCaptureService: screenshotCaptureService,
+            hasActiveRecordingSession: true
+        )
+        if let preflightError = preflightResult.error {
+            throw preflightError
+        }
+
+        onSelectionWillBegin()
+        defer {
+            onSelectionDidEnd()
+        }
+
+        let selectionResult = try await screenshotSelectionService.selectRegion()
+        guard case let .selected(selectionRect) = selectionResult else {
+            return .cancelled
+        }
+
+        let screenshotURL = artifactsService.makeScreenshotURL(
+            in: recordingSession.artifactsDirectoryURL,
+            prefix: prefix,
+            index: index,
+            elapsedTime: elapsedTime
+        )
+
+        do {
+            try await screenshotCaptureService.captureScreenshot(in: selectionRect, to: screenshotURL)
+        } catch {
+            try? fileManager.removeItem(at: screenshotURL)
+            throw error
+        }
+
+        guard isSessionActive(recordingSession.sessionID) else {
+            try? fileManager.removeItem(at: screenshotURL)
+            throw AppError.screenshotCaptureFailure("The session ended before the screenshot finished saving.")
+        }
+
+        return .captured(
+            SessionScreenshot(
+                elapsedTime: elapsedTime,
+                filePath: screenshotURL.path,
+                associatedMarkerID: associatedMarkerID
+            )
+        )
+    }
+
+    func cancelPendingSelection(reason: String) {
+        guard isCaptureInProgress else {
+            return
+        }
+
+        logger.info("screenshot_selection_cancel_requested", reason)
+        screenshotSelectionService.cancelActiveSelection()
+    }
+}
+
+enum ScreenshotCoordinatorResult {
+    case captured(SessionScreenshot)
+    case cancelled
+}

--- a/Tests/BugNarratorTests/ScreenshotCoordinatorTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotCoordinatorTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class ScreenshotCoordinatorTests: XCTestCase {
+    func testCaptureScreenshotReturnsScreenshotAndRestoresSelectionWindow() async throws {
+        let screenshotService = MockScreenshotCaptureService()
+        let harness = try ScreenshotCoordinatorHarness(screenshotCaptureService: screenshotService)
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        let markerID = UUID()
+        var selectionWillBeginCount = 0
+        var selectionDidEndCount = 0
+
+        let result = try await harness.coordinator.captureScreenshot(
+            in: recordingSession,
+            prefix: "capture",
+            index: 1,
+            elapsedTime: 12,
+            associatedMarkerID: markerID,
+            onSelectionWillBegin: {
+                selectionWillBeginCount += 1
+            },
+            onSelectionDidEnd: {
+                selectionDidEndCount += 1
+            },
+            isSessionActive: { $0 == recordingSession.sessionID }
+        )
+
+        guard case .captured(let screenshot) = result else {
+            return XCTFail("Expected captured screenshot.")
+        }
+        XCTAssertEqual(selectionWillBeginCount, 1)
+        XCTAssertEqual(selectionDidEndCount, 1)
+        XCTAssertEqual(harness.selectionService.selectRegionCallCount, 1)
+        XCTAssertEqual(screenshotService.capturedRects, [CGRect(x: 20, y: 20, width: 120, height: 80)])
+        XCTAssertEqual(screenshot.elapsedTime, 12)
+        XCTAssertEqual(screenshot.associatedMarkerID, markerID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: screenshot.filePath))
+        XCTAssertFalse(harness.coordinator.isCaptureInProgress)
+    }
+
+    func testCaptureScreenshotWithDeniedPermissionDoesNotOpenSelection() async throws {
+        let screenshotService = MockScreenshotCaptureService()
+        let harness = try ScreenshotCoordinatorHarness(
+            permissionState: .denied,
+            screenshotCaptureService: screenshotService
+        )
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        var selectionWillBeginCount = 0
+        var selectionDidEndCount = 0
+
+        do {
+            _ = try await harness.coordinator.captureScreenshot(
+                in: recordingSession,
+                prefix: "capture",
+                index: 1,
+                elapsedTime: 4,
+                associatedMarkerID: UUID(),
+                onSelectionWillBegin: {
+                    selectionWillBeginCount += 1
+                },
+                onSelectionDidEnd: {
+                    selectionDidEndCount += 1
+                },
+                isSessionActive: { _ in true }
+            )
+            XCTFail("Expected permission denial.")
+        } catch let error as AppError {
+            XCTAssertEqual(error, .screenRecordingPermissionDenied)
+        }
+
+        XCTAssertEqual(selectionWillBeginCount, 0)
+        XCTAssertEqual(selectionDidEndCount, 0)
+        XCTAssertEqual(harness.selectionService.selectRegionCallCount, 0)
+        XCTAssertEqual(screenshotService.capturedRects, [])
+        XCTAssertFalse(harness.coordinator.isCaptureInProgress)
+    }
+
+    func testConcurrentCaptureRequestIsRejectedWhileSelectionIsActive() async throws {
+        let selectionStarted = expectation(description: "selection started")
+        let selectionService = MockScreenshotSelectionService()
+        selectionService.suspendUntilCancelled = true
+        selectionService.onSelectRegionStart = {
+            selectionStarted.fulfill()
+        }
+        let harness = try ScreenshotCoordinatorHarness(selectionService: selectionService)
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+
+        async let firstCapture = harness.coordinator.captureScreenshot(
+            in: recordingSession,
+            prefix: "capture",
+            index: 1,
+            elapsedTime: 2,
+            associatedMarkerID: UUID(),
+            onSelectionWillBegin: {},
+            onSelectionDidEnd: {},
+            isSessionActive: { _ in true }
+        )
+        await fulfillment(of: [selectionStarted], timeout: 1.0)
+
+        do {
+            _ = try await harness.coordinator.captureScreenshot(
+                in: recordingSession,
+                prefix: "capture",
+                index: 2,
+                elapsedTime: 3,
+                associatedMarkerID: UUID(),
+                onSelectionWillBegin: {},
+                onSelectionDidEnd: {},
+                isSessionActive: { _ in true }
+            )
+            XCTFail("Expected duplicate capture rejection.")
+        } catch let error as AppError {
+            XCTAssertEqual(
+                error,
+                .screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+            )
+        }
+
+        harness.coordinator.cancelPendingSelection(reason: "Test cleanup cancels pending screenshot selection.")
+        guard case .cancelled = try await firstCapture else {
+            return XCTFail("Expected the first capture to be cancelled.")
+        }
+        XCTAssertEqual(selectionService.cancelActiveSelectionCallCount, 1)
+        XCTAssertFalse(harness.coordinator.isCaptureInProgress)
+    }
+
+    func testCaptureFailureRemovesPartialFileAndRestoresSelectionWindow() async throws {
+        let screenshotService = PartialFailureScreenshotCaptureService()
+        let harness = try ScreenshotCoordinatorHarness(screenshotCaptureService: screenshotService)
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        var selectionWillBeginCount = 0
+        var selectionDidEndCount = 0
+
+        do {
+            _ = try await harness.coordinator.captureScreenshot(
+                in: recordingSession,
+                prefix: "capture",
+                index: 1,
+                elapsedTime: 8,
+                associatedMarkerID: UUID(),
+                onSelectionWillBegin: {
+                    selectionWillBeginCount += 1
+                },
+                onSelectionDidEnd: {
+                    selectionDidEndCount += 1
+                },
+                isSessionActive: { _ in true }
+            )
+            XCTFail("Expected capture failure.")
+        } catch let error as AppError {
+            XCTAssertEqual(error, .screenshotCaptureFailure("partial write failed"))
+        }
+
+        let partialURL = try XCTUnwrap(screenshotService.capturedURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: partialURL.path))
+        XCTAssertEqual(selectionWillBeginCount, 1)
+        XCTAssertEqual(selectionDidEndCount, 1)
+        XCTAssertFalse(harness.coordinator.isCaptureInProgress)
+    }
+}
+
+@MainActor
+private final class ScreenshotCoordinatorHarness {
+    let rootDirectoryURL: URL
+    let permissionAccess: MockScreenCapturePermissionAccess
+    let artifactsService: MockArtifactsService
+    let selectionService: MockScreenshotSelectionService
+    let coordinator: ScreenshotCoordinator
+
+    init(
+        permissionState: ScreenCapturePermissionState = .granted,
+        screenshotCaptureService: any ScreenshotCapturing = MockScreenshotCaptureService(),
+        selectionService: MockScreenshotSelectionService = MockScreenshotSelectionService()
+    ) throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("BugNarratorScreenshotCoordinatorTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        permissionAccess = MockScreenCapturePermissionAccess()
+        permissionAccess.permissionState = permissionState
+        artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        self.selectionService = selectionService
+        coordinator = ScreenshotCoordinator(
+            screenCapturePermissionService: ScreenCapturePermissionService(permissionAccess: permissionAccess),
+            screenshotCaptureService: screenshotCaptureService,
+            screenshotSelectionService: selectionService,
+            artifactsService: artifactsService
+        )
+    }
+
+    func makeRecordingSession() throws -> RecordingSessionDraft {
+        let sessionID = UUID()
+        let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
+        return RecordingSessionDraft(sessionID: sessionID, artifactsDirectoryURL: artifactsDirectoryURL)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class PartialFailureScreenshotCaptureService: ScreenshotCapturing {
+    private(set) var capturedURL: URL?
+
+    func validateCaptureAvailability() async -> AppError? {
+        nil
+    }
+
+    func captureScreenshot(in rect: CGRect, to url: URL) async throws {
+        capturedURL = url
+        try Data("partial".utf8).write(to: url)
+        throw AppError.screenshotCaptureFailure("partial write failed")
+    }
+}


### PR DESCRIPTION
## Summary
- add ScreenshotCoordinator to own screenshot capture progress, permission preflight, region selection, capture, cleanup, and cancellation orchestration
- keep AppState as the facade for active-session checks, status/toast updates, and marker/screenshot mutation
- add focused coordinator tests for success, permission denial, concurrent capture rejection, and failure cleanup/restore behavior

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/ScreenshotCoordinatorTests -only-testing:BugNarratorTests/ScreenshotCaptureServiceTests -only-testing:BugNarratorTests/ScreenshotSelectionServiceTests (98 tests, 0 failures)
- ./scripts/validate.sh origin/main

Closes #87