### PR TITLE
Extract RecoveredRecordingImportController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
 		109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */; };
+		115A00000000000000000001 /* RecoveredRecordingImportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115A00000000000000000003 /* RecoveredRecordingImportController.swift */; };
+		115A00000000000000000002 /* RecoveredRecordingImportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */; };
 		111A00000000000000000001 /* SupportDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000003 /* SupportDataController.swift */; };
 		111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000004 /* SupportDataControllerTests.swift */; };
 		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
@@ -210,6 +212,8 @@
 		113A00000000000000000004 /* ExportHistoryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryControllerTests.swift; sourceTree = "<group>"; };
 		109A00000000000000000003 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
 		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
+		115A00000000000000000003 /* RecoveredRecordingImportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImportController.swift; sourceTree = "<group>"; };
+		115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImportControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
 		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
@@ -346,6 +350,7 @@
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */,
+				115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */,
 				2DE808CBBBE2F1EEE4FF5BEC /* RecoveredRecordingImporterTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
 				4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */,
@@ -468,6 +473,7 @@
 				109A00000000000000000003 /* PermissionRecoveryController.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
+				115A00000000000000000003 /* RecoveredRecordingImportController.swift */,
 				BC5286F2E07F27DFA63F4B76 /* RecoveredRecordingImporter.swift */,
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
@@ -684,6 +690,7 @@
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */,
+				115A00000000000000000002 /* RecoveredRecordingImportControllerTests.swift in Sources */,
 				62313F663336184217D1020B /* RecoveredRecordingImporterTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
 				79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */,
