### PR TITLE
Extract ExportHistoryController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		107A00000000000000000001 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000003 /* IssueExportController.swift */; };
 		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
+		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
+		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
 		109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */; };
 		111A00000000000000000001 /* SupportDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000003 /* SupportDataController.swift */; };
@@ -204,6 +206,8 @@
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
 		107A00000000000000000003 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
 		107A00000000000000000004 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
+		113A00000000000000000003 /* ExportHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryController.swift; sourceTree = "<group>"; };
+		113A00000000000000000004 /* ExportHistoryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryControllerTests.swift; sourceTree = "<group>"; };
 		109A00000000000000000003 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
 		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -326,6 +330,7 @@
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
+				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
 				107A00000000000000000004 /* IssueExportControllerTests.swift */,
 				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
@@ -445,6 +450,7 @@
 				2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */,
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
+				113A00000000000000000003 /* ExportHistoryController.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
 				46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */,
@@ -662,6 +668,7 @@
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
+				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
 				107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */,
 				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,
@@ -738,6 +745,7 @@
 				4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */,
 				A73F5969DB4A2C04BC83BF45 /* ExportReceiptStore.swift in Sources */,
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
+				113A00000000000000000001 /* ExportHistoryController.swift in Sources */,
 				9E2FEC30CC71E38CBD59106C /* ExtractedIssue.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,
 				6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,7 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published private(set) var exportHistory: [ExportReceipt] = []
     @Published private(set) var recoveredRecordingImportCount = 0
 
     let settingsStore: SettingsStore
@@ -16,6 +15,7 @@ final class AppState: ObservableObject {
     let presentationState: AppPresentationState
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
+    let exportHistoryController: ExportHistoryController
     let issueExtractionController: IssueExtractionController
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
@@ -34,7 +34,6 @@ final class AppState: ObservableObject {
 
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
-    private let exportService: any IssueExporting
     private let recoveredRecordingImporter: any RecoveredRecordingImporting
     private let artifactsService: any SessionArtifactsManaging
     private let clipboardService: any ClipboardWriting
@@ -63,7 +62,6 @@ final class AppState: ObservableObject {
         case diagnosticsExport = "diagnostics_export"
         case privacyExport = "privacy_export"
         case export
-        case exportHistory = "export_history"
         case sessionLibrary = "session_library"
         case recoveredRecordingImport = "recovered_recording_import"
     }
@@ -104,6 +102,10 @@ final class AppState: ObservableObject {
 
     var currentError: AppError? {
         presentationState.currentError
+    }
+
+    var exportHistory: [ExportReceipt] {
+        exportHistoryController.exportHistory
     }
 
     var exportDestinationInProgress: ExportDestination? {
@@ -258,6 +260,7 @@ final class AppState: ObservableObject {
             artifactsService: artifactsService,
             clipboardService: clipboardService
         )
+        self.exportHistoryController = ExportHistoryController(exportService: exportService)
         self.issueExtractionController = IssueExtractionController(
             sessionLibrary: self.sessionLibrary,
             issueExtractionService: issueExtractionService
@@ -295,7 +298,6 @@ final class AppState: ObservableObject {
         )
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
-        self.exportService = exportService
         self.recoveredRecordingImporter = recoveredRecordingImporter
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
@@ -351,6 +353,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         sessionLibrary.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        exportHistoryController.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -915,21 +923,7 @@ final class AppState: ObservableObject {
     }
 
     func refreshExportHistory() async {
-        do {
-            exportHistory = try await exportService.exportHistory()
-        } catch {
-            let normalizedError = normalizeError(
-                error,
-                operation: .exportHistory,
-                fallback: { .exportFailure($0) }
-            )
-            exportLogger.warning(
-                "export_history_refresh_failed",
-                normalizedError.appError.userMessage,
-                metadata: appErrorMetadata(for: normalizedError, context: "export_history_refresh_failed")
-            )
-            exportHistory = []
-        }
+        await exportHistoryController.refreshExportHistory()
     }
 
     func copyDisplayedTranscript() {

--- a/Sources/BugNarrator/Services/ExportHistoryController.swift
+++ b/Sources/BugNarrator/Services/ExportHistoryController.swift
@@ -1,0 +1,35 @@
+import Combine
+import Foundation
+
+@MainActor
+final class ExportHistoryController: ObservableObject {
+    @Published private(set) var exportHistory: [ExportReceipt]
+
+    private let exportService: any IssueExporting
+    private let exportLogger = DiagnosticsLogger(category: .export)
+
+    init(
+        exportService: any IssueExporting,
+        exportHistory: [ExportReceipt] = []
+    ) {
+        self.exportService = exportService
+        self.exportHistory = exportHistory
+    }
+
+    func refreshExportHistory() async {
+        do {
+            exportHistory = try await exportService.exportHistory()
+        } catch {
+            let appError = (error as? AppError) ?? .exportFailure(error.localizedDescription)
+            exportLogger.warning(
+                "export_history_refresh_failed",
+                appError.userMessage,
+                metadata: [
+                    "context": "export_history_refresh_failed",
+                    "operation": "export_history"
+                ]
+            )
+            exportHistory = []
+        }
+    }
+}

--- a/Tests/BugNarratorTests/ExportHistoryControllerTests.swift
+++ b/Tests/BugNarratorTests/ExportHistoryControllerTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class ExportHistoryControllerTests: XCTestCase {
+    func testRefreshLoadsReceiptsFromExportService() async {
+        let exportService = MockExportService()
+        let controller = ExportHistoryController(exportService: exportService)
+        let receipt = makeReceipt()
+        await exportService.setExportReceipts([receipt])
+
+        await controller.refreshExportHistory()
+
+        XCTAssertEqual(controller.exportHistory, [receipt])
+    }
+
+    func testRefreshClearsStaleReceiptsWhenExportServiceFails() async {
+        let staleReceipt = makeReceipt(fingerprint: "stale")
+        let controller = ExportHistoryController(
+            exportService: FailingExportHistoryService(),
+            exportHistory: [staleReceipt]
+        )
+
+        await controller.refreshExportHistory()
+
+        XCTAssertEqual(controller.exportHistory, [])
+    }
+
+    private func makeReceipt(fingerprint: String = "github:fixture") -> ExportReceipt {
+        ExportReceipt(
+            fingerprint: fingerprint,
+            sourceIssueID: UUID(),
+            destination: .github,
+            targetIdentity: "deffenda/bug-narrator",
+            state: .succeeded,
+            remoteIdentifier: "#42",
+            remoteURL: URL(string: "https://github.com/deffenda/bug-narrator/issues/42"),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+}
+
+private actor FailingExportHistoryService: IssueExporting {
+    func fetchGitHubRepositories(token: String) async throws -> [GitHubRepositoryOption] { [] }
+
+    func fetchJiraProjects(_ configuration: JiraConnectionConfiguration) async throws -> [JiraProjectOption] { [] }
+
+    func fetchJiraIssueTypes(
+        for projectKey: String,
+        projectID: String?,
+        configuration: JiraConnectionConfiguration
+    ) async throws -> [JiraIssueTypeOption] {
+        []
+    }
+
+    func validateGitHubConfiguration(_ configuration: GitHubExportConfiguration) async throws {}
+
+    func validateJiraConfiguration(_ configuration: JiraExportConfiguration) async throws {}
+
+    func prepareGitHubExportReview(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: GitHubExportConfiguration,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExportReview {
+        IssueExportReview(destination: .github, sessionID: session.id, items: [])
+    }
+
+    func prepareJiraExportReview(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: JiraExportConfiguration,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExportReview {
+        IssueExportReview(destination: .jira, sessionID: session.id, items: [])
+    }
+
+    func exportToGitHub(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: GitHubExportConfiguration
+    ) async throws -> [ExportResult] {
+        []
+    }
+
+    func exportToJira(
+        issues: [ExtractedIssue],
+        session: TranscriptSession,
+        configuration: JiraExportConfiguration
+    ) async throws -> [ExportResult] {
+        []
+    }
+
+    func exportHistory() async throws -> [ExportReceipt] {
+        throw NSError(domain: "ExportHistoryControllerTests", code: 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Extract export-history published state and refresh behavior into ExportHistoryController.
- Keep AppState exposing exportHistory and refreshExportHistory() while forwarding object changes from the new controller.
- Add controller tests for successful refresh and failure clearing of stale receipts.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/ExportHistoryControllerTests
- ./scripts/validate.sh origin/main

Closes #113