### PR TITLE
Extract IssueExportController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
+		107A00000000000000000001 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000003 /* IssueExportController.swift */; };
+		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
 		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
 		105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000004 /* IssueExtractionControllerTests.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
@@ -196,6 +198,8 @@
 		440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinator.swift; sourceTree = "<group>"; };
 		4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
+		107A00000000000000000003 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
+		107A00000000000000000004 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
@@ -315,6 +319,7 @@
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
+				107A00000000000000000004 /* IssueExportControllerTests.swift */,
 				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
 				33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */,
 				DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */,
@@ -433,6 +438,7 @@
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
 				46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */,
+				107A00000000000000000003 /* IssueExportController.swift */,
 				105A00000000000000000003 /* IssueExtractionController.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
@@ -645,6 +651,7 @@
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
+				107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */,
 				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,
 				F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */,
 				57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */,
@@ -724,6 +731,7 @@
 				3CDB0E66F370246528266E51 /* HotkeyRecorderView.swift in Sources */,
 				8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */,
 				474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */,
+				107A00000000000000000001 /* IssueExportController.swift in Sources */,
 				105A00000000000000000001 /* IssueExtractionController.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
 				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,8 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published private(set) var exportDestinationInProgress: ExportDestination?
-    @Published private(set) var pendingExportReview: IssueExportReview?
     @Published private(set) var exportHistory: [ExportReceipt] = []
     @Published private(set) var recoveredRecordingImportCount = 0
 
@@ -19,6 +17,7 @@ final class AppState: ObservableObject {
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
     let issueExtractionController: IssueExtractionController
+    let issueExportController: IssueExportController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
@@ -109,6 +108,14 @@ final class AppState: ObservableObject {
 
     var currentError: AppError? {
         presentationState.currentError
+    }
+
+    var exportDestinationInProgress: ExportDestination? {
+        issueExportController.exportDestinationInProgress
+    }
+
+    var pendingExportReview: IssueExportReview? {
+        issueExportController.pendingExportReview
     }
 
     var transientToast: TransientToast? {
@@ -259,6 +266,11 @@ final class AppState: ObservableObject {
             sessionLibrary: self.sessionLibrary,
             issueExtractionService: issueExtractionService
         )
+        self.issueExportController = IssueExportController(
+            settingsStore: settingsStore,
+            sessionLibrary: self.sessionLibrary,
+            exportService: exportService
+        )
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: self.sessionLibrary,
             artifactsService: artifactsService
@@ -339,6 +351,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         issueExtractionController.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        issueExportController.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -486,7 +504,7 @@ final class AppState: ObservableObject {
     }
 
     func isExporting(to destination: ExportDestination) -> Bool {
-        exportDestinationInProgress == destination
+        issueExportController.isExporting(to: destination)
     }
 
     func refreshPermissionRecoveryState() {
@@ -527,105 +545,27 @@ final class AppState: ObservableObject {
     }
 
     func canExportIssues(from session: TranscriptSession, to destination: ExportDestination) -> Bool {
-        guard canRequestIssueExport(from: session) else {
-            return false
-        }
-
-        guard let selectedIssues = sessionSnapshot(with: session.id)?.issueExtraction?.selectedIssues else {
-            return false
-        }
-
-        switch destination {
-        case .github:
-            return (try? configuredGitHubIssueGroups(for: selectedIssues)) != nil
-        case .jira:
-            return (try? configuredJiraIssueGroups(for: selectedIssues)) != nil
-        }
+        issueExportController.canExportIssues(from: session, to: destination, statusPhase: status.phase)
     }
 
     func canRequestIssueExport(from session: TranscriptSession) -> Bool {
-        guard status.phase != .recording,
-              status.phase != .transcribing,
-              pendingExportReview == nil,
-              let session = sessionSnapshot(with: session.id),
-              let extraction = session.issueExtraction,
-              !extraction.selectedIssues.isEmpty else {
-            return false
-        }
-
-        return true
+        issueExportController.canRequestIssueExport(from: session, statusPhase: status.phase)
     }
 
     func issueExportSetupMessage(for destination: ExportDestination) -> String? {
-        switch destination {
-        case .github:
-            guard !settingsStore.hasGitHubToken else {
-                return nil
-            }
-            return "GitHub token is missing. Click Set Up GitHub to open Settings."
-        case .jira:
-            guard settingsStore.jiraConnectionConfiguration == nil else {
-                return nil
-            }
-            return "Jira connection is missing. Click Set Up Jira to open Settings."
-        }
+        issueExportController.issueExportSetupMessage(for: destination)
     }
 
     func issueExportRoutingMessage(for destination: ExportDestination, session: TranscriptSession) -> String? {
-        guard let selectedIssues = sessionSnapshot(with: session.id)?.issueExtraction?.selectedIssues,
-              !selectedIssues.isEmpty else {
-            return nil
-        }
-
-        switch destination {
-        case .github:
-            guard settingsStore.hasGitHubToken else {
-                return nil
-            }
-
-            let missingCount = selectedIssues.filter { gitHubExportConfiguration(for: $0) == nil }.count
-            guard missingCount > 0 else {
-                return nil
-            }
-            return "Choose a GitHub repository for \(missingCount) selected issue\(missingCount == 1 ? "" : "s")."
-        case .jira:
-            guard settingsStore.jiraConnectionConfiguration != nil else {
-                return nil
-            }
-
-            let missingCount = selectedIssues.filter { jiraExportConfiguration(for: $0) == nil }.count
-            guard missingCount > 0 else {
-                return nil
-            }
-            return "Choose a Jira project and issue type for \(missingCount) selected issue\(missingCount == 1 ? "" : "s")."
-        }
+        issueExportController.issueExportRoutingMessage(for: destination, session: session)
     }
 
     func defaultGitHubIssueExportTarget() -> GitHubIssueExportTarget? {
-        guard !settingsStore.normalizedGitHubRepositoryOwner.isEmpty,
-              !settingsStore.normalizedGitHubRepositoryName.isEmpty else {
-            return nil
-        }
-
-        return GitHubIssueExportTarget(
-            repositoryID: settingsStore.normalizedGitHubRepositoryID.nilIfEmpty,
-            owner: settingsStore.normalizedGitHubRepositoryOwner,
-            repository: settingsStore.normalizedGitHubRepositoryName,
-            labels: settingsStore.githubDefaultLabelsList
-        )
+        issueExportController.defaultGitHubIssueExportTarget()
     }
 
     func defaultJiraIssueExportTarget() -> JiraIssueExportTarget? {
-        guard !settingsStore.normalizedJiraProjectKey.isEmpty else {
-            return nil
-        }
-
-        return JiraIssueExportTarget(
-            projectID: settingsStore.normalizedJiraProjectID.nilIfEmpty,
-            projectKey: settingsStore.normalizedJiraProjectKey,
-            issueTypeID: settingsStore.normalizedJiraIssueTypeID,
-            issueTypeName: settingsStore.normalizedJiraIssueType
-        )
+        issueExportController.defaultJiraIssueExportTarget()
     }
 
     func startSession() async {
@@ -1388,145 +1328,54 @@ final class AppState: ObservableObject {
     }
 
     func exportSelectedIssues(from session: TranscriptSession, to destination: ExportDestination) async {
-        guard status.phase != .recording, status.phase != .transcribing else {
-            presentError(AppError.exportFailure("Finish the current background work before exporting issues."), operation: .export)
-            return
-        }
-
-        guard let currentSession = sessionSnapshot(with: session.id) else {
-            presentError(AppError.exportFailure("This session is no longer available in the library."), operation: .export)
-            return
-        }
-
-        guard let extraction = currentSession.issueExtraction else {
-            presentError(AppError.exportFailure("Run issue extraction before exporting."), operation: .export)
-            return
-        }
-
-        let selectedIssues = extraction.selectedIssues
-        guard !selectedIssues.isEmpty else {
-            presentError(AppError.exportFailure("Select at least one extracted issue to export."), operation: .export)
-            return
-        }
-
-        settingsStore.refreshExportSecretsForUserInitiatedAccess()
-
-        do {
-            try validateExportConfiguration(for: destination)
-        } catch {
-            presentError(error, operation: .export, fallback: { .exportFailure($0) })
-            if case .exportConfigurationMissing = error as? AppError {
+        let context: IssueExportRequestContext
+        switch issueExportController.preflightIssueExport(
+            from: session,
+            to: destination,
+            statusPhase: status.phase
+        ) {
+        case .success(let readyContext):
+            context = readyContext
+        case .failure(let failure):
+            presentError(failure.error, operation: .export, fallback: { .exportFailure($0) })
+            if failure.opensSettings {
                 showSettingsWindow?()
             }
             return
         }
 
-        guard let apiKey = settingsStore.aiProviderCredentialForUserInitiatedAccess() else {
-            presentError(AppError.missingAPIKey, operation: .export)
-            return
-        }
-
-        exportDestinationInProgress = destination
         setStatus(.transcribing("Checking \(destination.rawValue) for similar open issues..."))
         beginActivity(reason: "Reviewing similar issues before export")
-        exportLogger.info(
-            "issue_export_review_requested",
-            "Preparing similar issue review before export.",
-            metadata: [
-                "destination": destination.rawValue,
-                "session_id": currentSession.id.uuidString,
-                "issue_count": "\(selectedIssues.count)"
-            ]
-        )
 
         do {
-            let review: IssueExportReview
-
-            switch destination {
-            case .github:
-                let groups = try configuredGitHubIssueGroups(for: selectedIssues)
-                var items: [IssueExportReviewItem] = []
-
-                for group in groups {
-                    try await exportService.validateGitHubConfiguration(group.configuration)
-                    let groupReview = try await exportService.prepareGitHubExportReview(
-                        issues: group.issues,
-                        session: currentSession,
-                        configuration: group.configuration,
-                        apiKey: apiKey,
-                        model: settingsStore.issueExtractionModelValue,
-                        apiBaseURL: settingsStore.openAIBaseURLValue
-                    )
-                    items.append(contentsOf: groupReview.items)
-                }
-
-                review = IssueExportReview(destination: .github, sessionID: currentSession.id, items: items)
-            case .jira:
-                let groups = try configuredJiraIssueGroups(for: selectedIssues)
-                var items: [IssueExportReviewItem] = []
-
-                for group in groups {
-                    try await exportService.validateJiraConfiguration(group.configuration)
-                    let groupReview = try await exportService.prepareJiraExportReview(
-                        issues: group.issues,
-                        session: currentSession,
-                        configuration: group.configuration,
-                        apiKey: apiKey,
-                        model: settingsStore.issueExtractionModelValue,
-                        apiBaseURL: settingsStore.openAIBaseURLValue
-                    )
-                    items.append(contentsOf: groupReview.items)
-                }
-
-                review = IssueExportReview(destination: .jira, sessionID: currentSession.id, items: items)
-            }
-
-            exportDestinationInProgress = nil
+            let review = try await issueExportController.prepareIssueExportReview(
+                for: context,
+                model: settingsStore.issueExtractionModelValue,
+                apiBaseURL: settingsStore.openAIBaseURLValue
+            )
             endActivity()
 
             if review.hasMatches {
-                pendingExportReview = review
-                exportLogger.info(
-                    "issue_export_review_ready",
-                    "Similar issue review is ready for user confirmation.",
-                    metadata: [
-                        "destination": destination.rawValue,
-                        "session_id": currentSession.id.uuidString
-                    ]
-                )
                 setStatus(.success("Review the similar \(destination.rawValue) issues before export."))
             } else {
                 await finalizeIssueExport(using: review)
             }
         } catch {
-            exportDestinationInProgress = nil
             endActivity()
             presentError(error, operation: .export, fallback: { .exportFailure($0) })
         }
     }
 
     func cancelPendingExportReview() {
-        pendingExportReview = nil
+        issueExportController.cancelPendingExportReview()
     }
 
     func setExportReviewResolution(_ resolution: SimilarIssueResolution, for issueID: UUID) {
-        guard var review = pendingExportReview,
-              let itemIndex = review.items.firstIndex(where: { $0.issue.id == issueID }) else {
-            return
-        }
-
-        review.items[itemIndex].setResolution(resolution)
-        pendingExportReview = review
+        issueExportController.setExportReviewResolution(resolution, for: issueID)
     }
 
     func selectExportReviewMatch(_ matchID: String, for issueID: UUID) {
-        guard var review = pendingExportReview,
-              let itemIndex = review.items.firstIndex(where: { $0.issue.id == issueID }) else {
-            return
-        }
-
-        review.items[itemIndex].selectMatch(id: matchID)
-        pendingExportReview = review
+        issueExportController.selectExportReviewMatch(matchID, for: issueID)
     }
 
     func confirmPendingExportReview() async {
@@ -1538,72 +1387,21 @@ final class AppState: ObservableObject {
     }
 
     private func finalizeIssueExport(using review: IssueExportReview) async {
-        guard let currentSession = sessionSnapshot(with: review.sessionID) else {
-            presentError(AppError.exportFailure("This session is no longer available in the library."), operation: .export)
-            pendingExportReview = nil
-            return
-        }
-
         do {
-            let preparedIssues = try IssueExportReviewPolicy.preparedIssues(from: review)
-            let duplicateMatches = try IssueExportReviewPolicy.duplicateMatchResults(from: review)
-
-            pendingExportReview = nil
-            let combinedResults: [ExportResult]
-
-            if preparedIssues.isEmpty {
-                combinedResults = duplicateMatches
-            } else {
-                exportDestinationInProgress = review.destination
+            let requiresRemoteExport = try issueExportController.pendingReviewRequiresRemoteExport(review)
+            if requiresRemoteExport {
                 setStatus(.transcribing("Exporting reviewed issues to \(review.destination.rawValue)..."))
                 beginActivity(reason: "Exporting extracted issues")
+            }
 
-                let exportedResults: [ExportResult]
-                switch review.destination {
-                case .github:
-                    var results: [ExportResult] = []
-                    for group in try configuredGitHubIssueGroups(for: preparedIssues) {
-                        results += try await exportService.exportToGitHub(
-                            issues: group.issues,
-                            session: currentSession,
-                            configuration: group.configuration
-                        )
-                    }
-                    exportedResults = results
-                case .jira:
-                    var results: [ExportResult] = []
-                    for group in try configuredJiraIssueGroups(for: preparedIssues) {
-                        results += try await exportService.exportToJira(
-                            issues: group.issues,
-                            session: currentSession,
-                            configuration: group.configuration
-                        )
-                    }
-                    exportedResults = results
-                }
-
-                combinedResults = exportedResults + duplicateMatches
-                exportDestinationInProgress = nil
+            let completion = try await issueExportController.finalizeIssueExport(using: review)
+            if completion.performedRemoteExport {
                 endActivity()
             }
 
-            exportLogger.info(
-                "issue_export_completed",
-                "Finished exporting selected issues.",
-                metadata: [
-                    "destination": review.destination.rawValue,
-                    "session_id": currentSession.id.uuidString,
-                    "issue_count": "\(combinedResults.count)"
-                ]
-            )
-            setStatus(.success(IssueExportReviewPolicy.exportSummary(
-                for: combinedResults,
-                duplicateCount: duplicateMatches.count,
-                destination: review.destination
-            )))
+            setStatus(.success(completion.summary))
             await refreshExportHistory()
         } catch {
-            exportDestinationInProgress = nil
             endActivity()
             presentError(error, operation: .export, fallback: { .exportFailure($0) })
         }
@@ -1691,7 +1489,7 @@ final class AppState: ObservableObject {
                 "status_phase": status.phase.debugName,
                 "has_active_recording_session": activeRecordingSession == nil ? "no" : "yes",
                 "is_extracting_issues": issueExtractionController.issueExtractionSessionID == nil ? "no" : "yes",
-                "is_exporting": exportDestinationInProgress == nil ? "no" : "yes"
+                "is_exporting": issueExportController.exportDestinationInProgress == nil ? "no" : "yes"
             ]
         )
 
@@ -1723,7 +1521,7 @@ final class AppState: ObservableObject {
         endActivity()
         cleanupPendingRecordedAudioIfNeeded()
         issueExtractionController.clearProgress()
-        exportDestinationInProgress = nil
+        issueExportController.clearProgress()
 
         let normalizedError = normalizeError(error, operation: operation, fallback: fallback)
         let appError = normalizedError.appError
@@ -2170,107 +1968,6 @@ final class AppState: ObservableObject {
 
     private func persistUpdatedSession(_ session: TranscriptSession) throws {
         try sessionLibrary.persistUpdatedSession(session)
-    }
-
-    private func validateExportConfiguration(for destination: ExportDestination) throws {
-        switch destination {
-        case .github:
-            guard settingsStore.hasGitHubToken else {
-                throw AppError.exportConfigurationMissing(
-                    "GitHub export requires a personal access token."
-                )
-            }
-        case .jira:
-            guard settingsStore.jiraConnectionConfiguration != nil else {
-                throw AppError.exportConfigurationMissing(
-                    "Jira export requires a base URL, email, and API token."
-                )
-            }
-        }
-    }
-
-    private func configuredGitHubIssueGroups(
-        for issues: [ExtractedIssue]
-    ) throws -> [(configuration: GitHubExportConfiguration, issues: [ExtractedIssue])] {
-        var groups: [(configuration: GitHubExportConfiguration, issues: [ExtractedIssue])] = []
-
-        for issue in issues {
-            guard let configuration = gitHubExportConfiguration(for: issue) else {
-                throw AppError.exportConfigurationMissing(
-                    "Choose a GitHub repository for every selected issue before exporting."
-                )
-            }
-
-            if let groupIndex = groups.firstIndex(where: { $0.configuration == configuration }) {
-                groups[groupIndex].issues.append(issue)
-            } else {
-                groups.append((configuration: configuration, issues: [issue]))
-            }
-        }
-
-        return groups
-    }
-
-    private func configuredJiraIssueGroups(
-        for issues: [ExtractedIssue]
-    ) throws -> [(configuration: JiraExportConfiguration, issues: [ExtractedIssue])] {
-        var groups: [(configuration: JiraExportConfiguration, issues: [ExtractedIssue])] = []
-
-        for issue in issues {
-            guard let configuration = jiraExportConfiguration(for: issue) else {
-                throw AppError.exportConfigurationMissing(
-                    "Choose a Jira project and issue type for every selected issue before exporting."
-                )
-            }
-
-            if let groupIndex = groups.firstIndex(where: { $0.configuration == configuration }) {
-                groups[groupIndex].issues.append(issue)
-            } else {
-                groups.append((configuration: configuration, issues: [issue]))
-            }
-        }
-
-        return groups
-    }
-
-    private func gitHubExportConfiguration(for issue: ExtractedIssue) -> GitHubExportConfiguration? {
-        guard settingsStore.hasGitHubToken else {
-            return nil
-        }
-
-        let target = issue.gitHubExportTarget ?? defaultGitHubIssueExportTarget()
-        guard let target, target.isComplete else {
-            return nil
-        }
-
-        return GitHubExportConfiguration(
-            token: settingsStore.trimmedGitHubToken,
-            repositoryID: target.repositoryID,
-            owner: target.owner,
-            repository: target.repository,
-            labels: target.labels
-        )
-    }
-
-    private func jiraExportConfiguration(for issue: ExtractedIssue) -> JiraExportConfiguration? {
-        guard let connection = settingsStore.jiraConnectionConfiguration else {
-            return nil
-        }
-
-        let target = issue.jiraExportTarget ?? defaultJiraIssueExportTarget()
-        guard let target, target.isComplete else {
-            return nil
-        }
-
-        return JiraExportConfiguration(
-            baseURL: connection.baseURL,
-            email: connection.email,
-            apiToken: connection.apiToken,
-            projectID: target.projectID,
-            projectKey: target.projectKey,
-            issueTypeID: target.issueTypeID,
-            issueTypeName: target.issueTypeName
-        )
     }
 
     private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {

--- a/Sources/BugNarrator/Services/IssueExportController.swift
+++ b/Sources/BugNarrator/Services/IssueExportController.swift
@@ -1,0 +1,497 @@
+import Combine
+import Foundation
+
+@MainActor
+final class IssueExportController: ObservableObject {
+    @Published private(set) var exportDestinationInProgress: ExportDestination?
+    @Published private(set) var pendingExportReview: IssueExportReview?
+
+    private let settingsStore: SettingsStore
+    private let sessionLibrary: SessionLibraryController
+    private let exportService: any IssueExporting
+    private let logger: DiagnosticsLogger
+
+    init(
+        settingsStore: SettingsStore,
+        sessionLibrary: SessionLibraryController,
+        exportService: any IssueExporting,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .export)
+    ) {
+        self.settingsStore = settingsStore
+        self.sessionLibrary = sessionLibrary
+        self.exportService = exportService
+        self.logger = logger
+    }
+
+    func isExporting(to destination: ExportDestination) -> Bool {
+        exportDestinationInProgress == destination
+    }
+
+    func clearProgress() {
+        exportDestinationInProgress = nil
+    }
+
+    func canRequestIssueExport(
+        from session: TranscriptSession,
+        statusPhase: AppStatus.Phase
+    ) -> Bool {
+        guard statusPhase != .recording,
+              statusPhase != .transcribing,
+              pendingExportReview == nil,
+              let session = sessionLibrary.sessionSnapshot(with: session.id),
+              let extraction = session.issueExtraction,
+              !extraction.selectedIssues.isEmpty else {
+            return false
+        }
+
+        return true
+    }
+
+    func canExportIssues(
+        from session: TranscriptSession,
+        to destination: ExportDestination,
+        statusPhase: AppStatus.Phase
+    ) -> Bool {
+        guard canRequestIssueExport(from: session, statusPhase: statusPhase),
+              let selectedIssues = sessionLibrary.sessionSnapshot(with: session.id)?.issueExtraction?.selectedIssues else {
+            return false
+        }
+
+        switch destination {
+        case .github:
+            return (try? configuredGitHubIssueGroups(for: selectedIssues)) != nil
+        case .jira:
+            return (try? configuredJiraIssueGroups(for: selectedIssues)) != nil
+        }
+    }
+
+    func issueExportSetupMessage(for destination: ExportDestination) -> String? {
+        switch destination {
+        case .github:
+            guard !settingsStore.hasGitHubToken else {
+                return nil
+            }
+            return "GitHub token is missing. Click Set Up GitHub to open Settings."
+        case .jira:
+            guard settingsStore.jiraConnectionConfiguration == nil else {
+                return nil
+            }
+            return "Jira connection is missing. Click Set Up Jira to open Settings."
+        }
+    }
+
+    func issueExportRoutingMessage(
+        for destination: ExportDestination,
+        session: TranscriptSession
+    ) -> String? {
+        guard let selectedIssues = sessionLibrary.sessionSnapshot(with: session.id)?.issueExtraction?.selectedIssues,
+              !selectedIssues.isEmpty else {
+            return nil
+        }
+
+        switch destination {
+        case .github:
+            guard settingsStore.hasGitHubToken else {
+                return nil
+            }
+
+            let missingCount = selectedIssues.filter { gitHubExportConfiguration(for: $0) == nil }.count
+            guard missingCount > 0 else {
+                return nil
+            }
+            return "Choose a GitHub repository for \(missingCount) selected issue\(missingCount == 1 ? "" : "s")."
+        case .jira:
+            guard settingsStore.jiraConnectionConfiguration != nil else {
+                return nil
+            }
+
+            let missingCount = selectedIssues.filter { jiraExportConfiguration(for: $0) == nil }.count
+            guard missingCount > 0 else {
+                return nil
+            }
+            return "Choose a Jira project and issue type for \(missingCount) selected issue\(missingCount == 1 ? "" : "s")."
+        }
+    }
+
+    func defaultGitHubIssueExportTarget() -> GitHubIssueExportTarget? {
+        guard !settingsStore.normalizedGitHubRepositoryOwner.isEmpty,
+              !settingsStore.normalizedGitHubRepositoryName.isEmpty else {
+            return nil
+        }
+
+        return GitHubIssueExportTarget(
+            repositoryID: settingsStore.normalizedGitHubRepositoryID.nilIfEmpty,
+            owner: settingsStore.normalizedGitHubRepositoryOwner,
+            repository: settingsStore.normalizedGitHubRepositoryName,
+            labels: settingsStore.githubDefaultLabelsList
+        )
+    }
+
+    func defaultJiraIssueExportTarget() -> JiraIssueExportTarget? {
+        guard !settingsStore.normalizedJiraProjectKey.isEmpty else {
+            return nil
+        }
+
+        return JiraIssueExportTarget(
+            projectID: settingsStore.normalizedJiraProjectID.nilIfEmpty,
+            projectKey: settingsStore.normalizedJiraProjectKey,
+            issueTypeID: settingsStore.normalizedJiraIssueTypeID,
+            issueTypeName: settingsStore.normalizedJiraIssueType
+        )
+    }
+
+    func preflightIssueExport(
+        from session: TranscriptSession,
+        to destination: ExportDestination,
+        statusPhase: AppStatus.Phase
+    ) -> Result<IssueExportRequestContext, IssueExportPreflightFailure> {
+        guard statusPhase != .recording, statusPhase != .transcribing else {
+            return .failure(IssueExportPreflightFailure(
+                error: .exportFailure("Finish the current background work before exporting issues."),
+                opensSettings: false
+            ))
+        }
+
+        guard let currentSession = sessionLibrary.sessionSnapshot(with: session.id) else {
+            return .failure(IssueExportPreflightFailure(
+                error: .exportFailure("This session is no longer available in the library."),
+                opensSettings: false
+            ))
+        }
+
+        guard let extraction = currentSession.issueExtraction else {
+            return .failure(IssueExportPreflightFailure(
+                error: .exportFailure("Run issue extraction before exporting."),
+                opensSettings: false
+            ))
+        }
+
+        let selectedIssues = extraction.selectedIssues
+        guard !selectedIssues.isEmpty else {
+            return .failure(IssueExportPreflightFailure(
+                error: .exportFailure("Select at least one extracted issue to export."),
+                opensSettings: false
+            ))
+        }
+
+        settingsStore.refreshExportSecretsForUserInitiatedAccess()
+
+        do {
+            try validateExportConfiguration(for: destination)
+        } catch {
+            let appError = (error as? AppError) ?? .exportFailure(error.localizedDescription)
+            let opensSettings: Bool
+            if case .exportConfigurationMissing = appError {
+                opensSettings = true
+            } else {
+                opensSettings = false
+            }
+
+            return .failure(IssueExportPreflightFailure(
+                error: appError,
+                opensSettings: opensSettings
+            ))
+        }
+
+        guard let apiKey = settingsStore.aiProviderCredentialForUserInitiatedAccess() else {
+            return .failure(IssueExportPreflightFailure(error: .missingAPIKey, opensSettings: false))
+        }
+
+        return .success(IssueExportRequestContext(
+            destination: destination,
+            session: currentSession,
+            selectedIssues: selectedIssues,
+            apiKey: apiKey
+        ))
+    }
+
+    func prepareIssueExportReview(
+        for context: IssueExportRequestContext,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExportReview {
+        exportDestinationInProgress = context.destination
+        defer { exportDestinationInProgress = nil }
+
+        logger.info(
+            "issue_export_review_requested",
+            "Preparing similar issue review before export.",
+            metadata: [
+                "destination": context.destination.rawValue,
+                "session_id": context.session.id.uuidString,
+                "issue_count": "\(context.selectedIssues.count)"
+            ]
+        )
+
+        let review: IssueExportReview
+        switch context.destination {
+        case .github:
+            var items: [IssueExportReviewItem] = []
+            for group in try configuredGitHubIssueGroups(for: context.selectedIssues) {
+                try await exportService.validateGitHubConfiguration(group.configuration)
+                let groupReview = try await exportService.prepareGitHubExportReview(
+                    issues: group.issues,
+                    session: context.session,
+                    configuration: group.configuration,
+                    apiKey: context.apiKey,
+                    model: model,
+                    apiBaseURL: apiBaseURL
+                )
+                items.append(contentsOf: groupReview.items)
+            }
+            review = IssueExportReview(destination: .github, sessionID: context.session.id, items: items)
+        case .jira:
+            var items: [IssueExportReviewItem] = []
+            for group in try configuredJiraIssueGroups(for: context.selectedIssues) {
+                try await exportService.validateJiraConfiguration(group.configuration)
+                let groupReview = try await exportService.prepareJiraExportReview(
+                    issues: group.issues,
+                    session: context.session,
+                    configuration: group.configuration,
+                    apiKey: context.apiKey,
+                    model: model,
+                    apiBaseURL: apiBaseURL
+                )
+                items.append(contentsOf: groupReview.items)
+            }
+            review = IssueExportReview(destination: .jira, sessionID: context.session.id, items: items)
+        }
+
+        if review.hasMatches {
+            pendingExportReview = review
+            logger.info(
+                "issue_export_review_ready",
+                "Similar issue review is ready for user confirmation.",
+                metadata: [
+                    "destination": context.destination.rawValue,
+                    "session_id": context.session.id.uuidString
+                ]
+            )
+        }
+
+        return review
+    }
+
+    func cancelPendingExportReview() {
+        pendingExportReview = nil
+    }
+
+    func setExportReviewResolution(_ resolution: SimilarIssueResolution, for issueID: UUID) {
+        guard var review = pendingExportReview,
+              let itemIndex = review.items.firstIndex(where: { $0.issue.id == issueID }) else {
+            return
+        }
+
+        review.items[itemIndex].setResolution(resolution)
+        pendingExportReview = review
+    }
+
+    func selectExportReviewMatch(_ matchID: String, for issueID: UUID) {
+        guard var review = pendingExportReview,
+              let itemIndex = review.items.firstIndex(where: { $0.issue.id == issueID }) else {
+            return
+        }
+
+        review.items[itemIndex].selectMatch(id: matchID)
+        pendingExportReview = review
+    }
+
+    func pendingReviewRequiresRemoteExport(_ review: IssueExportReview) throws -> Bool {
+        try !IssueExportReviewPolicy.preparedIssues(from: review).isEmpty
+    }
+
+    func finalizeIssueExport(using review: IssueExportReview) async throws -> IssueExportCompletion {
+        guard let currentSession = sessionLibrary.sessionSnapshot(with: review.sessionID) else {
+            pendingExportReview = nil
+            throw AppError.exportFailure("This session is no longer available in the library.")
+        }
+
+        let preparedIssues = try IssueExportReviewPolicy.preparedIssues(from: review)
+        let duplicateMatches = try IssueExportReviewPolicy.duplicateMatchResults(from: review)
+
+        pendingExportReview = nil
+        let combinedResults: [ExportResult]
+        var performedRemoteExport = false
+
+        if preparedIssues.isEmpty {
+            combinedResults = duplicateMatches
+        } else {
+            exportDestinationInProgress = review.destination
+            defer { exportDestinationInProgress = nil }
+
+            let exportedResults: [ExportResult]
+            switch review.destination {
+            case .github:
+                var results: [ExportResult] = []
+                for group in try configuredGitHubIssueGroups(for: preparedIssues) {
+                    results += try await exportService.exportToGitHub(
+                        issues: group.issues,
+                        session: currentSession,
+                        configuration: group.configuration
+                    )
+                }
+                exportedResults = results
+            case .jira:
+                var results: [ExportResult] = []
+                for group in try configuredJiraIssueGroups(for: preparedIssues) {
+                    results += try await exportService.exportToJira(
+                        issues: group.issues,
+                        session: currentSession,
+                        configuration: group.configuration
+                    )
+                }
+                exportedResults = results
+            }
+
+            performedRemoteExport = true
+            combinedResults = exportedResults + duplicateMatches
+        }
+
+        logger.info(
+            "issue_export_completed",
+            "Finished exporting selected issues.",
+            metadata: [
+                "destination": review.destination.rawValue,
+                "session_id": currentSession.id.uuidString,
+                "issue_count": "\(combinedResults.count)"
+            ]
+        )
+
+        return IssueExportCompletion(
+            destination: review.destination,
+            sessionID: currentSession.id,
+            results: combinedResults,
+            duplicateCount: duplicateMatches.count,
+            performedRemoteExport: performedRemoteExport
+        )
+    }
+
+    private func configuredGitHubIssueGroups(
+        for issues: [ExtractedIssue]
+    ) throws -> [(configuration: GitHubExportConfiguration, issues: [ExtractedIssue])] {
+        var groups: [(configuration: GitHubExportConfiguration, issues: [ExtractedIssue])] = []
+
+        for issue in issues {
+            guard let configuration = gitHubExportConfiguration(for: issue) else {
+                throw AppError.exportConfigurationMissing(
+                    "Choose a GitHub repository for every selected issue before exporting."
+                )
+            }
+
+            if let groupIndex = groups.firstIndex(where: { $0.configuration == configuration }) {
+                groups[groupIndex].issues.append(issue)
+            } else {
+                groups.append((configuration: configuration, issues: [issue]))
+            }
+        }
+
+        return groups
+    }
+
+    private func configuredJiraIssueGroups(
+        for issues: [ExtractedIssue]
+    ) throws -> [(configuration: JiraExportConfiguration, issues: [ExtractedIssue])] {
+        var groups: [(configuration: JiraExportConfiguration, issues: [ExtractedIssue])] = []
+
+        for issue in issues {
+            guard let configuration = jiraExportConfiguration(for: issue) else {
+                throw AppError.exportConfigurationMissing(
+                    "Choose a Jira project and issue type for every selected issue before exporting."
+                )
+            }
+
+            if let groupIndex = groups.firstIndex(where: { $0.configuration == configuration }) {
+                groups[groupIndex].issues.append(issue)
+            } else {
+                groups.append((configuration: configuration, issues: [issue]))
+            }
+        }
+
+        return groups
+    }
+
+    private func validateExportConfiguration(for destination: ExportDestination) throws {
+        switch destination {
+        case .github:
+            guard settingsStore.hasGitHubToken else {
+                throw AppError.exportConfigurationMissing(
+                    "GitHub export requires a personal access token."
+                )
+            }
+        case .jira:
+            guard settingsStore.jiraConnectionConfiguration != nil else {
+                throw AppError.exportConfigurationMissing(
+                    "Jira export requires a base URL, email, and API token."
+                )
+            }
+        }
+    }
+
+    private func gitHubExportConfiguration(for issue: ExtractedIssue) -> GitHubExportConfiguration? {
+        guard settingsStore.hasGitHubToken else {
+            return nil
+        }
+
+        let target = issue.gitHubExportTarget ?? defaultGitHubIssueExportTarget()
+        guard let target, target.isComplete else {
+            return nil
+        }
+
+        return GitHubExportConfiguration(
+            token: settingsStore.trimmedGitHubToken,
+            repositoryID: target.repositoryID,
+            owner: target.owner,
+            repository: target.repository,
+            labels: target.labels
+        )
+    }
+
+    private func jiraExportConfiguration(for issue: ExtractedIssue) -> JiraExportConfiguration? {
+        guard let connection = settingsStore.jiraConnectionConfiguration else {
+            return nil
+        }
+
+        let target = issue.jiraExportTarget ?? defaultJiraIssueExportTarget()
+        guard let target, target.isComplete else {
+            return nil
+        }
+
+        return JiraExportConfiguration(
+            baseURL: connection.baseURL,
+            email: connection.email,
+            apiToken: connection.apiToken,
+            projectID: target.projectID,
+            projectKey: target.projectKey,
+            issueTypeID: target.issueTypeID,
+            issueTypeName: target.issueTypeName
+        )
+    }
+}
+
+struct IssueExportPreflightFailure: Error {
+    let error: AppError
+    let opensSettings: Bool
+}
+
+struct IssueExportRequestContext {
+    let destination: ExportDestination
+    let session: TranscriptSession
+    let selectedIssues: [ExtractedIssue]
+    let apiKey: String
+}
+
+struct IssueExportCompletion {
+    let destination: ExportDestination
+    let sessionID: UUID
+    let results: [ExportResult]
+    let duplicateCount: Int
+    let performedRemoteExport: Bool
+
+    var summary: String {
+        IssueExportReviewPolicy.exportSummary(
+            for: results,
+            duplicateCount: duplicateCount,
+            destination: destination
+        )
+    }
+}

--- a/Tests/BugNarratorTests/IssueExportControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExportControllerTests.swift
@@ -1,0 +1,326 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class IssueExportControllerTests: XCTestCase {
+    func testReadinessAndDefaultGitHubRouting() throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = harness.makeSession(issues: [harness.makeIssue(title: "Exportable issue")])
+        try harness.transcriptStore.add(session)
+
+        XCTAssertTrue(harness.controller.canRequestIssueExport(from: session, statusPhase: .idle))
+        XCTAssertFalse(harness.controller.canExportIssues(from: session, to: .github, statusPhase: .idle))
+        XCTAssertEqual(
+            harness.controller.issueExportSetupMessage(for: .github),
+            "GitHub token is missing. Click Set Up GitHub to open Settings."
+        )
+
+        harness.settingsStore.githubToken = "fixture-github-token"
+        harness.settingsStore.githubRepositoryOwner = "acme"
+        harness.settingsStore.githubRepositoryName = "bugnarrator"
+        harness.settingsStore.githubRepositoryID = "R_kgDOFixture"
+        harness.settingsStore.githubDefaultLabels = "bug, triage"
+
+        XCTAssertTrue(harness.controller.canExportIssues(from: session, to: .github, statusPhase: .idle))
+        XCTAssertNil(harness.controller.issueExportSetupMessage(for: .github))
+        XCTAssertNil(harness.controller.issueExportRoutingMessage(for: .github, session: session))
+        XCTAssertEqual(harness.controller.defaultGitHubIssueExportTarget()?.displayLabel, "acme/bugnarrator")
+        XCTAssertEqual(harness.controller.defaultGitHubIssueExportTarget()?.labels, ["bug", "triage"])
+    }
+
+    func testGitHubGroupingUsesPerIssueTargets() async throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.githubToken = "fixture-github-token"
+        let firstIssue = harness.makeIssue(
+            title: "Frontend issue",
+            gitHubExportTarget: GitHubIssueExportTarget(owner: "acme", repository: "frontend", labels: ["ui"])
+        )
+        let secondIssue = harness.makeIssue(
+            title: "Backend issue",
+            gitHubExportTarget: GitHubIssueExportTarget(owner: "acme", repository: "backend", labels: ["api"])
+        )
+        let session = harness.makeSession(issues: [firstIssue, secondIssue])
+        try harness.transcriptStore.add(session)
+
+        let context = try harness.requireContext(
+            harness.controller.preflightIssueExport(from: session, to: .github, statusPhase: .idle)
+        )
+        let review = try await harness.controller.prepareIssueExportReview(
+            for: context,
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!
+        )
+
+        let reviewConfigurations = await harness.exportService.gitHubReviewConfigurations
+        XCTAssertEqual(review.items.map(\.issue.title), ["Frontend issue", "Backend issue"])
+        XCTAssertEqual(reviewConfigurations.map(\.targetIdentity), ["acme/frontend", "acme/backend"])
+        XCTAssertNil(harness.controller.exportDestinationInProgress)
+        XCTAssertNil(harness.controller.pendingExportReview)
+    }
+
+    func testJiraGroupingUsesPerIssueTargets() async throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.jiraBaseURL = "https://example.atlassian.net"
+        harness.settingsStore.jiraEmail = "jira-user@example.com"
+        harness.settingsStore.jiraAPIToken = "fixture-jira-token"
+        let firstIssue = harness.makeIssue(
+            title: "App issue",
+            jiraExportTarget: JiraIssueExportTarget(
+                projectID: "10000",
+                projectKey: "APP",
+                issueTypeID: "10001",
+                issueTypeName: "Bug"
+            )
+        )
+        let secondIssue = harness.makeIssue(
+            title: "Ops issue",
+            jiraExportTarget: JiraIssueExportTarget(
+                projectID: "20000",
+                projectKey: "OPS",
+                issueTypeID: "20001",
+                issueTypeName: "Task"
+            )
+        )
+        let session = harness.makeSession(issues: [firstIssue, secondIssue])
+        try harness.transcriptStore.add(session)
+
+        let context = try harness.requireContext(
+            harness.controller.preflightIssueExport(from: session, to: .jira, statusPhase: .idle)
+        )
+        _ = try await harness.controller.prepareIssueExportReview(
+            for: context,
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!
+        )
+
+        let reviewConfigurations = await harness.exportService.jiraReviewConfigurations
+        XCTAssertEqual(reviewConfigurations.map(\.targetIdentity), ["10000::10001", "20000::20001"])
+        XCTAssertNil(harness.controller.exportDestinationInProgress)
+        XCTAssertNil(harness.controller.pendingExportReview)
+    }
+
+    func testPendingReviewMutationAndCancel() async throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.githubToken = "fixture-github-token"
+        harness.settingsStore.githubRepositoryOwner = "acme"
+        harness.settingsStore.githubRepositoryName = "bugnarrator"
+        let issue = harness.makeIssue(title: "Login issue")
+        let session = harness.makeSession(issues: [issue])
+        try harness.transcriptStore.add(session)
+        await harness.exportService.setGitHubReview(harness.makeReview(for: issue, sessionID: session.id))
+
+        let context = try harness.requireContext(
+            harness.controller.preflightIssueExport(from: session, to: .github, statusPhase: .idle)
+        )
+        _ = try await harness.controller.prepareIssueExportReview(
+            for: context,
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!
+        )
+
+        XCTAssertNotNil(harness.controller.pendingExportReview)
+        harness.controller.setExportReviewResolution(.linkAsRelated, for: issue.id)
+        XCTAssertEqual(harness.controller.pendingExportReview?.items.first?.resolution, .linkAsRelated)
+
+        harness.controller.cancelPendingExportReview()
+        XCTAssertNil(harness.controller.pendingExportReview)
+    }
+
+    func testFinalizeReviewedExportSkipsDuplicateAndClearsPendingReview() async throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.githubToken = "fixture-github-token"
+        harness.settingsStore.githubRepositoryOwner = "acme"
+        harness.settingsStore.githubRepositoryName = "bugnarrator"
+        let issue = harness.makeIssue(title: "Duplicate login issue")
+        let session = harness.makeSession(issues: [issue])
+        try harness.transcriptStore.add(session)
+        await harness.exportService.setGitHubReview(harness.makeReview(for: issue, sessionID: session.id))
+
+        let context = try harness.requireContext(
+            harness.controller.preflightIssueExport(from: session, to: .github, statusPhase: .idle)
+        )
+        _ = try await harness.controller.prepareIssueExportReview(
+            for: context,
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!
+        )
+        harness.controller.setExportReviewResolution(.markDuplicate, for: issue.id)
+
+        let review = try XCTUnwrap(harness.controller.pendingExportReview)
+        XCTAssertFalse(try harness.controller.pendingReviewRequiresRemoteExport(review))
+        let completion = try await harness.controller.finalizeIssueExport(using: review)
+
+        let exportCallCount = await harness.exportService.gitHubCallCount
+        XCTAssertEqual(exportCallCount, 0)
+        XCTAssertEqual(completion.duplicateCount, 1)
+        XCTAssertFalse(completion.performedRemoteExport)
+        XCTAssertNil(harness.controller.pendingExportReview)
+    }
+
+    func testFinalizeReviewedExportAddsRelatedContextForRemoteExport() async throws {
+        let harness = try IssueExportControllerHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.githubToken = "fixture-github-token"
+        harness.settingsStore.githubRepositoryOwner = "acme"
+        harness.settingsStore.githubRepositoryName = "bugnarrator"
+        let issue = harness.makeIssue(title: "Related login issue")
+        let session = harness.makeSession(issues: [issue])
+        try harness.transcriptStore.add(session)
+        await harness.exportService.setGitHubReview(harness.makeReview(for: issue, sessionID: session.id))
+        await harness.exportService.setGitHubResults([
+            ExportResult(
+                sourceIssueID: issue.id,
+                destination: .github,
+                remoteIdentifier: "#200",
+                remoteURL: URL(string: "https://github.com/acme/bugnarrator/issues/200")
+            )
+        ])
+
+        let context = try harness.requireContext(
+            harness.controller.preflightIssueExport(from: session, to: .github, statusPhase: .idle)
+        )
+        _ = try await harness.controller.prepareIssueExportReview(
+            for: context,
+            model: "gpt-test",
+            apiBaseURL: URL(string: "https://api.example.test")!
+        )
+        harness.controller.setExportReviewResolution(.linkAsRelated, for: issue.id)
+
+        let review = try XCTUnwrap(harness.controller.pendingExportReview)
+        XCTAssertTrue(try harness.controller.pendingReviewRequiresRemoteExport(review))
+        let completion = try await harness.controller.finalizeIssueExport(using: review)
+
+        let exportedIssues = await harness.exportService.lastGitHubIssues
+        XCTAssertTrue(completion.performedRemoteExport)
+        XCTAssertEqual(exportedIssues.count, 1)
+        XCTAssertTrue(exportedIssues.first?.note?.contains("Related to #142") == true)
+    }
+}
+
+@MainActor
+private final class IssueExportControllerHarness {
+    let rootDirectoryURL: URL
+    let defaultsSuiteName: String
+    let defaults: UserDefaults
+    let settingsStore: SettingsStore
+    let transcriptStore: TranscriptStore
+    let exportService: MockExportService
+    let sessionLibrary: SessionLibraryController
+    let controller: IssueExportController
+
+    init() throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("BugNarratorIssueExportControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        defaultsSuiteName = "BugNarratorIssueExportControllerTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+
+        settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: MockLaunchAtLoginService()
+        )
+        settingsStore.apiKey = "test-api-key"
+
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        exportService = MockExportService()
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts")),
+            clipboardService: MockClipboardService()
+        )
+        controller = IssueExportController(
+            settingsStore: settingsStore,
+            sessionLibrary: sessionLibrary,
+            exportService: exportService
+        )
+    }
+
+    func makeSession(issues: [ExtractedIssue]) -> TranscriptSession {
+        TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: issues)
+        )
+    }
+
+    func makeIssue(
+        title: String,
+        gitHubExportTarget: GitHubIssueExportTarget? = nil,
+        jiraExportTarget: JiraIssueExportTarget? = nil
+    ) -> ExtractedIssue {
+        ExtractedIssue(
+            title: title,
+            category: .bug,
+            summary: "Summary for \(title)",
+            evidenceExcerpt: "Evidence for \(title)",
+            timestamp: 2,
+            requiresReview: true,
+            isSelectedForExport: true,
+            gitHubExportTarget: gitHubExportTarget,
+            jiraExportTarget: jiraExportTarget
+        )
+    }
+
+    func makeReview(for issue: ExtractedIssue, sessionID: UUID) -> IssueExportReview {
+        IssueExportReview(
+            destination: .github,
+            sessionID: sessionID,
+            items: [
+                IssueExportReviewItem(
+                    issue: issue,
+                    matches: [
+                        SimilarIssueMatch(
+                            remoteIdentifier: "#142",
+                            title: "Login form validation broken",
+                            summary: "The login form never re-enables its submit button.",
+                            remoteURL: URL(string: "https://github.com/acme/bugnarrator/issues/142"),
+                            confidence: 0.85,
+                            reasoning: "Both reports describe the same blocked login action after valid input."
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+
+    func requireContext(
+        _ result: Result<IssueExportRequestContext, IssueExportPreflightFailure>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> IssueExportRequestContext {
+        switch result {
+        case .success(let context):
+            return context
+        case .failure(let failure):
+            XCTFail("Expected export preflight success, got \(failure.error)", file: file, line: line)
+            throw failure.error
+        }
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract issue export orchestration from AppState into IssueExportController.
- Keep AppState as the UI-facing coordinator while delegating export readiness, review mutation, grouping, configuration, and finalization.
- Add focused controller tests for routing, grouping, pending review mutation, duplicate skips, and remote context.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExportControllerTests
- ./scripts/validate.sh origin/main

Closes #107