@@ -778,6 +785,7 @@
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				A31A0BF8A4486E52DEA38F29 /* RecoveredRecordingImporter.swift in Sources */,
+				115A00000000000000000001 /* RecoveredRecordingImportController.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -5,7 +5,6 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     @Published var showDiscardConfirmation = false
-    @Published private(set) var recoveredRecordingImportCount = 0
 
     let settingsStore: SettingsStore
     let transcriptStore: TranscriptStore
@@ -16,6 +15,7 @@ final class AppState: ObservableObject {
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
     let exportHistoryController: ExportHistoryController
+    let recoveredRecordingImportController: RecoveredRecordingImportController
     let issueExtractionController: IssueExtractionController
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
@@ -34,7 +34,6 @@ final class AppState: ObservableObject {
 
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
-    private let recoveredRecordingImporter: any RecoveredRecordingImporting
     private let artifactsService: any SessionArtifactsManaging
     private let clipboardService: any ClipboardWriting
     private let urlHandler: any URLOpening
@@ -102,6 +101,10 @@ final class AppState: ObservableObject {
 
     var currentError: AppError? {
         presentationState.currentError
+    }
+
+    var recoveredRecordingImportCount: Int {
+        recoveredRecordingImportController.recoveredRecordingImportCount
     }
 
     var exportHistory: [ExportReceipt] {
@@ -261,6 +264,12 @@ final class AppState: ObservableObject {
             clipboardService: clipboardService
         )
         self.exportHistoryController = ExportHistoryController(exportService: exportService)
+        self.recoveredRecordingImportController = RecoveredRecordingImportController(
+            transcriptStore: transcriptStore,
+            sessionLibrary: self.sessionLibrary,
+            recoveredRecordingImporter: recoveredRecordingImporter,
+            artifactsService: artifactsService
+        )
         self.issueExtractionController = IssueExtractionController(
             sessionLibrary: self.sessionLibrary,
             issueExtractionService: issueExtractionService
@@ -298,7 +307,6 @@ final class AppState: ObservableObject {
         )
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
-        self.recoveredRecordingImporter = recoveredRecordingImporter
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
         self.urlHandler = urlHandler
@@ -359,6 +367,12 @@ final class AppState: ObservableObject {
             .store(in: &cancellables)
 
         exportHistoryController.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
+        recoveredRecordingImportController.objectWillChange
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -2091,28 +2105,12 @@ final class AppState: ObservableObject {
 
     private func importRecoveredRecordingsAtLaunch() {
         do {
-            let importedCount = try recoveredRecordingImporter.importRecoverableRecordings(
-                into: transcriptStore,
-                artifactsService: artifactsService
-            )
-            recoveredRecordingImportCount = importedCount
-
-            guard importedCount > 0 else {
+            let outcome = try recoveredRecordingImportController.importRecoveredRecordingsAtLaunch()
+            guard case .imported(let message, let error) = outcome else {
                 return
             }
 
-            sessionLibrary.selectLatestPendingTranscriptionSession()
-            sessionLibraryLogger.warning(
-                "recovered_recordings_imported",
-                "Imported recovered recordings as retryable transcript sessions.",
-                metadata: ["imported_count": "\(importedCount)"]
-            )
-            setStatus(
-                .error(importedCount == 1
-                    ? "Recovered 1 recording after an unexpected quit. Open Session Library to transcribe it."
-                    : "Recovered \(importedCount) recordings after an unexpected quit. Open Session Library to transcribe them."),
-                error: .transcriptionFailure("Recovered recordings are waiting for transcription.")
-            )
+            setStatus(.error(message), error: error)
             showTranscriptWindow?()
         } catch {
             let normalizedError = normalizeError(

--- a/Sources/BugNarrator/Services/RecoveredRecordingImportController.swift
+++ b/Sources/BugNarrator/Services/RecoveredRecordingImportController.swift
@@ -1,0 +1,57 @@
+import Combine
+import Foundation
+
+enum RecoveredRecordingImportOutcome: Equatable {
+    case none
+    case imported(message: String, error: AppError)
+}
+
+@MainActor
+final class RecoveredRecordingImportController: ObservableObject {
+    @Published private(set) var recoveredRecordingImportCount = 0
+
+    private let transcriptStore: TranscriptStore
+    private let sessionLibrary: SessionLibraryController
+    private let recoveredRecordingImporter: any RecoveredRecordingImporting
+    private let artifactsService: any SessionArtifactsManaging
+    private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
+
+    init(
+        transcriptStore: TranscriptStore,
+        sessionLibrary: SessionLibraryController,
+        recoveredRecordingImporter: any RecoveredRecordingImporting,
+        artifactsService: any SessionArtifactsManaging
+    ) {
+        self.transcriptStore = transcriptStore
+        self.sessionLibrary = sessionLibrary
+        self.recoveredRecordingImporter = recoveredRecordingImporter
+        self.artifactsService = artifactsService
+    }
+
+    func importRecoveredRecordingsAtLaunch() throws -> RecoveredRecordingImportOutcome {
+        let importedCount = try recoveredRecordingImporter.importRecoverableRecordings(
+            into: transcriptStore,
+            artifactsService: artifactsService
+        )
+        recoveredRecordingImportCount = importedCount
+
+        guard importedCount > 0 else {
+            return .none
+        }
+
+        sessionLibrary.selectLatestPendingTranscriptionSession()
+        sessionLibraryLogger.warning(
+            "recovered_recordings_imported",
+            "Imported recovered recordings as retryable transcript sessions.",
+            metadata: ["imported_count": "\(importedCount)"]
+        )
+
+        let message = importedCount == 1
+            ? "Recovered 1 recording after an unexpected quit. Open Session Library to transcribe it."
+            : "Recovered \(importedCount) recordings after an unexpected quit. Open Session Library to transcribe them."
+        return .imported(
+            message: message,
+            error: .transcriptionFailure("Recovered recordings are waiting for transcription.")
+        )
+    }
+}

--- a/Tests/BugNarratorTests/RecoveredRecordingImportControllerTests.swift
+++ b/Tests/BugNarratorTests/RecoveredRecordingImportControllerTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class RecoveredRecordingImportControllerTests: XCTestCase {
+    func testImportReturnsNoneWhenNoRecordingsAreRecovered() throws {
+        let harness = RecoveredRecordingImportControllerHarness(importResult: .success(0))
+        defer { harness.cleanup() }
+
+        let outcome = try harness.controller.importRecoveredRecordingsAtLaunch()
+
+        XCTAssertEqual(outcome, .none)
+        XCTAssertEqual(harness.controller.recoveredRecordingImportCount, 0)
+        XCTAssertEqual(harness.importer.importCallCount, 1)
+    }
+
+    func testImportReturnsRecoveredStatusMessageWhenRecordingsAreImported() throws {
+        let harness = RecoveredRecordingImportControllerHarness(importResult: .success(2))
+        defer { harness.cleanup() }
+
+        let outcome = try harness.controller.importRecoveredRecordingsAtLaunch()
+
+        XCTAssertEqual(harness.controller.recoveredRecordingImportCount, 2)
+        XCTAssertEqual(harness.importer.importCallCount, 1)
+        XCTAssertEqual(
+            outcome,
+            .imported(
+                message: "Recovered 2 recordings after an unexpected quit. Open Session Library to transcribe them.",
+                error: .transcriptionFailure("Recovered recordings are waiting for transcription.")
+            )
+        )
+    }
+
+    func testImportPropagatesImporterFailure() {
+        let expectedError = NSError(domain: "RecoveredRecordingImportControllerTests", code: 1)
+        let harness = RecoveredRecordingImportControllerHarness(importResult: .failure(expectedError))
+        defer { harness.cleanup() }
+
+        XCTAssertThrowsError(try harness.controller.importRecoveredRecordingsAtLaunch()) { error in
+            XCTAssertEqual((error as NSError).domain, expectedError.domain)
+            XCTAssertEqual((error as NSError).code, expectedError.code)
+        }
+        XCTAssertEqual(harness.controller.recoveredRecordingImportCount, 0)
+        XCTAssertEqual(harness.importer.importCallCount, 1)
+    }
+}
+
+@MainActor
+private final class RecoveredRecordingImportControllerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let artifactsService: MockArtifactsService
+    let importer: MockRecoveredRecordingImporter
+    let controller: RecoveredRecordingImportController
+
+    init(importResult: Result<Int, Error>) {
+        let fileManager = FileManager.default
+        let rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("RecoveredRecordingImportControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try? fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        let transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        let artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        let clipboardService = MockClipboardService()
+        let sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: clipboardService
+        )
+        let importer = MockRecoveredRecordingImporter()
+        importer.importResult = importResult
+
+        self.rootDirectoryURL = rootDirectoryURL
+        self.transcriptStore = transcriptStore
+        self.artifactsService = artifactsService
+        self.importer = importer
+        self.controller = RecoveredRecordingImportController(
+            transcriptStore: transcriptStore,
+            sessionLibrary: sessionLibrary,
+            recoveredRecordingImporter: importer,
+            artifactsService: artifactsService
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- move launch-time recovered recording import orchestration into RecoveredRecordingImportController
- keep AppState responsible for user-visible status normalization and transcript window presentation
- add focused controller tests for no-op, recovered recordings, and importer failure paths

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecoveredRecordingImportControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #115