### PR TITLE
Extract IssueExtractionController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
+		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
+		105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000004 /* IssueExtractionControllerTests.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
 		4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */; };
 		5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */; };
@@ -183,6 +185,8 @@
 		3104282993DE974208688237 /* TranscriptQualityFinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFinding.swift; sourceTree = "<group>"; };
 		33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionServiceTests.swift; sourceTree = "<group>"; };
 		33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogDocument.swift; sourceTree = "<group>"; };
+		105A00000000000000000003 /* IssueExtractionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionController.swift; sourceTree = "<group>"; };
+		105A00000000000000000004 /* IssueExtractionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionControllerTests.swift; sourceTree = "<group>"; };
 		34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWorkspaceTests.swift; sourceTree = "<group>"; };
 		3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionControllerTests.swift; sourceTree = "<group>"; };
 		3B361DA07CDFA2543A36258F /* ExtractedIssue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtractedIssue.swift; sourceTree = "<group>"; };
@@ -311,6 +315,7 @@
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
+				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
 				33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */,
 				DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */,
 				B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */,
@@ -428,6 +433,7 @@
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
 				46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */,
+				105A00000000000000000003 /* IssueExtractionController.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
@@ -639,6 +645,7 @@
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
+				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,
 				F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */,
 				57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */,
 				6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */,
@@ -717,6 +724,7 @@
 				3CDB0E66F370246528266E51 /* HotkeyRecorderView.swift in Sources */,
 				8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */,
 				474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */,
+				105A00000000000000000001 /* IssueExtractionController.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
 				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,7 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published private(set) var issueExtractionSessionID: UUID?
     @Published private(set) var exportDestinationInProgress: ExportDestination?
     @Published private(set) var pendingExportReview: IssueExportReview?
     @Published private(set) var exportHistory: [ExportReceipt] = []
@@ -19,6 +18,7 @@ final class AppState: ObservableObject {
     let presentationState: AppPresentationState
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
+    let issueExtractionController: IssueExtractionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
@@ -36,7 +36,6 @@ final class AppState: ObservableObject {
     private let screenCapturePermissionService: any ScreenCapturePermissionServicing
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
-    private let issueExtractionService: any IssueExtracting
     private let exportService: any IssueExporting
     private let recoveredRecordingImporter: any RecoveredRecordingImporting
     private let artifactsService: any SessionArtifactsManaging
@@ -256,6 +255,10 @@ final class AppState: ObservableObject {
             artifactsService: artifactsService,
             clipboardService: clipboardService
         )
+        self.issueExtractionController = IssueExtractionController(
+            sessionLibrary: self.sessionLibrary,
+            issueExtractionService: issueExtractionService
+        )
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: self.sessionLibrary,
             artifactsService: artifactsService
@@ -271,7 +274,6 @@ final class AppState: ObservableObject {
         self.screenCapturePermissionService = screenCapturePermissionService
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
-        self.issueExtractionService = issueExtractionService
         self.exportService = exportService
         self.recoveredRecordingImporter = recoveredRecordingImporter
         self.artifactsService = artifactsService
@@ -331,6 +333,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         sessionLibrary.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        issueExtractionController.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -474,7 +482,7 @@ final class AppState: ObservableObject {
     }
 
     func isExtractingIssues(for session: TranscriptSession) -> Bool {
-        issueExtractionSessionID == session.id
+        issueExtractionController.isExtractingIssues(for: session)
     }
 
     func isExporting(to destination: ExportDestination) -> Bool {
@@ -1310,8 +1318,12 @@ final class AppState: ObservableObject {
             return
         }
 
-        guard let preflightError = preflightForIssueExtraction(transcriptSession) else {
-            issueExtractionSessionID = transcriptSession.id
+        guard let preflightError = issueExtractionController.preflightIssueExtraction(
+            for: transcriptSession,
+            hasUsableAIProviderCredential: settingsStore.hasUsableAIProviderCredential,
+            aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue,
+            statusPhase: status.phase
+        ) else {
             setStatus(.transcribing("Running issue extraction with a 10-second time limit..."))
             beginActivity(reason: "Extracting review issues")
             transcriptionLogger.info(
@@ -1325,31 +1337,18 @@ final class AppState: ObservableObject {
                     throw AppError.missingAPIKey
                 }
 
-                let extraction = try await issueExtractionService.extractIssues(
-                    from: transcriptSession,
+                let extraction = try await issueExtractionController.extractIssues(
+                    for: transcriptSession,
                     apiKey: apiKey,
                     model: settingsStore.issueExtractionModelValue,
-                    apiBaseURL: settingsStore.openAIBaseURLValue
+                    apiBaseURL: settingsStore.openAIBaseURLValue,
+                    completionLog: .manual
                 )
 
-                var updatedSession = transcriptSession
-                updatedSession.issueExtraction = extraction
-                try persistUpdatedSession(updatedSession)
-
-                issueExtractionSessionID = nil
                 endActivity()
-                transcriptionLogger.info(
-                    "issue_extraction_completed",
-                    "Issue extraction finished successfully.",
-                    metadata: [
-                        "session_id": transcriptSession.id.uuidString,
-                        "issue_count": "\(extraction.issues.count)"
-                    ]
-                )
                 setStatus(.success("Extracted \(extraction.issues.count) review issues."))
                 showTranscriptWindow?()
             } catch {
-                issueExtractionSessionID = nil
                 presentError(error, operation: .postTranscription, fallback: { .issueExtractionFailure($0) })
             }
 
@@ -1365,54 +1364,24 @@ final class AppState: ObservableObject {
     }
 
     func updateExtractedIssue(_ updatedIssue: ExtractedIssue, in sessionID: UUID) {
-        guard var session = editableSession(with: sessionID),
-              var extraction = session.issueExtraction,
-              let issueIndex = extraction.issues.firstIndex(where: { $0.id == updatedIssue.id }) else {
-            return
-        }
-
-        extraction.issues[issueIndex] = updatedIssue
-        session.issueExtraction = extraction
-
         do {
-            try persistUpdatedSession(session)
+            try issueExtractionController.updateExtractedIssue(updatedIssue, in: sessionID)
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
     }
 
     func setIssueSelection(_ isSelected: Bool, issueID: UUID, in sessionID: UUID) {
-        guard var session = editableSession(with: sessionID),
-              var extraction = session.issueExtraction,
-              let issueIndex = extraction.issues.firstIndex(where: { $0.id == issueID }) else {
-            return
-        }
-
-        extraction.issues[issueIndex].isSelectedForExport = isSelected
-        session.issueExtraction = extraction
-
         do {
-            try persistUpdatedSession(session)
+            try issueExtractionController.setIssueSelection(isSelected, issueID: issueID, in: sessionID)
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
     }
 
     func setAllIssuesSelected(_ isSelected: Bool, in sessionID: UUID) {
-        guard var session = editableSession(with: sessionID),
-              var extraction = session.issueExtraction else {
-            return
-        }
-
-        extraction.issues = extraction.issues.map { issue in
-            var updatedIssue = issue
-            updatedIssue.isSelectedForExport = isSelected
-            return updatedIssue
-        }
-        session.issueExtraction = extraction
-
         do {
-            try persistUpdatedSession(session)
+            try issueExtractionController.setAllIssuesSelected(isSelected, in: sessionID)
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
@@ -1721,7 +1690,7 @@ final class AppState: ObservableObject {
             metadata: [
                 "status_phase": status.phase.debugName,
                 "has_active_recording_session": activeRecordingSession == nil ? "no" : "yes",
-                "is_extracting_issues": issueExtractionSessionID == nil ? "no" : "yes",
+                "is_extracting_issues": issueExtractionController.issueExtractionSessionID == nil ? "no" : "yes",
                 "is_exporting": exportDestinationInProgress == nil ? "no" : "yes"
             ]
         )
@@ -1753,7 +1722,7 @@ final class AppState: ObservableObject {
         stopTimer(resetElapsed: status.phase == .recording)
         endActivity()
         cleanupPendingRecordedAudioIfNeeded()
-        issueExtractionSessionID = nil
+        issueExtractionController.clearProgress()
         exportDestinationInProgress = nil
 
         let normalizedError = normalizeError(error, operation: operation, fallback: fallback)
@@ -1990,28 +1959,17 @@ final class AppState: ObservableObject {
         apiKey: String
     ) async throws -> TranscriptSession {
         var session = session
-        issueExtractionSessionID = session.id
-        defer { issueExtractionSessionID = nil }
-
         setStatus(.transcribing(transcriptionProgressMessage(step: 3, action: "Extracting reviewable issues...")))
         swapActivity(reason: "Extracting review issues")
 
-        let extraction = try await issueExtractionService.extractIssues(
-            from: session,
+        let extraction = try await issueExtractionController.extractIssues(
+            for: session,
             apiKey: apiKey,
             model: settingsStore.issueExtractionModelValue,
-            apiBaseURL: settingsStore.openAIBaseURLValue
+            apiBaseURL: settingsStore.openAIBaseURLValue,
+            completionLog: .postTranscription
         )
         session.issueExtraction = extraction
-        try persistUpdatedSession(session)
-        transcriptionLogger.info(
-            "issue_extraction_completed_after_transcription",
-            "Automatic issue extraction completed after transcription.",
-            metadata: [
-                "session_id": session.id.uuidString,
-                "issue_count": "\(extraction.issues.count)"
-            ]
-        )
         return session
     }
 
@@ -2214,27 +2172,6 @@ final class AppState: ObservableObject {
         try sessionLibrary.persistUpdatedSession(session)
     }
 
-    private func preflightForIssueExtraction(_ session: TranscriptSession) -> AppError? {
-        if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-            return .transcriptionFailure(compatibilityIssue)
-        }
-
-        guard settingsStore.hasUsableAIProviderCredential else {
-            return .missingAPIKey
-        }
-
-        let transcript = session.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !transcript.isEmpty else {
-            return .emptyTranscript
-        }
-
-        guard status.phase != .recording else {
-            return .recordingFailure("Stop the current recording before extracting issues.")
-        }
-
-        return nil
-    }
-
     private func validateExportConfiguration(for destination: ExportDestination) throws {
         switch destination {
         case .github:
@@ -2334,10 +2271,6 @@ final class AppState: ObservableObject {
             issueTypeID: target.issueTypeID,
             issueTypeName: target.issueTypeName
         )
-    }
-
-    private func editableSession(with sessionID: UUID) -> TranscriptSession? {
-        sessionLibrary.editableSession(with: sessionID)
     }
 
     private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -1,0 +1,147 @@
+import Combine
+import Foundation
+
+@MainActor
+final class IssueExtractionController: ObservableObject {
+    @Published private(set) var issueExtractionSessionID: UUID?
+
+    private let sessionLibrary: SessionLibraryController
+    private let issueExtractionService: any IssueExtracting
+    private let logger: DiagnosticsLogger
+
+    init(
+        sessionLibrary: SessionLibraryController,
+        issueExtractionService: any IssueExtracting,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .transcription)
+    ) {
+        self.sessionLibrary = sessionLibrary
+        self.issueExtractionService = issueExtractionService
+        self.logger = logger
+    }
+
+    func isExtractingIssues(for session: TranscriptSession) -> Bool {
+        issueExtractionSessionID == session.id
+    }
+
+    func clearProgress() {
+        issueExtractionSessionID = nil
+    }
+
+    func preflightIssueExtraction(
+        for session: TranscriptSession,
+        hasUsableAIProviderCredential: Bool,
+        aiProviderCompatibilityIssue: String?,
+        statusPhase: AppStatus.Phase
+    ) -> AppError? {
+        if let compatibilityIssue = aiProviderCompatibilityIssue {
+            return .transcriptionFailure(compatibilityIssue)
+        }
+
+        guard hasUsableAIProviderCredential else {
+            return .missingAPIKey
+        }
+
+        let transcript = session.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !transcript.isEmpty else {
+            return .emptyTranscript
+        }
+
+        guard statusPhase != .recording else {
+            return .recordingFailure("Stop the current recording before extracting issues.")
+        }
+
+        return nil
+    }
+
+    func extractIssues(
+        for session: TranscriptSession,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL,
+        completionLog: IssueExtractionCompletionLog
+    ) async throws -> IssueExtractionResult {
+        issueExtractionSessionID = session.id
+        defer { issueExtractionSessionID = nil }
+
+        let extraction = try await issueExtractionService.extractIssues(
+            from: session,
+            apiKey: apiKey,
+            model: model,
+            apiBaseURL: apiBaseURL
+        )
+
+        var updatedSession = session
+        updatedSession.issueExtraction = extraction
+        try sessionLibrary.persistUpdatedSession(updatedSession)
+
+        logger.info(
+            completionLog.eventName,
+            completionLog.message,
+            metadata: [
+                "session_id": session.id.uuidString,
+                "issue_count": "\(extraction.issues.count)"
+            ]
+        )
+        return extraction
+    }
+
+    @discardableResult
+    func updateExtractedIssue(_ updatedIssue: ExtractedIssue, in sessionID: UUID) throws -> Bool {
+        guard var session = sessionLibrary.editableSession(with: sessionID),
+              var extraction = session.issueExtraction,
+              let issueIndex = extraction.issues.firstIndex(where: { $0.id == updatedIssue.id }) else {
+            return false
+        }
+
+        extraction.issues[issueIndex] = updatedIssue
+        session.issueExtraction = extraction
+        try sessionLibrary.persistUpdatedSession(session)
+        return true
+    }
+
+    @discardableResult
+    func setIssueSelection(_ isSelected: Bool, issueID: UUID, in sessionID: UUID) throws -> Bool {
+        guard var session = sessionLibrary.editableSession(with: sessionID),
+              var extraction = session.issueExtraction,
+              let issueIndex = extraction.issues.firstIndex(where: { $0.id == issueID }) else {
+            return false
+        }
+
+        extraction.issues[issueIndex].isSelectedForExport = isSelected
+        session.issueExtraction = extraction
+        try sessionLibrary.persistUpdatedSession(session)
+        return true
+    }
+
+    @discardableResult
+    func setAllIssuesSelected(_ isSelected: Bool, in sessionID: UUID) throws -> Bool {
+        guard var session = sessionLibrary.editableSession(with: sessionID),
+              var extraction = session.issueExtraction else {
+            return false
+        }
+
+        extraction.issues = extraction.issues.map { issue in
+            var updatedIssue = issue
+            updatedIssue.isSelectedForExport = isSelected
+            return updatedIssue
+        }
+        session.issueExtraction = extraction
+        try sessionLibrary.persistUpdatedSession(session)
+        return true
+    }
+}
+
+struct IssueExtractionCompletionLog {
+    let eventName: String
+    let message: String
+
+    static let manual = IssueExtractionCompletionLog(
+        eventName: "issue_extraction_completed",
+        message: "Issue extraction finished successfully."
+    )
+
+    static let postTranscription = IssueExtractionCompletionLog(
+        eventName: "issue_extraction_completed_after_transcription",
+        message: "Automatic issue extraction completed after transcription."
+    )
+}

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class IssueExtractionControllerTests: XCTestCase {
+    func testPreflightMapsCredentialTranscriptAndRecordingFailures() throws {
+        let harness = try IssueExtractionControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = harness.makeSession(transcript: "Transcript")
+        XCTAssertEqual(
+            harness.controller.preflightIssueExtraction(
+                for: session,
+                hasUsableAIProviderCredential: false,
+                aiProviderCompatibilityIssue: nil,
+                statusPhase: .idle
+            ),
+            .missingAPIKey
+        )
+        XCTAssertEqual(
+            harness.controller.preflightIssueExtraction(
+                for: harness.makeSession(transcript: "  \n"),
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                statusPhase: .idle
+            ),
+            .emptyTranscript
+        )
+        XCTAssertEqual(
+            harness.controller.preflightIssueExtraction(
+                for: session,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                statusPhase: .recording
+            ),
+            .recordingFailure("Stop the current recording before extracting issues.")
+        )
+        XCTAssertEqual(
+            harness.controller.preflightIssueExtraction(
+                for: session,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: "Provider unavailable.",
+                statusPhase: .idle
+            ),
+            .transcriptionFailure("Provider unavailable.")
+        )
+    }
+
+    func testExtractIssuesPersistsResultAndClearsProgress() async throws {
+        let harness = try IssueExtractionControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = harness.makeSession(transcript: "The save button fails.")
+        try harness.transcriptStore.add(session)
+        let issue = harness.makeIssue(title: "Save button fails")
+        await harness.issueExtractionService.setResult(
+            IssueExtractionResult(summary: "One bug.", issues: [issue])
+        )
+
+        let extraction = try await harness.controller.extractIssues(
+            for: session,
+            apiKey: "test-key",
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!,
+            completionLog: .manual
+        )
+
+        XCTAssertEqual(extraction.issues.map(\.title), ["Save button fails"])
+        XCTAssertNil(harness.controller.issueExtractionSessionID)
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id)?.issueExtraction?.summary, "One bug.")
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+    }
+
+    func testUpdateExtractedIssuePersistsEditedIssue() throws {
+        let harness = try IssueExtractionControllerHarness()
+        defer { harness.cleanup() }
+
+        let issue = harness.makeIssue(title: "Original title")
+        let session = harness.makeSession(
+            transcript: "Transcript",
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+        try harness.transcriptStore.add(session)
+
+        var updatedIssue = issue
+        updatedIssue.title = "Updated title"
+
+        XCTAssertTrue(try harness.controller.updateExtractedIssue(updatedIssue, in: session.id))
+        XCTAssertEqual(
+            harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.first?.title,
+            "Updated title"
+        )
+    }
+
+    func testSetIssueSelectionPersistsSingleIssueSelection() throws {
+        let harness = try IssueExtractionControllerHarness()
+        defer { harness.cleanup() }
+
+        let issue = harness.makeIssue(title: "Selectable", isSelectedForExport: false)
+        let session = harness.makeSession(
+            transcript: "Transcript",
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+        try harness.transcriptStore.add(session)
+
+        XCTAssertTrue(try harness.controller.setIssueSelection(true, issueID: issue.id, in: session.id))
+        XCTAssertEqual(
+            harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.first?.isSelectedForExport,
+            true
+        )
+    }
+
+    func testSetAllIssuesSelectedPersistsBulkSelection() throws {
+        let harness = try IssueExtractionControllerHarness()
+        defer { harness.cleanup() }
+
+        let firstIssue = harness.makeIssue(title: "First", isSelectedForExport: false)
+        let secondIssue = harness.makeIssue(title: "Second", isSelectedForExport: true)
+        let session = harness.makeSession(
+            transcript: "Transcript",
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [firstIssue, secondIssue])
+        )
+        try harness.transcriptStore.add(session)
+
+        XCTAssertTrue(try harness.controller.setAllIssuesSelected(false, in: session.id))
+        XCTAssertEqual(
+            harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.map(\.isSelectedForExport),
+            [false, false]
+        )
+    }
+}
+
+@MainActor
+private final class IssueExtractionControllerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let issueExtractionService: MockIssueExtractionService
+    let sessionLibrary: SessionLibraryController
+    let controller: IssueExtractionController
+
+    init() throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("BugNarratorIssueExtractionControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        issueExtractionService = MockIssueExtractionService()
+        let artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: MockClipboardService()
+        )
+        controller = IssueExtractionController(
+            sessionLibrary: sessionLibrary,
+            issueExtractionService: issueExtractionService
+        )
+    }
+
+    func makeSession(
+        transcript: String,
+        issueExtraction: IssueExtractionResult? = nil
+    ) -> TranscriptSession {
+        TranscriptSession(
+            createdAt: Date(),
+            transcript: transcript,
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: issueExtraction
+        )
+    }
+
+    func makeIssue(
+        title: String,
+        isSelectedForExport: Bool = true
+    ) -> ExtractedIssue {
+        ExtractedIssue(
+            title: title,
+            category: .bug,
+            summary: "Summary for \(title)",
+            evidenceExcerpt: "Evidence for \(title)",
+            timestamp: 2,
+            requiresReview: true,
+            isSelectedForExport: isSelectedForExport
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- Add IssueExtractionController to own issue extraction progress, preflight, persistence, and selected-issue mutation helpers
- Keep AppState as the UI-facing facade for status/activity/window behavior
- Add focused controller tests for preflight, successful extraction, issue updates, and selection mutation

Closes #105.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExtractionControllerTests\n- ./scripts/validate.sh origin/main