### PR TITLE
Extract RecordingSessionController

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */; };
 		6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */; };
 		6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E006D3F529E46315F3585 /* HotkeyAction.swift */; };
+		86F4D0030000000000000003 /* RecordingSessionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F4D0020000000000000002 /* RecordingSessionControllerTests.swift */; };
+		86F4D0040000000000000004 /* RecordingSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F4D0010000000000000001 /* RecordingSessionController.swift */; };
 		87F4D0030000000000000003 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F4D0020000000000000002 /* ScreenshotCoordinatorTests.swift */; };
 		87F4D0040000000000000004 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F4D0010000000000000001 /* ScreenshotCoordinator.swift */; };
 		88F4D0030000000000000003 /* TranscriptionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F4D0020000000000000002 /* TranscriptionRecoveryControllerTests.swift */; };
@@ -228,6 +230,8 @@
 		85A1F6C9245B4A1F95C0A101 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
+		86F4D0010000000000000001 /* RecordingSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionController.swift; sourceTree = "<group>"; };
+		86F4D0020000000000000002 /* RecordingSessionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionControllerTests.swift; sourceTree = "<group>"; };
 		87F4D0010000000000000001 /* ScreenshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinator.swift; sourceTree = "<group>"; };
 		87F4D0020000000000000002 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		88F4D0010000000000000001 /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
@@ -318,6 +322,7 @@
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				2DE808CBBBE2F1EEE4FF5BEC /* RecoveredRecordingImporterTests.swift */,
+				86F4D0020000000000000002 /* RecordingSessionControllerTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
 				4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */,
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
@@ -434,6 +439,7 @@
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				BC5286F2E07F27DFA63F4B76 /* RecoveredRecordingImporter.swift */,
+				86F4D0010000000000000001 /* RecordingSessionController.swift */,
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
@@ -644,6 +650,7 @@
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				62313F663336184217D1020B /* RecoveredRecordingImporterTests.swift in Sources */,
+				86F4D0030000000000000003 /* RecordingSessionControllerTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
 				79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */,
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
@@ -731,6 +738,7 @@
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				A31A0BF8A4486E52DEA38F29 /* RecoveredRecordingImporter.swift in Sources */,
+				86F4D0040000000000000004 /* RecordingSessionController.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,7 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published private(set) var activeRecordingSession: RecordingSessionDraft?
     @Published private(set) var issueExtractionSessionID: UUID?
     @Published private(set) var exportDestinationInProgress: ExportDestination?
     @Published private(set) var pendingExportReview: IssueExportReview?
@@ -18,6 +17,7 @@ final class AppState: ObservableObject {
     let aiProviderSettings: AIProviderSettingsController
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
+    let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
@@ -32,7 +32,6 @@ final class AppState: ObservableObject {
     var prepareForScreenshotSelection: (() -> Void)?
     var restoreAfterScreenshotSelection: (() -> Void)?
 
-    private let audioRecorder: any AudioRecording
     private let microphonePermissionService: any MicrophonePermissionServicing
     private let screenCapturePermissionService: any ScreenCapturePermissionServicing
     private let transcriptionClient: any TranscriptionServing
@@ -56,18 +55,8 @@ final class AppState: ObservableObject {
     private let screenshotLogger = DiagnosticsLogger(category: .screenshots)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
-    private var processActivity: NSObjectProtocol?
-    private var pendingRecordedAudio: RecordedAudio?
     private var cancellables = Set<AnyCancellable>()
-    private var recordingTransition: RecordingTransition = .idle
     private var toastDismissTask: Task<Void, Never>?
-
-    private enum RecordingTransition {
-        case idle
-        case starting
-        case stopping
-        case cancelling
-    }
 
     private enum AppErrorOperation: String {
         case generic
@@ -256,6 +245,12 @@ final class AppState: ObservableObject {
         self.transcriptStore = transcriptStore
         self.recordingTimer = recordingTimer
         self.presentationState = AppPresentationState()
+        self.recordingSessionController = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: microphonePermissionService,
+            artifactsService: artifactsService,
+            recordingTimer: recordingTimer
+        )
         self.sessionLibrary = SessionLibraryController(
             transcriptStore: transcriptStore,
             artifactsService: artifactsService,
@@ -272,7 +267,6 @@ final class AppState: ObservableObject {
             artifactsService: artifactsService
         )
         self.runtimeEnvironment = runtimeEnvironment
-        self.audioRecorder = audioRecorder
         self.microphonePermissionService = microphonePermissionService
         self.screenCapturePermissionService = screenCapturePermissionService
         self.transcriptionClient = transcriptionClient
@@ -325,6 +319,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         presentationState.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        recordingSessionController.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -463,6 +463,10 @@ final class AppState: ObservableObject {
         transcriptStore.pendingTranscriptionSessions.contains {
             $0.pendingTranscription?.failureReason == .crashRecovery
         }
+    }
+
+    var activeRecordingSession: RecordingSessionDraft? {
+        recordingSessionController.activeRecordingSession
     }
 
     var isScreenshotCaptureInProgress: Bool {
@@ -619,78 +623,57 @@ final class AppState: ObservableObject {
     func startSession() async {
         recordingLogger.info(.sessionStartRequested, "A feedback session start was requested.")
 
-        guard recordingTransition == .idle else {
+        let outcome = await recordingSessionController.startSession(
+            statusPhase: status.phase,
+            activityReason: recordingActivityReason()
+        )
+
+        switch outcome {
+        case .transitionInProgress:
             recordingLogger.debug(.sessionStartIgnored, "The start request was ignored because another recording transition is already in progress.")
             return
-        }
 
-        recordingTransition = .starting
-        defer { recordingTransition = .idle }
-
-        if status.phase == .recording || status.phase == .transcribing {
+        case .busy:
             recordingLogger.warning(.sessionStartRejected, "The start request was rejected because BugNarrator is already busy.")
             return
-        }
 
-        if let activeRecordingSession {
+        case .restored(let recordingSession):
             recordingLogger.warning(
                 "session_start_reconciled_active_session",
                 "A start request arrived while a recording session draft was still active; restoring recording state instead of starting a duplicate recorder.",
-                metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
+                metadata: ["session_id": recordingSession.sessionID.uuidString]
             )
             setStatus(.recording(recordingDetailMessage()))
-            beginActivity(reason: recordingActivityReason())
-            startTimer()
             return
-        }
 
-        let preflightResult = await preflightForSessionStart()
-        if let preflightError = preflightResult.error {
+        case .preflightFailure(let preflightError):
             permissionsLogger.warning(.sessionStartPreflightFailed, preflightError.userMessage)
             presentError(preflightError, operation: .recordingStart)
             return
-        }
 
-        do {
-            let sessionID = UUID()
-            let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
-
-            do {
-                try await audioRecorder.startRecording()
-                pendingRecordedAudio = nil
-                recordingTimer.stop(resetElapsed: true)
-                activeRecordingSession = RecordingSessionDraft(
-                    sessionID: sessionID,
-                    artifactsDirectoryURL: artifactsDirectoryURL
-                )
-
-                setStatus(.recording(recordingDetailMessage()))
-                beginActivity(reason: recordingActivityReason())
-                startTimer()
-                recordingLogger.info(
-                    .sessionStarted,
-                    "A feedback session started successfully.",
-                    metadata: [
-                        "session_id": sessionID.uuidString,
-                        "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
-                        "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
-                        "ai_provider": settingsStore.aiProvider.rawValue
-                    ]
-                )
-                telemetryRecorder.record(
-                    .recordingStarted,
-                    metadata: [
-                        "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
-                        "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
-                        "ai_provider": settingsStore.aiProvider.rawValue
-                    ]
-                )
-            } catch {
-                artifactsService.removeArtifactsDirectory(at: artifactsDirectoryURL)
-                throw error
-            }
-        } catch {
+        case .failure(let error):
             presentError(error, operation: .recordingStart, fallback: { .recordingFailure($0) })
+
+        case .started(let recordingSession):
+            setStatus(.recording(recordingDetailMessage()))
+            recordingLogger.info(
+                .sessionStarted,
+                "A feedback session started successfully.",
+                metadata: [
+                    "session_id": recordingSession.sessionID.uuidString,
+                    "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
+                    "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
+                    "ai_provider": settingsStore.aiProvider.rawValue
+                ]
+            )
+            telemetryRecorder.record(
+                .recordingStarted,
+                metadata: [
+                    "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
+                    "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
+                    "ai_provider": settingsStore.aiProvider.rawValue
+                ]
+            )
         }
     }
 
@@ -732,16 +715,15 @@ final class AppState: ObservableObject {
             return
         }
 
-        defer { recordingTransition = .idle }
+        defer { recordingSessionController.finishStoppingSession() }
 
         cancelPendingScreenshotSelection(reason: "Stopping the active session cancels pending screenshot selection.")
-        stopTimer(resetElapsed: false)
+        recordingSessionController.prepareForStopSession()
         let request = makeTranscriptionRequest()
 
         do {
             logSessionStopRequested(recordingSession)
-            let recordedAudio = try await audioRecorder.stopRecording()
-            pendingRecordedAudio = recordedAudio
+            let recordedAudio = try await recordingSessionController.stopRecording()
 
             guard let apiKey = settingsStore.aiProviderCredentialForUserInitiatedAccess() else {
                 preserveRetryableSession(
@@ -787,30 +769,29 @@ final class AppState: ObservableObject {
     }
 
     func cancelSession() async {
-        guard recordingTransition == .idle else {
+        let outcome = await recordingSessionController.cancelSession(
+            preserveFile: settingsStore.debugMode,
+            onCancelWillBegin: { [weak self] in
+                self?.showDiscardConfirmation = false
+                self?.cancelPendingScreenshotSelection(reason: "Discarding the active session cancels pending screenshot selection.")
+            }
+        )
+
+        switch outcome {
+        case .transitionInProgress:
             recordingLogger.debug("session_cancel_ignored", "The cancel request was ignored because another recording transition is already in progress.")
             return
-        }
 
-        recordingTransition = .cancelling
-        defer { recordingTransition = .idle }
-
-        showDiscardConfirmation = false
-        cancelPendingScreenshotSelection(reason: "Discarding the active session cancels pending screenshot selection.")
-        stopTimer(resetElapsed: true)
-        endActivity()
-        await audioRecorder.cancelRecording(preserveFile: settingsStore.debugMode)
-        if let activeRecordingSession {
-            artifactsService.removeArtifactsDirectory(at: activeRecordingSession.artifactsDirectoryURL)
-            self.activeRecordingSession = nil
-            recordingLogger.info(
-                "session_cancelled",
-                "The active feedback session was discarded.",
-                metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
-            )
+        case .cancelled(let activeRecordingSession):
+            if let activeRecordingSession {
+                recordingLogger.info(
+                    "session_cancelled",
+                    "The active feedback session was discarded.",
+                    metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
+                )
+            }
+            setStatus(.idle("Session discarded."))
         }
-        pendingRecordedAudio = nil
-        setStatus(.idle("Session discarded."))
     }
 
     func openTranscriptHistory() {
@@ -1235,7 +1216,7 @@ final class AppState: ObservableObject {
 
         let screenshotIndex = recordingSession.screenshots.count + 1
         let markerIndex = recordingSession.markers.count + 1
-        let elapsedTime = max(audioRecorder.currentDuration, elapsedDuration)
+        let elapsedTime = max(recordingSessionController.currentDuration, elapsedDuration)
         let markerID = UUID()
         let markerTitle = "Screenshot \(screenshotIndex)"
 
@@ -1285,7 +1266,7 @@ final class AppState: ObservableObject {
                 )
             )
             latestRecordingSession.screenshots.append(screenshot)
-            activeRecordingSession = latestRecordingSession
+            recordingSessionController.updateActiveRecordingSession(latestRecordingSession)
             screenshotLogger.info(
                 "screenshot_captured",
                 "Captured a screenshot and inserted the automatic marker.",
@@ -1714,31 +1695,23 @@ final class AppState: ObservableObject {
     }
 
     private func startTimer() {
-        recordingTimer.start()
+        recordingSessionController.startTimer()
     }
 
     private func stopTimer(resetElapsed: Bool) {
-        recordingTimer.stop(resetElapsed: resetElapsed)
+        recordingSessionController.stopTimer(resetElapsed: resetElapsed)
     }
 
     private func beginActivity(reason: String) {
-        endActivity()
-        processActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.userInitiated, .idleSystemSleepDisabled],
-            reason: reason
-        )
+        recordingSessionController.beginActivity(reason: reason)
     }
 
     private func swapActivity(reason: String) {
-        beginActivity(reason: reason)
+        recordingSessionController.swapActivity(reason: reason)
     }
 
     private func endActivity() {
-        if let processActivity {
-            ProcessInfo.processInfo.endActivity(processActivity)
-        }
-
-        processActivity = nil
+        recordingSessionController.endActivity()
     }
 
     private func prepareForApplicationTermination() {
@@ -1818,26 +1791,7 @@ final class AppState: ObservableObject {
     }
 
     private func cleanupPendingRecordedAudioIfNeeded() {
-        guard let pendingRecordedAudio else {
-            return
-        }
-
-        if !settingsStore.debugMode {
-            try? FileManager.default.removeItem(at: pendingRecordedAudio.fileURL)
-            recordingLogger.debug(
-                "temporary_audio_removed",
-                "Removed the temporary recorded audio file after use.",
-                metadata: ["file_name": pendingRecordedAudio.fileURL.lastPathComponent]
-            )
-        } else {
-            recordingLogger.debug(
-                "temporary_audio_preserved",
-                "Preserved the temporary recorded audio file because debug mode is enabled.",
-                metadata: ["file_name": pendingRecordedAudio.fileURL.lastPathComponent]
-            )
-        }
-
-        self.pendingRecordedAudio = nil
+        recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
     }
 
     private func makeTranscriptionRequest() -> TranscriptionRequest {
@@ -1858,26 +1812,25 @@ final class AppState: ObservableObject {
     }
 
     private func beginStoppingSession() -> RecordingSessionDraft? {
-        guard recordingTransition == .idle else {
+        switch recordingSessionController.beginStoppingSession(statusPhase: status.phase) {
+        case .transitionInProgress:
             recordingLogger.debug(.sessionStopIgnored, "The stop request was ignored because another recording transition is already in progress.")
             return nil
-        }
 
-        guard status.phase == .recording else {
+        case .noActiveRecording:
             recordingLogger.warning(.sessionStopRejected, "The stop request was rejected because no recording session is active.")
             return nil
-        }
 
-        guard let recordingSession = activeRecordingSession else {
+        case .missingSessionMetadata:
             presentError(
                 AppError.recordingFailure("The recording session metadata was unavailable."),
                 operation: .recordingStop
             )
             return nil
-        }
 
-        recordingTransition = .stopping
-        return recordingSession
+        case .ready(let recordingSession):
+            return recordingSession
+        }
     }
 
     private func transcribeAudio(
@@ -2028,7 +1981,7 @@ final class AppState: ObservableObject {
         }
 
         sessionLibrary.setCurrentTranscript(session)
-        activeRecordingSession = nil
+        recordingSessionController.clearActiveRecordingSession()
         showTranscriptWindow?()
     }
 
@@ -2088,7 +2041,7 @@ final class AppState: ObservableObject {
         session: TranscriptSession
     ) {
         sessionLibrary.stageCurrentTranscript(session)
-        activeRecordingSession = nil
+        recordingSessionController.clearActiveRecordingSession()
 
         if settingsStore.autoCopyTranscript {
             clipboardService.copy(session.transcript)
@@ -2137,7 +2090,7 @@ final class AppState: ObservableObject {
         request: TranscriptionRequest
     ) {
         if let failureReason = transcriptionRecovery.recoverablePendingTranscriptionReason(for: error),
-           let recordedAudio = pendingRecordedAudio {
+           let recordedAudio = recordingSessionController.pendingRecordedAudioSnapshot {
             preserveRetryableSession(
                 from: recordingSession,
                 recordedAudio: recordedAudio,
@@ -2150,8 +2103,8 @@ final class AppState: ObservableObject {
         if !settingsStore.debugMode {
             artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
         }
-        activeRecordingSession = nil
-        if pendingRecordedAudio == nil {
+        recordingSessionController.clearActiveRecordingSession()
+        if recordingSessionController.pendingRecordedAudioSnapshot == nil {
             presentError(error, operation: .recordingStop, fallback: { .recordingFailure($0) })
         } else {
             presentError(error, operation: .transcription)
@@ -2203,7 +2156,7 @@ final class AppState: ObservableObject {
             failureReason: failureReason
         ) {
         case .preserved(let retryableSession, let appError):
-            activeRecordingSession = nil
+            recordingSessionController.clearActiveRecordingSession()
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
             logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
@@ -2214,7 +2167,7 @@ final class AppState: ObservableObject {
             }
 
         case .persistenceFailure(let retryableSession, let error):
-            activeRecordingSession = nil
+            recordingSessionController.clearActiveRecordingSession()
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
 
@@ -2245,7 +2198,7 @@ final class AppState: ObservableObject {
             if !settingsStore.debugMode {
                 artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
             }
-            activeRecordingSession = nil
+            recordingSessionController.clearActiveRecordingSession()
             presentError(error, operation: .recordingStop)
         }
     }
@@ -2259,10 +2212,6 @@ final class AppState: ObservableObject {
 
     private func persistUpdatedSession(_ session: TranscriptSession) throws {
         try sessionLibrary.persistUpdatedSession(session)
-    }
-
-    private func preflightForSessionStart() async -> RecordingStartPreflightResult {
-        await microphonePermissionService.preflightForRecordingStart(audioRecorder: audioRecorder)
     }
 
     private func preflightForIssueExtraction(_ session: TranscriptSession) -> AppError? {

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+@MainActor
+final class RecordingSessionController: ObservableObject {
+    @Published private(set) var activeRecordingSession: RecordingSessionDraft?
+
+    private let audioRecorder: any AudioRecording
+    private let microphonePermissionService: any MicrophonePermissionServicing
+    private let artifactsService: any SessionArtifactsManaging
+    private let recordingTimer: RecordingTimerViewModel
+    private let recordingLogger: DiagnosticsLogger
+    private let fileManager: FileManager
+
+    private var processActivity: NSObjectProtocol?
+    private var pendingRecordedAudio: RecordedAudio?
+    private var transition: RecordingTransition = .idle
+
+    init(
+        audioRecorder: any AudioRecording,
+        microphonePermissionService: any MicrophonePermissionServicing,
+        artifactsService: any SessionArtifactsManaging,
+        recordingTimer: RecordingTimerViewModel,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording),
+        fileManager: FileManager = .default
+    ) {
+        self.audioRecorder = audioRecorder
+        self.microphonePermissionService = microphonePermissionService
+        self.artifactsService = artifactsService
+        self.recordingTimer = recordingTimer
+        self.recordingLogger = recordingLogger
+        self.fileManager = fileManager
+    }
+
+    var currentDuration: TimeInterval {
+        audioRecorder.currentDuration
+    }
+
+    var pendingRecordedAudioSnapshot: RecordedAudio? {
+        pendingRecordedAudio
+    }
+
+    func startSession(
+        statusPhase: AppStatus.Phase,
+        activityReason: String
+    ) async -> RecordingSessionStartOutcome {
+        guard transition == .idle else {
+            return .transitionInProgress
+        }
+
+        transition = .starting
+        defer { transition = .idle }
+
+        guard statusPhase != .recording, statusPhase != .transcribing else {
+            return .busy
+        }
+
+        if let activeRecordingSession {
+            beginActivity(reason: activityReason)
+            startTimer()
+            return .restored(activeRecordingSession)
+        }
+
+        let preflightResult = await microphonePermissionService.preflightForRecordingStart(audioRecorder: audioRecorder)
+        if let preflightError = preflightResult.error {
+            return .preflightFailure(preflightError)
+        }
+
+        do {
+            let sessionID = UUID()
+            let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
+
+            do {
+                try await audioRecorder.startRecording()
+                pendingRecordedAudio = nil
+                stopTimer(resetElapsed: true)
+                let recordingSession = RecordingSessionDraft(
+                    sessionID: sessionID,
+                    artifactsDirectoryURL: artifactsDirectoryURL
+                )
+                activeRecordingSession = recordingSession
+                beginActivity(reason: activityReason)
+                startTimer()
+                return .started(recordingSession)
+            } catch {
+                artifactsService.removeArtifactsDirectory(at: artifactsDirectoryURL)
+                throw error
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func beginStoppingSession(statusPhase: AppStatus.Phase) -> RecordingSessionStopReadiness {
+        guard transition == .idle else {
+            return .transitionInProgress
+        }
+
+        guard statusPhase == .recording else {
+            return .noActiveRecording
+        }
+
+        guard let activeRecordingSession else {
+            return .missingSessionMetadata
+        }
+
+        transition = .stopping
+        return .ready(activeRecordingSession)
+    }
+
+    func prepareForStopSession() {
+        stopTimer(resetElapsed: false)
+    }
+
+    func stopRecording() async throws -> RecordedAudio {
+        let recordedAudio = try await audioRecorder.stopRecording()
+        pendingRecordedAudio = recordedAudio
+        return recordedAudio
+    }
+
+    func finishStoppingSession() {
+        transition = .idle
+    }
+
+    func cancelSession(
+        preserveFile: Bool,
+        onCancelWillBegin: () -> Void
+    ) async -> RecordingSessionCancelOutcome {
+        guard transition == .idle else {
+            return .transitionInProgress
+        }
+
+        transition = .cancelling
+        defer { transition = .idle }
+
+        onCancelWillBegin()
+        stopTimer(resetElapsed: true)
+        endActivity()
+        await audioRecorder.cancelRecording(preserveFile: preserveFile)
+
+        let cancelledSession = activeRecordingSession
+        if let cancelledSession {
+            artifactsService.removeArtifactsDirectory(at: cancelledSession.artifactsDirectoryURL)
+            activeRecordingSession = nil
+        }
+
+        pendingRecordedAudio = nil
+        return .cancelled(cancelledSession)
+    }
+
+    func updateActiveRecordingSession(_ recordingSession: RecordingSessionDraft) {
+        activeRecordingSession = recordingSession
+    }
+
+    func clearActiveRecordingSession() {
+        activeRecordingSession = nil
+    }
+
+    func startTimer() {
+        recordingTimer.start()
+    }
+
+    func stopTimer(resetElapsed: Bool) {
+        recordingTimer.stop(resetElapsed: resetElapsed)
+    }
+
+    func beginActivity(reason: String) {
+        endActivity()
+        processActivity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleSystemSleepDisabled],
+            reason: reason
+        )
+    }
+
+    func swapActivity(reason: String) {
+        beginActivity(reason: reason)
+    }
+
+    func endActivity() {
+        if let processActivity {
+            ProcessInfo.processInfo.endActivity(processActivity)
+        }
+
+        processActivity = nil
+    }
+
+    func cleanupPendingRecordedAudioIfNeeded(debugMode: Bool) {
+        guard let pendingRecordedAudio else {
+            return
+        }
+
+        if !debugMode {
+            try? fileManager.removeItem(at: pendingRecordedAudio.fileURL)
+            recordingLogger.debug(
+                "temporary_audio_removed",
+                "Removed the temporary recorded audio file after use.",
+                metadata: ["file_name": pendingRecordedAudio.fileURL.lastPathComponent]
+            )
+        } else {
+            recordingLogger.debug(
+                "temporary_audio_preserved",
+                "Preserved the temporary recorded audio file because debug mode is enabled.",
+                metadata: ["file_name": pendingRecordedAudio.fileURL.lastPathComponent]
+            )
+        }
+
+        self.pendingRecordedAudio = nil
+    }
+}
+
+private enum RecordingTransition {
+    case idle
+    case starting
+    case stopping
+    case cancelling
+}
+
+enum RecordingSessionStartOutcome {
+    case started(RecordingSessionDraft)
+    case restored(RecordingSessionDraft)
+    case transitionInProgress
+    case busy
+    case preflightFailure(AppError)
+    case failure(Error)
+}
+
+enum RecordingSessionStopReadiness {
+    case ready(RecordingSessionDraft)
+    case transitionInProgress
+    case noActiveRecording
+    case missingSessionMetadata
+}
+
+enum RecordingSessionCancelOutcome {
+    case cancelled(RecordingSessionDraft?)
+    case transitionInProgress
+}

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class RecordingSessionControllerTests: XCTestCase {
+    func testStartSessionCreatesDraftAndStartsRecorder() async throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        let outcome = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        )
+
+        guard case .started(let recordingSession) = outcome else {
+            return XCTFail("Expected started outcome.")
+        }
+        XCTAssertEqual(harness.audioRecorder.startCallCount, 1)
+        XCTAssertEqual(harness.controller.activeRecordingSession?.sessionID, recordingSession.sessionID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recordingSession.artifactsDirectoryURL.path))
+        XCTAssertEqual(harness.artifactsService.createdDirectories, [recordingSession.artifactsDirectoryURL])
+    }
+
+    func testStartSessionRestoresExistingDraftWithoutStartingDuplicateRecorder() async throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        guard case .started(let firstSession) = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        ) else {
+            return XCTFail("Expected first start to succeed.")
+        }
+
+        let outcome = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        )
+
+        guard case .restored(let restoredSession) = outcome else {
+            return XCTFail("Expected restored outcome.")
+        }
+        XCTAssertEqual(restoredSession.sessionID, firstSession.sessionID)
+        XCTAssertEqual(harness.audioRecorder.startCallCount, 1)
+    }
+
+    func testStopSessionReturnsRecordedAudioAndStoresHandoff() async throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "recorded-stop")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        guard case .started = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        ) else {
+            return XCTFail("Expected start to succeed.")
+        }
+
+        guard case .ready = harness.controller.beginStoppingSession(statusPhase: .recording) else {
+            return XCTFail("Expected stop readiness.")
+        }
+        let stoppedAudio = try await harness.controller.stopRecording()
+        harness.controller.finishStoppingSession()
+
+        XCTAssertEqual(stoppedAudio.fileURL, recordedAudio.fileURL)
+        XCTAssertEqual(harness.controller.pendingRecordedAudioSnapshot?.fileURL, recordedAudio.fileURL)
+        XCTAssertEqual(harness.audioRecorder.stopCallCount, 1)
+        XCTAssertNotNil(harness.controller.activeRecordingSession)
+    }
+
+    func testStopWhenIdleReturnsNoActiveRecordingNoOp() throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        let readiness = harness.controller.beginStoppingSession(statusPhase: .idle)
+
+        guard case .noActiveRecording = readiness else {
+            return XCTFail("Expected no active recording no-op.")
+        }
+        XCTAssertEqual(harness.audioRecorder.stopCallCount, 0)
+    }
+
+    func testCancelSessionCancelsRecorderAndRemovesArtifacts() async throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        guard case .started(let recordingSession) = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        ) else {
+            return XCTFail("Expected start to succeed.")
+        }
+
+        let outcome = await harness.controller.cancelSession(preserveFile: false, onCancelWillBegin: {})
+
+        guard case .cancelled(let cancelledSession) = outcome else {
+            return XCTFail("Expected cancelled outcome.")
+        }
+        XCTAssertEqual(cancelledSession?.sessionID, recordingSession.sessionID)
+        XCTAssertNil(harness.controller.activeRecordingSession)
+        XCTAssertNil(harness.controller.pendingRecordedAudioSnapshot)
+        XCTAssertEqual(harness.audioRecorder.cancelPreserveArguments, [false])
+        XCTAssertEqual(harness.artifactsService.removedDirectories, [recordingSession.artifactsDirectoryURL])
+    }
+
+    func testCleanupPendingRecordedAudioPreservesDebugFilesUntilExplicitCleanup() async throws {
+        let harness = try RecordingSessionControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "pending-audio")
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        guard case .started = await harness.controller.startSession(
+            statusPhase: .idle,
+            activityReason: "Recording test session"
+        ) else {
+            return XCTFail("Expected start to succeed.")
+        }
+        guard case .ready = harness.controller.beginStoppingSession(statusPhase: .recording) else {
+            return XCTFail("Expected stop readiness.")
+        }
+        _ = try await harness.controller.stopRecording()
+        harness.controller.finishStoppingSession()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        harness.controller.cleanupPendingRecordedAudioIfNeeded(debugMode: true)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        XCTAssertNil(harness.controller.pendingRecordedAudioSnapshot)
+    }
+}
+
+@MainActor
+private final class RecordingSessionControllerHarness {
+    let rootDirectoryURL: URL
+    let audioRecorder: MockAudioRecorder
+    let artifactsService: MockArtifactsService
+    let controller: RecordingSessionController
+
+    init() throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("BugNarratorRecordingSessionControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        audioRecorder = MockAudioRecorder()
+        artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        controller = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            artifactsService: artifactsService,
+            recordingTimer: RecordingTimerViewModel()
+        )
+    }
+
+    func makeRecordedAudio(fileName: String, contents: String = "audio") throws -> RecordedAudio {
+        let fileURL = rootDirectoryURL.appendingPathComponent(fileName).appendingPathExtension("m4a")
+        try Data(contents.utf8).write(to: fileURL)
+        return RecordedAudio(fileURL: fileURL, duration: 3)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- add RecordingSessionController to own active recording drafts, transition guards, recorder calls, timer/process activity, cancellation cleanup, and pending audio handoff
- keep AppState as the UI/transcription facade over explicit controller outcomes
- add focused controller tests for start success, duplicate start restoration, stop success, idle stop no-op, cancel cleanup, and pending audio preservation

## Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests (92 tests, 0 failures)
- ./scripts/validate.sh origin/main

Closes #86