### PR TITLE
Extract PermissionRecoveryController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		107A00000000000000000001 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000003 /* IssueExportController.swift */; };
 		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
+		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
+		109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */; };
 		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
 		105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000004 /* IssueExtractionControllerTests.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
@@ -200,6 +202,8 @@
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
 		107A00000000000000000003 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
 		107A00000000000000000004 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
+		109A00000000000000000003 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
+		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
@@ -329,6 +333,7 @@
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
+				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */,
@@ -449,6 +454,7 @@
 				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
+				109A00000000000000000003 /* PermissionRecoveryController.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
 				BC5286F2E07F27DFA63F4B76 /* RecoveredRecordingImporter.swift */,
@@ -661,6 +667,7 @@
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,
+				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */,
@@ -748,6 +755,7 @@
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */,
+				109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -18,10 +18,10 @@ final class AppState: ObservableObject {
     let sessionLibrary: SessionLibraryController
     let issueExtractionController: IssueExtractionController
     let issueExportController: IssueExportController
+    let permissionRecoveryController: PermissionRecoveryController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
-    private let runtimeEnvironment: AppRuntimeEnvironment
     var showTranscriptWindow: (() -> Void)?
     var showSettingsWindow: (() -> Void)?
     var showAboutWindow: (() -> Void)?
@@ -31,8 +31,6 @@ final class AppState: ObservableObject {
     var prepareForScreenshotSelection: (() -> Void)?
     var restoreAfterScreenshotSelection: (() -> Void)?
 
-    private let microphonePermissionService: any MicrophonePermissionServicing
-    private let screenCapturePermissionService: any ScreenCapturePermissionServicing
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
     private let exportService: any IssueExporting
@@ -271,6 +269,12 @@ final class AppState: ObservableObject {
             sessionLibrary: self.sessionLibrary,
             exportService: exportService
         )
+        self.permissionRecoveryController = PermissionRecoveryController(
+            microphonePermissionService: microphonePermissionService,
+            screenCapturePermissionService: screenCapturePermissionService,
+            urlHandler: urlHandler,
+            runtimeEnvironment: runtimeEnvironment
+        )
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: self.sessionLibrary,
             artifactsService: artifactsService
@@ -281,9 +285,6 @@ final class AppState: ObservableObject {
             screenshotSelectionService: screenshotSelectionService,
             artifactsService: artifactsService
         )
-        self.runtimeEnvironment = runtimeEnvironment
-        self.microphonePermissionService = microphonePermissionService
-        self.screenCapturePermissionService = screenCapturePermissionService
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
         self.exportService = exportService
@@ -508,39 +509,14 @@ final class AppState: ObservableObject {
     }
 
     func refreshPermissionRecoveryState() {
-        permissionsLogger.debug(
-            "permission_recovery_refresh_started",
-            "Refreshing permission recovery state after BugNarrator became active.",
-            metadata: [
-                "microphone_status": microphonePermissionService.currentStatus().rawValue,
-                "screen_capture_status": screenCapturePermissionService.currentStatus().rawValue
-            ]
-        )
-
-        switch currentError {
-        case .microphonePermissionDenied, .microphonePermissionRestricted, .microphoneUnavailable:
-            guard status.phase != .recording, status.phase != .transcribing else {
-                return
-            }
-
-            let microphoneStatus = microphonePermissionService.currentStatus()
-            guard microphoneStatus == .granted else {
-                return
-            }
-
-            setStatus(.idle("Microphone access enabled. You can start recording again."))
-        case .screenRecordingPermissionDenied:
-            guard screenCapturePermissionService.currentStatus() == .granted else {
-                return
-            }
-
-            if status.phase == .recording {
-                setStatus(.recording("Screen Recording access enabled. You can capture screenshots again."))
-            } else {
-                setStatus(.idle("Screen Recording access enabled. You can capture screenshots again."))
-            }
-        default:
-            return
+        switch permissionRecoveryController.refreshRecoveryState(
+            currentError: currentError,
+            statusPhase: status.phase
+        ) {
+        case .unchanged:
+            break
+        case .recovered(let recoveredStatus):
+            setStatus(recoveredStatus)
         }
     }
 
@@ -819,45 +795,15 @@ final class AppState: ObservableObject {
     }
 
     func openMicrophonePrivacySettings() {
-        let candidateURLs = [
-            BugNarratorLinks.microphonePrivacySettings,
-            BugNarratorLinks.securityPrivacySettings,
-            BugNarratorLinks.systemSettingsApp
-        ]
-
-        for url in candidateURLs where urlHandler.open(url) {
-            return
-        }
-
-        presentUtilityActionFailure("BugNarrator could not open Microphone settings automatically.")
+        presentPermissionSettingsResult(permissionRecoveryController.openMicrophonePrivacySettings())
     }
 
     func openScreenRecordingPrivacySettings() {
-        let candidateURLs = [
-            BugNarratorLinks.screenRecordingPrivacySettings,
-            BugNarratorLinks.securityPrivacySettings,
-            BugNarratorLinks.systemSettingsApp
-        ]
-
-        for url in candidateURLs where urlHandler.open(url) {
-            return
-        }
-
-        presentUtilityActionFailure("BugNarrator could not open Screen Recording settings automatically.")
+        presentPermissionSettingsResult(permissionRecoveryController.openScreenRecordingPrivacySettings())
     }
 
     func openSystemAudioPrivacySettings() {
-        let candidateURLs = [
-            BugNarratorLinks.screenRecordingPrivacySettings,
-            BugNarratorLinks.securityPrivacySettings,
-            BugNarratorLinks.systemSettingsApp
-        ]
-
-        for url in candidateURLs where urlHandler.open(url) {
-            return
-        }
-
-        presentUtilityActionFailure("BugNarrator could not open Screen & System Audio Recording settings automatically.")
+        presentPermissionSettingsResult(permissionRecoveryController.openSystemAudioPrivacySettings())
     }
 
     func checkForUpdates() {
@@ -1447,6 +1393,15 @@ final class AppState: ObservableObject {
             "Opened an external support or documentation link.",
             metadata: ["label": label]
         )
+    }
+
+    private func presentPermissionSettingsResult(_ result: PermissionSettingsOpenResult) {
+        switch result {
+        case .opened:
+            return
+        case .failed(let message):
+            presentUtilityActionFailure(message)
+        }
     }
 
     private func presentUtilityActionFailure(_ message: String) {
@@ -2175,23 +2130,7 @@ final class AppState: ObservableObject {
     }
 
     private var microphoneRecoveryGuidanceDetails: MicrophoneRecoveryGuidance {
-        microphonePermissionService.recoveryGuidance(
-            for: microphoneRecoveryStatus,
-            runtimeEnvironment: runtimeEnvironment
-        )
-    }
-
-    private var microphoneRecoveryStatus: MicrophonePermissionStatus {
-        switch currentError {
-        case .microphonePermissionDenied:
-            return .denied
-        case .microphonePermissionRestricted:
-            return .restricted
-        case .microphoneUnavailable:
-            return .captureSetupFailed
-        default:
-            return microphonePermissionService.currentStatus()
-        }
+        permissionRecoveryController.microphoneRecoveryGuidance(currentError: currentError)
     }
 
     private func makeDebugBundleSnapshot() async -> DebugBundleSnapshot {
@@ -2203,35 +2142,11 @@ final class AppState: ObservableObject {
     }
 
     private func validateRuntimeConfiguration() {
-        guard let microphoneUsageDescription = Bundle.main.object(
-            forInfoDictionaryKey: "NSMicrophoneUsageDescription"
-        ) as? String else {
-            permissionsLogger.error(
-                "runtime_configuration_missing_microphone_usage_description",
-                "BugNarrator is missing NSMicrophoneUsageDescription. macOS microphone prompting will not work correctly."
-            )
-            return
-        }
-
-        if microphoneUsageDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            permissionsLogger.error(
-                "runtime_configuration_empty_microphone_usage_description",
-                "BugNarrator has an empty NSMicrophoneUsageDescription. macOS microphone prompting will not work correctly."
-            )
-        }
+        permissionRecoveryController.validateRuntimeConfiguration()
     }
 
     private func logLaunchDiagnostics() {
-        permissionsLogger.info(
-            "launch_permission_snapshot",
-            "Captured the initial permission state snapshot for this BugNarrator app copy.",
-            metadata: [
-                "bundle_path": runtimeEnvironment.bundlePath,
-                "is_local_testing_build": runtimeEnvironment.isLocalTestingBuild ? "yes" : "no",
-                "microphone_status": microphonePermissionService.currentStatus().rawValue,
-                "screen_capture_status": screenCapturePermissionService.currentStatus().rawValue
-            ]
-        )
+        permissionRecoveryController.logLaunchPermissionSnapshot()
 
         sessionLibraryLogger.info(
             "launch_session_store_snapshot",

--- a/Sources/BugNarrator/Services/PermissionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/PermissionRecoveryController.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+enum PermissionRecoveryRefreshOutcome: Equatable {
+    case unchanged
+    case recovered(AppStatus)
+}
+
+enum PermissionSettingsOpenResult: Equatable {
+    case opened(URL)
+    case failed(String)
+}
+
+@MainActor
+final class PermissionRecoveryController {
+    private let microphonePermissionService: any MicrophonePermissionServicing
+    private let screenCapturePermissionService: any ScreenCapturePermissionServicing
+    private let urlHandler: any URLOpening
+    private let runtimeEnvironment: AppRuntimeEnvironment
+    private let permissionsLogger = DiagnosticsLogger(category: .permissions)
+
+    init(
+        microphonePermissionService: any MicrophonePermissionServicing,
+        screenCapturePermissionService: any ScreenCapturePermissionServicing,
+        urlHandler: any URLOpening,
+        runtimeEnvironment: AppRuntimeEnvironment
+    ) {
+        self.microphonePermissionService = microphonePermissionService
+        self.screenCapturePermissionService = screenCapturePermissionService
+        self.urlHandler = urlHandler
+        self.runtimeEnvironment = runtimeEnvironment
+    }
+
+    func refreshRecoveryState(
+        currentError: AppError?,
+        statusPhase: AppStatus.Phase
+    ) -> PermissionRecoveryRefreshOutcome {
+        permissionsLogger.debug(
+            "permission_recovery_refresh_started",
+            "Refreshing permission recovery state after BugNarrator became active.",
+            metadata: [
+                "microphone_status": microphonePermissionService.currentStatus().rawValue,
+                "screen_capture_status": screenCapturePermissionService.currentStatus().rawValue
+            ]
+        )
+
+        switch currentError {
+        case .microphonePermissionDenied?, .microphonePermissionRestricted?, .microphoneUnavailable?:
+            guard statusPhase != .recording, statusPhase != .transcribing else {
+                return .unchanged
+            }
+
+            guard microphonePermissionService.currentStatus() == .granted else {
+                return .unchanged
+            }
+
+            return .recovered(.idle("Microphone access enabled. You can start recording again."))
+        case .screenRecordingPermissionDenied?:
+            guard screenCapturePermissionService.currentStatus() == .granted else {
+                return .unchanged
+            }
+
+            if statusPhase == .recording {
+                return .recovered(.recording("Screen Recording access enabled. You can capture screenshots again."))
+            }
+
+            return .recovered(.idle("Screen Recording access enabled. You can capture screenshots again."))
+        default:
+            return .unchanged
+        }
+    }
+
+    func microphoneRecoveryGuidance(currentError: AppError?) -> MicrophoneRecoveryGuidance {
+        microphonePermissionService.recoveryGuidance(
+            for: microphoneRecoveryStatus(currentError: currentError),
+            runtimeEnvironment: runtimeEnvironment
+        )
+    }
+
+    func openMicrophonePrivacySettings() -> PermissionSettingsOpenResult {
+        openPrivacySettings(
+            candidateURLs: [
+                BugNarratorLinks.microphonePrivacySettings,
+                BugNarratorLinks.securityPrivacySettings,
+                BugNarratorLinks.systemSettingsApp
+            ],
+            failureMessage: "BugNarrator could not open Microphone settings automatically."
+        )
+    }
+
+    func openScreenRecordingPrivacySettings() -> PermissionSettingsOpenResult {
+        openPrivacySettings(
+            candidateURLs: [
+                BugNarratorLinks.screenRecordingPrivacySettings,
+                BugNarratorLinks.securityPrivacySettings,
+                BugNarratorLinks.systemSettingsApp
+            ],
+            failureMessage: "BugNarrator could not open Screen Recording settings automatically."
+        )
+    }
+
+    func openSystemAudioPrivacySettings() -> PermissionSettingsOpenResult {
+        openPrivacySettings(
+            candidateURLs: [
+                BugNarratorLinks.screenRecordingPrivacySettings,
+                BugNarratorLinks.securityPrivacySettings,
+                BugNarratorLinks.systemSettingsApp
+            ],
+            failureMessage: "BugNarrator could not open Screen & System Audio Recording settings automatically."
+        )
+    }
+
+    func validateRuntimeConfiguration() {
+        guard let microphoneUsageDescription = Bundle.main.object(
+            forInfoDictionaryKey: "NSMicrophoneUsageDescription"
+        ) as? String else {
+            permissionsLogger.error(
+                "runtime_configuration_missing_microphone_usage_description",
+                "BugNarrator is missing NSMicrophoneUsageDescription. macOS microphone prompting will not work correctly."
+            )
+            return
+        }
+
+        if microphoneUsageDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            permissionsLogger.error(
+                "runtime_configuration_empty_microphone_usage_description",
+                "BugNarrator has an empty NSMicrophoneUsageDescription. macOS microphone prompting will not work correctly."
+            )
+        }
+    }
+
+    func logLaunchPermissionSnapshot() {
+        permissionsLogger.info(
+            "launch_permission_snapshot",
+            "Captured the initial permission state snapshot for this BugNarrator app copy.",
+            metadata: [
+                "bundle_path": runtimeEnvironment.bundlePath,
+                "is_local_testing_build": runtimeEnvironment.isLocalTestingBuild ? "yes" : "no",
+                "microphone_status": microphonePermissionService.currentStatus().rawValue,
+                "screen_capture_status": screenCapturePermissionService.currentStatus().rawValue
+            ]
+        )
+    }
+
+    private func openPrivacySettings(
+        candidateURLs: [URL],
+        failureMessage: String
+    ) -> PermissionSettingsOpenResult {
+        for url in candidateURLs where urlHandler.open(url) {
+            return .opened(url)
+        }
+
+        return .failed(failureMessage)
+    }
+
+    private func microphoneRecoveryStatus(currentError: AppError?) -> MicrophonePermissionStatus {
+        switch currentError {
+        case .microphonePermissionDenied:
+            return .denied
+        case .microphonePermissionRestricted:
+            return .restricted
+        case .microphoneUnavailable:
+            return .captureSetupFailed
+        default:
+            return microphonePermissionService.currentStatus()
+        }
+    }
+}

--- a/Tests/BugNarratorTests/PermissionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/PermissionRecoveryControllerTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class PermissionRecoveryControllerTests: XCTestCase {
+    func testRefreshRecoversMicrophoneDeniedStateWhenAccessIsGranted() {
+        let harness = PermissionRecoveryControllerHarness(microphonePermissionState: .authorized)
+
+        let outcome = harness.controller.refreshRecoveryState(
+            currentError: .microphonePermissionDenied,
+            statusPhase: .idle
+        )
+
+        XCTAssertEqual(
+            outcome,
+            .recovered(.idle("Microphone access enabled. You can start recording again."))
+        )
+    }
+
+    func testRefreshLeavesMicrophoneErrorWhenAccessIsStillBlocked() {
+        let harness = PermissionRecoveryControllerHarness(microphonePermissionState: .denied)
+
+        let outcome = harness.controller.refreshRecoveryState(
+            currentError: .microphonePermissionDenied,
+            statusPhase: .idle
+        )
+
+        XCTAssertEqual(outcome, .unchanged)
+    }
+
+    func testRefreshDoesNotClearMicrophoneErrorDuringRecording() {
+        let harness = PermissionRecoveryControllerHarness(microphonePermissionState: .authorized)
+
+        let outcome = harness.controller.refreshRecoveryState(
+            currentError: .microphonePermissionDenied,
+            statusPhase: .recording
+        )
+
+        XCTAssertEqual(outcome, .unchanged)
+    }
+
+    func testRefreshRecoversScreenRecordingStateWhileRecording() {
+        let harness = PermissionRecoveryControllerHarness(screenPermissionState: .granted)
+
+        let outcome = harness.controller.refreshRecoveryState(
+            currentError: .screenRecordingPermissionDenied,
+            statusPhase: .recording
+        )
+
+        XCTAssertEqual(
+            outcome,
+            .recovered(.recording("Screen Recording access enabled. You can capture screenshots again."))
+        )
+    }
+
+    func testLocalTestingBuildAddsMicrophoneGuidanceNote() {
+        let harness = PermissionRecoveryControllerHarness(
+            microphonePermissionState: .denied,
+            runtimeEnvironment: AppRuntimeEnvironment(
+                bundlePath: "/tmp/DerivedData/BugNarrator/Build/Products/Debug/BugNarrator.app"
+            )
+        )
+
+        let guidance = harness.controller.microphoneRecoveryGuidance(
+            currentError: .microphonePermissionDenied
+        )
+
+        XCTAssertTrue(guidance.message.contains("System Settings > Privacy & Security > Microphone"))
+        XCTAssertEqual(
+            guidance.localTestingNote,
+            "Local unsigned builds can need microphone approval again if you switch to a different app copy or rebuild into a new path. If System Settings already shows BugNarrator enabled, quit any other BugNarrator copies and retest the same app bundle path or the signed DMG build."
+        )
+    }
+
+    func testOpenMicrophoneSettingsFallsBackToSecuritySettings() {
+        let harness = PermissionRecoveryControllerHarness()
+        harness.urlHandler.openResults = [false, true]
+
+        let result = harness.controller.openMicrophonePrivacySettings()
+
+        XCTAssertEqual(result, .opened(BugNarratorLinks.securityPrivacySettings))
+        XCTAssertEqual(
+            harness.urlHandler.openedURLs,
+            [
+                BugNarratorLinks.microphonePrivacySettings,
+                BugNarratorLinks.securityPrivacySettings
+            ]
+        )
+    }
+
+    func testOpenSystemAudioSettingsReturnsFailureAfterAllCandidatesFail() {
+        let harness = PermissionRecoveryControllerHarness()
+        harness.urlHandler.shouldSucceed = false
+
+        let result = harness.controller.openSystemAudioPrivacySettings()
+
+        XCTAssertEqual(
+            result,
+            .failed("BugNarrator could not open Screen & System Audio Recording settings automatically.")
+        )
+        XCTAssertEqual(
+            harness.urlHandler.openedURLs,
+            [
+                BugNarratorLinks.screenRecordingPrivacySettings,
+                BugNarratorLinks.securityPrivacySettings,
+                BugNarratorLinks.systemSettingsApp
+            ]
+        )
+    }
+}
+
+@MainActor
+private final class PermissionRecoveryControllerHarness {
+    let audioRecorder: MockAudioRecorder
+    let screenCapturePermissionAccess: MockScreenCapturePermissionAccess
+    let urlHandler: MockURLHandler
+    let controller: PermissionRecoveryController
+
+    init(
+        microphonePermissionState: MicrophonePermissionState = .authorized,
+        screenPermissionState: ScreenCapturePermissionState = .granted,
+        runtimeEnvironment: AppRuntimeEnvironment = AppRuntimeEnvironment(bundlePath: "/Applications/BugNarrator.app")
+    ) {
+        let audioRecorder = MockAudioRecorder()
+        audioRecorder.permissionState = microphonePermissionState
+
+        let screenCapturePermissionAccess = MockScreenCapturePermissionAccess()
+        screenCapturePermissionAccess.permissionState = screenPermissionState
+
+        let urlHandler = MockURLHandler()
+
+        self.audioRecorder = audioRecorder
+        self.screenCapturePermissionAccess = screenCapturePermissionAccess
+        self.urlHandler = urlHandler
+        self.controller = PermissionRecoveryController(
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            screenCapturePermissionService: ScreenCapturePermissionService(permissionAccess: screenCapturePermissionAccess),
+            urlHandler: urlHandler,
+            runtimeEnvironment: runtimeEnvironment
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Extract permission recovery decisions, microphone guidance, privacy settings routing, runtime permission config checks, and launch permission snapshots into PermissionRecoveryController.
- Keep AppState's existing SwiftUI-facing methods as a thin compatibility facade.
- Add focused controller tests for recovery outcomes, local testing guidance, and System Settings URL fallback behavior.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/PermissionRecoveryControllerTests
- ./scripts/validate.sh origin/main

Closes #109