### PR TITLE
Extract SupportDataController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
 		109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */; };
+		111A00000000000000000001 /* SupportDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000003 /* SupportDataController.swift */; };
+		111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000004 /* SupportDataControllerTests.swift */; };
 		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
 		105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000004 /* IssueExtractionControllerTests.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
@@ -204,6 +206,8 @@
 		107A00000000000000000004 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
 		109A00000000000000000003 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
 		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
+		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
+		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
@@ -351,6 +355,7 @@
 				67770387C5BA986EEB40382E /* SessionLibraryTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
+				111A00000000000000000004 /* SupportDataControllerTests.swift */,
 				22447E5581818B8003AA49F8 /* TestSupport.swift */,
 				7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */,
 				F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */,
@@ -468,6 +473,7 @@
 				76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */,
 				52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */,
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
+				111A00000000000000000003 /* SupportDataController.swift */,
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
@@ -685,6 +691,7 @@
 				8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
+				111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */,
 				5090A54144CACF59295F137C /* TestSupport.swift in Sources */,
 				683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */,
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
@@ -781,6 +788,7 @@
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
 				6470CFDC78DB57C49819E4A9 /* SupportView.swift in Sources */,
+				111A00000000000000000001 /* SupportDataController.swift in Sources */,
 				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -19,6 +19,7 @@ final class AppState: ObservableObject {
     let issueExtractionController: IssueExtractionController
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
+    let supportDataController: SupportDataController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
@@ -38,10 +39,7 @@ final class AppState: ObservableObject {
     private let artifactsService: any SessionArtifactsManaging
     private let clipboardService: any ClipboardWriting
     private let urlHandler: any URLOpening
-    private let debugBundleExporter: any DebugBundleExporting
-    private let privacyDataExporter: any PrivacyDataExporting
     private let telemetryRecorder: any OperationalTelemetryRecording
-    private let localPrivacyDataManager: any LocalPrivacyDataManaging
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
@@ -275,6 +273,16 @@ final class AppState: ObservableObject {
             urlHandler: urlHandler,
             runtimeEnvironment: runtimeEnvironment
         )
+        self.supportDataController = SupportDataController(
+            settingsStore: settingsStore,
+            transcriptStore: transcriptStore,
+            exportService: exportService,
+            clipboardService: clipboardService,
+            debugBundleExporter: debugBundleExporter,
+            privacyDataExporter: privacyDataExporter,
+            telemetryRecorder: telemetryRecorder,
+            localPrivacyDataManager: localPrivacyDataManager
+        )
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: self.sessionLibrary,
             artifactsService: artifactsService
@@ -292,10 +300,7 @@ final class AppState: ObservableObject {
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
         self.urlHandler = urlHandler
-        self.debugBundleExporter = debugBundleExporter
-        self.privacyDataExporter = privacyDataExporter
         self.telemetryRecorder = telemetryRecorder
-        self.localPrivacyDataManager = localPrivacyDataManager
         self.trackerIntegration = TrackerIntegrationController(
             settingsStore: settingsStore,
             exportService: exportService
@@ -475,11 +480,7 @@ final class AppState: ObservableObject {
     }
 
     var debugInfoSnapshot: DebugInfoSnapshot {
-        DebugInfoSnapshot(
-            metadata: BugNarratorMetadata(),
-            settingsStore: settingsStore,
-            sessionID: currentDebugSessionID
-        )
+        supportDataController.debugInfoSnapshot(sessionID: currentDebugSessionID)
     }
 
     var storageRecoveryMessage: String? {
@@ -811,40 +812,20 @@ final class AppState: ObservableObject {
     }
 
     func copyDebugInfo() {
-        let snapshot = debugInfoSnapshot
-        clipboardService.copy(snapshot.clipboardText)
-        settingsLogger.info(
-            "debug_info_copied",
-            "Copied debug info to the clipboard.",
-            metadata: ["session_id": snapshot.sessionID?.uuidString ?? "none"]
-        )
-        setStatus(.success("Debug info copied to the clipboard."))
+        let result = supportDataController.copyDebugInfo(sessionID: currentDebugSessionID)
+        setStatus(.success(result.statusMessage))
     }
 
     func exportDebugBundle() async {
-        let snapshot = await makeDebugBundleSnapshot()
-
         do {
-            guard let bundleURL = try debugBundleExporter.export(snapshot: snapshot) else {
+            guard let completion = try await supportDataController.exportDebugBundle(
+                sessionMetadata: currentDebugSessionMetadata()
+            ) else {
                 return
             }
 
-            settingsLogger.info(
-                "debug_bundle_exported",
-                "Exported a local debug bundle.",
-                metadata: [
-                    "session_id": snapshot.sessionMetadata.sessionID?.uuidString ?? "none",
-                    "debug_mode": snapshot.debugInfo.debugModeEnabled ? "enabled" : "disabled"
-                ]
-            )
-            NSWorkspace.shared.activateFileViewerSelecting([bundleURL])
-            setStatus(
-                .success(
-                    settingsStore.debugMode
-                        ? "Debug bundle exported with verbose diagnostics."
-                        : "Debug bundle exported."
-                )
-            )
+            NSWorkspace.shared.activateFileViewerSelecting([completion.bundleURL])
+            setStatus(.success(completion.statusMessage))
         } catch {
             presentError(
                 error,
@@ -856,26 +837,14 @@ final class AppState: ObservableObject {
 
     func exportPrivacyData() async {
         do {
-            let diagnostics = await makePrivacyDataExportDiagnosticsSnapshot()
-            guard let bundleURL = try privacyDataExporter.export(
-                sessions: transcriptStore.allStoredSessions(),
-                settings: makePrivacyDataExportSettingsSnapshot(),
-                diagnostics: diagnostics
+            guard let completion = try await supportDataController.exportPrivacyData(
+                exportHistoryFallback: exportHistory
             ) else {
                 return
             }
 
-            sessionLibraryLogger.info(
-                "privacy_data_exported",
-                "Exported a local privacy data bundle.",
-                metadata: ["session_count": "\(transcriptStore.sessionCount)"]
-            )
-            telemetryRecorder.record(
-                .privacyDataExported,
-                metadata: ["session_count": "\(transcriptStore.sessionCount)"]
-            )
-            NSWorkspace.shared.activateFileViewerSelecting([bundleURL])
-            setStatus(.success("Data export created. API keys and tracker credentials were not included."))
+            NSWorkspace.shared.activateFileViewerSelecting([completion.bundleURL])
+            setStatus(.success(completion.statusMessage))
         } catch {
             presentError(
                 error,
@@ -1929,32 +1898,8 @@ final class AppState: ObservableObject {
         sessionLibrary.sessionSnapshot(with: sessionID)
     }
 
-    private func makePrivacyDataExportSettingsSnapshot() -> PrivacyDataExportSettingsSnapshot {
-        PrivacyDataExportSettingsSnapshot(settingsStore: settingsStore)
-    }
-
-    private func makePrivacyDataExportDiagnosticsSnapshot() async -> PrivacyDataExportDiagnosticsSnapshot {
-        let debugInfo = debugInfoSnapshot
-        let recentLogText = await BugNarratorDiagnostics.store.recentLogText(limit: 200)
-        let receipts = (try? await exportService.exportHistory()) ?? exportHistory
-
-        return PrivacyDataExportDiagnosticsSnapshot(
-            appName: debugInfo.appName,
-            versionDescription: debugInfo.versionDescription,
-            macOSVersion: debugInfo.macOSVersion,
-            architecture: debugInfo.architecture,
-            activeTranscriptionModel: debugInfo.activeTranscriptionModel,
-            issueExtractionModel: debugInfo.issueExtractionModel,
-            logLevel: debugInfo.logLevel,
-            debugModeEnabled: debugInfo.debugModeEnabled,
-            recentTelemetryEvents: telemetryRecorder.recentEvents(limit: 200),
-            recentDiagnosticsLog: recentLogText,
-            exportHistory: receipts
-        )
-    }
-
     private func clearLocalPrivacyArtifacts() async {
-        await localPrivacyDataManager.clearLocalSupportArtifacts()
+        await supportDataController.clearLocalPrivacyArtifacts()
         await refreshExportHistory()
     }
 
@@ -2131,14 +2076,6 @@ final class AppState: ObservableObject {
 
     private var microphoneRecoveryGuidanceDetails: MicrophoneRecoveryGuidance {
         permissionRecoveryController.microphoneRecoveryGuidance(currentError: currentError)
-    }
-
-    private func makeDebugBundleSnapshot() async -> DebugBundleSnapshot {
-        DebugBundleSnapshot(
-            debugInfo: debugInfoSnapshot,
-            sessionMetadata: currentDebugSessionMetadata(),
-            recentLogText: await BugNarratorDiagnostics.recentLogText()
-        )
     }
 
     private func validateRuntimeConfiguration() {

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+struct DebugInfoCopyResult {
+    let snapshot: DebugInfoSnapshot
+    let statusMessage: String
+}
+
+struct DebugBundleExportCompletion {
+    let bundleURL: URL
+    let statusMessage: String
+}
+
+struct PrivacyDataExportCompletion {
+    let bundleURL: URL
+    let statusMessage: String
+}
+
+@MainActor
+final class SupportDataController {
+    private let settingsStore: SettingsStore
+    private let transcriptStore: TranscriptStore
+    private let exportService: any IssueExporting
+    private let clipboardService: any ClipboardWriting
+    private let debugBundleExporter: any DebugBundleExporting
+    private let privacyDataExporter: any PrivacyDataExporting
+    private let telemetryRecorder: any OperationalTelemetryRecording
+    private let localPrivacyDataManager: any LocalPrivacyDataManaging
+    private let settingsLogger = DiagnosticsLogger(category: .settings)
+    private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
+
+    init(
+        settingsStore: SettingsStore,
+        transcriptStore: TranscriptStore,
+        exportService: any IssueExporting,
+        clipboardService: any ClipboardWriting,
+        debugBundleExporter: any DebugBundleExporting,
+        privacyDataExporter: any PrivacyDataExporting,
+        telemetryRecorder: any OperationalTelemetryRecording,
+        localPrivacyDataManager: any LocalPrivacyDataManaging
+    ) {
+        self.settingsStore = settingsStore
+        self.transcriptStore = transcriptStore
+        self.exportService = exportService
+        self.clipboardService = clipboardService
+        self.debugBundleExporter = debugBundleExporter
+        self.privacyDataExporter = privacyDataExporter
+        self.telemetryRecorder = telemetryRecorder
+        self.localPrivacyDataManager = localPrivacyDataManager
+    }
+
+    func debugInfoSnapshot(sessionID: UUID?) -> DebugInfoSnapshot {
+        DebugInfoSnapshot(
+            metadata: BugNarratorMetadata(),
+            settingsStore: settingsStore,
+            sessionID: sessionID
+        )
+    }
+
+    func copyDebugInfo(sessionID: UUID?) -> DebugInfoCopyResult {
+        let snapshot = debugInfoSnapshot(sessionID: sessionID)
+        clipboardService.copy(snapshot.clipboardText)
+        settingsLogger.info(
+            "debug_info_copied",
+            "Copied debug info to the clipboard.",
+            metadata: ["session_id": snapshot.sessionID?.uuidString ?? "none"]
+        )
+        return DebugInfoCopyResult(
+            snapshot: snapshot,
+            statusMessage: "Debug info copied to the clipboard."
+        )
+    }
+
+    func exportDebugBundle(
+        sessionMetadata: DebugSessionMetadata
+    ) async throws -> DebugBundleExportCompletion? {
+        let snapshot = DebugBundleSnapshot(
+            debugInfo: debugInfoSnapshot(sessionID: sessionMetadata.sessionID),
+            sessionMetadata: sessionMetadata,
+            recentLogText: await BugNarratorDiagnostics.recentLogText()
+        )
+
+        guard let bundleURL = try debugBundleExporter.export(snapshot: snapshot) else {
+            return nil
+        }
+
+        settingsLogger.info(
+            "debug_bundle_exported",
+            "Exported a local debug bundle.",
+            metadata: [
+                "session_id": snapshot.sessionMetadata.sessionID?.uuidString ?? "none",
+                "debug_mode": snapshot.debugInfo.debugModeEnabled ? "enabled" : "disabled"
+            ]
+        )
+
+        return DebugBundleExportCompletion(
+            bundleURL: bundleURL,
+            statusMessage: settingsStore.debugMode
+                ? "Debug bundle exported with verbose diagnostics."
+                : "Debug bundle exported."
+        )
+    }
+
+    func exportPrivacyData(
+        exportHistoryFallback: [ExportReceipt]
+    ) async throws -> PrivacyDataExportCompletion? {
+        let diagnostics = await makePrivacyDataExportDiagnosticsSnapshot(
+            exportHistoryFallback: exportHistoryFallback
+        )
+        let sessions = transcriptStore.allStoredSessions()
+
+        guard let bundleURL = try privacyDataExporter.export(
+            sessions: sessions,
+            settings: makePrivacyDataExportSettingsSnapshot(),
+            diagnostics: diagnostics
+        ) else {
+            return nil
+        }
+
+        let sessionCount = transcriptStore.sessionCount
+        sessionLibraryLogger.info(
+            "privacy_data_exported",
+            "Exported a local privacy data bundle.",
+            metadata: ["session_count": "\(sessionCount)"]
+        )
+        telemetryRecorder.record(
+            .privacyDataExported,
+            metadata: ["session_count": "\(sessionCount)"]
+        )
+
+        return PrivacyDataExportCompletion(
+            bundleURL: bundleURL,
+            statusMessage: "Data export created. API keys and tracker credentials were not included."
+        )
+    }
+
+    func clearLocalPrivacyArtifacts() async {
+        await localPrivacyDataManager.clearLocalSupportArtifacts()
+    }
+
+    private func makePrivacyDataExportSettingsSnapshot() -> PrivacyDataExportSettingsSnapshot {
+        PrivacyDataExportSettingsSnapshot(settingsStore: settingsStore)
+    }
+
+    private func makePrivacyDataExportDiagnosticsSnapshot(
+        exportHistoryFallback: [ExportReceipt]
+    ) async -> PrivacyDataExportDiagnosticsSnapshot {
+        let debugInfo = debugInfoSnapshot(sessionID: nil)
+        let recentLogText = await BugNarratorDiagnostics.store.recentLogText(limit: 200)
+        let receipts = (try? await exportService.exportHistory()) ?? exportHistoryFallback
+
+        return PrivacyDataExportDiagnosticsSnapshot(
+            appName: debugInfo.appName,
+            versionDescription: debugInfo.versionDescription,
+            macOSVersion: debugInfo.macOSVersion,
+            architecture: debugInfo.architecture,
+            activeTranscriptionModel: debugInfo.activeTranscriptionModel,
+            issueExtractionModel: debugInfo.issueExtractionModel,
+            logLevel: debugInfo.logLevel,
+            debugModeEnabled: debugInfo.debugModeEnabled,
+            recentTelemetryEvents: telemetryRecorder.recentEvents(limit: 200),
+            recentDiagnosticsLog: recentLogText,
+            exportHistory: receipts
+        )
+    }
+}

--- a/Tests/BugNarratorTests/SupportDataControllerTests.swift
+++ b/Tests/BugNarratorTests/SupportDataControllerTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class SupportDataControllerTests: XCTestCase {
+    func testCopyDebugInfoCopiesSnapshotToClipboard() {
+        let harness = SupportDataControllerHarness()
+        defer { harness.cleanup() }
+        let sessionID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+
+        let result = harness.controller.copyDebugInfo(sessionID: sessionID)
+
+        XCTAssertEqual(result.snapshot.sessionID, sessionID)
+        XCTAssertEqual(result.statusMessage, "Debug info copied to the clipboard.")
+        XCTAssertEqual(harness.clipboardService.copiedStrings.count, 1)
+        XCTAssertTrue(harness.clipboardService.copiedStrings[0].contains("Session ID: \(sessionID.uuidString)"))
+        XCTAssertFalse(harness.clipboardService.copiedStrings[0].contains(harness.settingsStore.trimmedAPIKey))
+    }
+
+    func testExportDebugBundleBuildsSnapshotAndReturnsVerboseStatusWhenDebugModeIsEnabled() async throws {
+        let bundleURL = URL(fileURLWithPath: "/tmp/bugnarrator-debug-bundle")
+        let harness = SupportDataControllerHarness(debugMode: true)
+        defer { harness.cleanup() }
+        harness.debugBundleExporter.exportResult = .success(bundleURL)
+
+        let metadata = DebugSessionMetadata.make(
+            currentTranscript: nil,
+            displayedTranscript: nil,
+            activeRecordingSession: nil,
+            status: .idle(),
+            currentError: nil
+        )
+
+        let result = try await harness.controller.exportDebugBundle(sessionMetadata: metadata)
+
+        XCTAssertEqual(result?.bundleURL, bundleURL)
+        XCTAssertEqual(result?.statusMessage, "Debug bundle exported with verbose diagnostics.")
+        XCTAssertEqual(harness.debugBundleExporter.exportedSnapshots.count, 1)
+        XCTAssertEqual(harness.debugBundleExporter.exportedSnapshots[0].sessionMetadata, metadata)
+        XCTAssertTrue(harness.debugBundleExporter.exportedSnapshots[0].debugInfo.debugModeEnabled)
+    }
+
+    func testExportPrivacyDataIncludesSessionsDiagnosticsAndTelemetry() async throws {
+        let bundleURL = URL(fileURLWithPath: "/tmp/bugnarrator-data-export")
+        let exportService = MockExportService()
+        let harness = SupportDataControllerHarness(exportService: exportService)
+        defer { harness.cleanup() }
+        harness.privacyDataExporter.exportResult = .success(bundleURL)
+        harness.telemetryRecorder.recentEventsResult = [
+            OperationalTelemetryEvent(name: "recording_started", metadata: ["source": "test"])
+        ]
+        let session = harness.makeSession()
+        try harness.transcriptStore.add(session)
+
+        let receipt = ExportReceipt(
+            fingerprint: "fixture-fingerprint",
+            sourceIssueID: UUID(),
+            destination: .github,
+            targetIdentity: "acme/bugnarrator",
+            state: .succeeded,
+            remoteIdentifier: "42",
+            remoteURL: URL(string: "https://github.com/acme/bugnarrator/issues/42"),
+            updatedAt: Date()
+        )
+        await exportService.setExportReceipts([receipt])
+
+        let result = try await harness.controller.exportPrivacyData(exportHistoryFallback: [])
+
+        XCTAssertEqual(result?.bundleURL, bundleURL)
+        XCTAssertEqual(
+            result?.statusMessage,
+            "Data export created. API keys and tracker credentials were not included."
+        )
+        XCTAssertEqual(harness.privacyDataExporter.exportRequests.count, 1)
+        XCTAssertEqual(harness.privacyDataExporter.exportRequests[0].sessions.map(\.id), [session.id])
+        XCTAssertEqual(harness.privacyDataExporter.exportRequests[0].diagnostics.recentTelemetryEvents.count, 1)
+        XCTAssertEqual(harness.privacyDataExporter.exportRequests[0].diagnostics.exportHistory, [receipt])
+        XCTAssertEqual(harness.telemetryRecorder.recentEventsLimits, [200])
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.last?.name, TelemetryEvent.privacyDataExported.rawValue)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.last?.metadata["session_count"], "1")
+    }
+
+    func testExportPrivacyDataUsesFallbackExportHistoryWhenRefreshFails() async throws {
+        let harness = SupportDataControllerHarness(
+            exportService: FailingExportHistoryService()
+        )
+        defer { harness.cleanup() }
+        harness.privacyDataExporter.exportResult = .success(URL(fileURLWithPath: "/tmp/export"))
+        let fallbackReceipt = ExportReceipt(
+            fingerprint: "fallback",
+            sourceIssueID: UUID(),
+            destination: .jira,
+            targetIdentity: "UCAP",
+            state: .pending,
+            remoteIdentifier: nil,
+            remoteURL: nil,
+            updatedAt: Date()
+        )
+
+        _ = try await harness.controller.exportPrivacyData(exportHistoryFallback: [fallbackReceipt])
+
+        XCTAssertEqual(harness.privacyDataExporter.exportRequests[0].diagnostics.exportHistory, [fallbackReceipt])
+    }
+
+    func testClearLocalPrivacyArtifactsUsesInjectedManager() async {
+        let harness = SupportDataControllerHarness()
+        defer { harness.cleanup() }
+
+        await harness.controller.clearLocalPrivacyArtifacts()
+
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
+    }
+}
+
+@MainActor
+private final class SupportDataControllerHarness {
+    let rootDirectoryURL: URL
+    let defaultsSuiteName: String
+    let defaults: UserDefaults
+    let keychainService: MockKeychainService
+    let settingsStore: SettingsStore
+    let transcriptStore: TranscriptStore
+    let exportService: any IssueExporting
+    let clipboardService: MockClipboardService
+    let debugBundleExporter: MockDebugBundleExporter
+    let privacyDataExporter: MockPrivacyDataExporter
+    let telemetryRecorder: MockOperationalTelemetryRecorder
+    let localPrivacyDataManager: MockLocalPrivacyDataManager
+    let controller: SupportDataController
+
+    init(
+        debugMode: Bool = false,
+        exportService: any IssueExporting = MockExportService()
+    ) {
+        let fileManager = FileManager.default
+        let rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("SupportDataControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try? fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        let defaultsSuiteName = "SupportDataControllerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+
+        let keychainService = MockKeychainService()
+        let settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychainService,
+            launchAtLoginService: MockLaunchAtLoginService()
+        )
+        settingsStore.apiKey = "test-api-key"
+        settingsStore.debugMode = debugMode
+
+        let transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        let clipboardService = MockClipboardService()
+        let debugBundleExporter = MockDebugBundleExporter()
+        let privacyDataExporter = MockPrivacyDataExporter()
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let localPrivacyDataManager = MockLocalPrivacyDataManager()
+
+        self.rootDirectoryURL = rootDirectoryURL
+        self.defaultsSuiteName = defaultsSuiteName
+        self.defaults = defaults
+        self.keychainService = keychainService
+        self.settingsStore = settingsStore
+        self.transcriptStore = transcriptStore
+        self.exportService = exportService
+        self.clipboardService = clipboardService
+        self.debugBundleExporter = debugBundleExporter
+        self.privacyDataExporter = privacyDataExporter
+        self.telemetryRecorder = telemetryRecorder
+        self.localPrivacyDataManager = localPrivacyDataManager
+        self.controller = SupportDataController(
+            settingsStore: settingsStore,
+            transcriptStore: transcriptStore,
+            exportService: exportService,
+            clipboardService: clipboardService,
+            debugBundleExporter: debugBundleExporter,
+            privacyDataExporter: privacyDataExporter,
+            telemetryRecorder: telemetryRecorder,
+            localPrivacyDataManager: localPrivacyDataManager
+        )
+    }
+
+    func makeSession(id: UUID = UUID()) -> TranscriptSession {
+        TranscriptSession(
+            id: id,
+            createdAt: Date(),
+            transcript: "A saved transcript.",
+            duration: 12,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+}
+
+private actor FailingExportHistoryService: IssueExporting {
+    func fetchGitHubRepositories(token: String) async throws -> [GitHubRepositoryOption] { [] }
+
+    func fetchJiraProjects(_ configuration: JiraConnectionConfiguration) async throws -> [JiraProjectOption] { [] }
+
+    func fetchJiraIssueTypes(
+        for projectKey: String,
+        projectID: String?,
+        configuration: JiraConnectionConfiguration
+    ) async throws -> [JiraIssueTypeOption] {
+        []
+    }
+
+    func validateGitHubConfiguration(_ configuration: GitHubExportConfiguration) async throws {}
+
+    func validateJiraConfiguration(_ configuration: JiraExportConfiguration) async throws {}
+
+    func prepareGitHubExportReview(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: GitHubExportConfiguration,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExportReview {
+        IssueExportReview(destination: .github, sessionID: session.id, items: [])
+    }
+
+    func prepareJiraExportReview(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: JiraExportConfiguration,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExportReview {
+        IssueExportReview(destination: .jira, sessionID: session.id, items: [])
+    }
+
+    func exportToGitHub(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: GitHubExportConfiguration
+    ) async throws -> [ExportResult] {
+        []
+    }
+
+    func exportToJira(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: JiraExportConfiguration
+    ) async throws -> [ExportResult] {
+        []
+    }
+
+    func exportHistory() async throws -> [ExportReceipt] {
+        throw NSError(domain: "SupportDataControllerTests", code: 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract debug info copy, debug bundle export, privacy data export diagnostics, and local privacy artifact cleanup into SupportDataController.
- Keep AppState as the status/Finder-reveal facade while removing direct debug/privacy exporter ownership from AppState.
- Add focused SupportDataController tests for debug snapshots, export results, diagnostics payloads, fallback export history, and cleanup delegation.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SupportDataControllerTests
- ./scripts/validate.sh origin/main

Closes #111