### PR TITLE
Extract AppErrorPresenter from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		107A00000000000000000001 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000003 /* IssueExportController.swift */; };
 		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
+		117A00000000000000000001 /* AppErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000003 /* AppErrorPresenter.swift */; };
+		117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000004 /* AppErrorPresenterTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
 		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
@@ -214,6 +216,8 @@
 		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		115A00000000000000000003 /* RecoveredRecordingImportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImportController.swift; sourceTree = "<group>"; };
 		115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImportControllerTests.swift; sourceTree = "<group>"; };
+		117A00000000000000000003 /* AppErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenter.swift; sourceTree = "<group>"; };
+		117A00000000000000000004 /* AppErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenterTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
 		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
@@ -331,6 +335,7 @@
 			children = (
 				553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */,
 				C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */,
+				117A00000000000000000004 /* AppErrorPresenterTests.swift */,
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
@@ -449,6 +454,7 @@
 			isa = PBXGroup;
 			children = (
 				99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */,
+				117A00000000000000000003 /* AppErrorPresenter.swift */,
 				C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */,
 				8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */,
 				A663ED1B160E290FCFAC3AED /* ClipboardService.swift */,
@@ -671,6 +677,7 @@
 			files = (
 				A514C06B61A203200CF118A1 /* AppBootstrapTests.swift in Sources */,
 				7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */,
+				117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */,
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
@@ -732,6 +739,7 @@
 				7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */,
 				19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */,
 				CB9E1F15D2FB0B7CF38DD5F6 /* AppError.swift in Sources */,
+				117A00000000000000000001 /* AppErrorPresenter.swift in Sources */,
 				FEFF63FB3DA83F5C8BC659C1 /* AppPresentationState.swift in Sources */,
 				5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */,
 				292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -12,6 +12,7 @@ final class AppState: ObservableObject {
     let aiProviderSettings: AIProviderSettingsController
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
+    let errorPresenter: AppErrorPresenter
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
     let exportHistoryController: ExportHistoryController
@@ -42,34 +43,12 @@ final class AppState: ObservableObject {
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
     private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
-    private let exportLogger = DiagnosticsLogger(category: .export)
     private let permissionsLogger = DiagnosticsLogger(category: .permissions)
     private let screenshotLogger = DiagnosticsLogger(category: .screenshots)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
     private var cancellables = Set<AnyCancellable>()
     private var toastDismissTask: Task<Void, Never>?
-
-    private enum AppErrorOperation: String {
-        case generic
-        case recordingStart = "recording_start"
-        case recordingStop = "recording_stop"
-        case transcription
-        case retryTranscription = "retry_transcription"
-        case postTranscription = "post_transcription"
-        case screenshotCapture = "screenshot_capture"
-        case diagnosticsExport = "diagnostics_export"
-        case privacyExport = "privacy_export"
-        case export
-        case sessionLibrary = "session_library"
-        case recoveredRecordingImport = "recovered_recording_import"
-    }
-
-    private struct AppErrorNormalization {
-        let appError: AppError
-        let operation: AppErrorOperation
-        let underlyingErrorDescription: String?
-    }
 
     private enum PostTranscriptionPipelineMode: Equatable {
         case finishedRecording
@@ -251,7 +230,12 @@ final class AppState: ObservableObject {
         self.settingsStore = settingsStore
         self.transcriptStore = transcriptStore
         self.recordingTimer = recordingTimer
-        self.presentationState = AppPresentationState()
+        let presentationState = AppPresentationState()
+        self.presentationState = presentationState
+        self.errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
         self.recordingSessionController = RecordingSessionController(
             audioRecorder: audioRecorder,
             microphonePermissionService: microphonePermissionService,
@@ -1150,7 +1134,7 @@ final class AppState: ObservableObject {
             setStatus(.recording("Captured \(markerTitle)."))
             showToast("Screenshot captured")
         } catch {
-            let normalizedError = normalizeError(
+            let normalizedError = errorPresenter.normalizeError(
                 error,
                 operation: .screenshotCapture,
                 fallback: { .screenshotCaptureFailure($0) }
@@ -1159,8 +1143,8 @@ final class AppState: ObservableObject {
             guard status.phase == .recording else {
                 return
             }
-            logAppError(normalizedError, context: "screenshot_capture_failed")
-            var metadata = appErrorMetadata(for: normalizedError, context: "screenshot_capture_failed")
+            errorPresenter.logAppError(normalizedError, context: "screenshot_capture_failed")
+            var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "screenshot_capture_failed")
             metadata["session_id"] = recordingSession.sessionID.uuidString
             screenshotLogger.error(
                 "screenshot_capture_failed",
@@ -1441,7 +1425,7 @@ final class AppState: ObservableObject {
     }
 
     private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {
-        presentationState.setStatus(newStatus, error: error)
+        errorPresenter.setStatus(newStatus, error: error)
     }
 
     private func presentError(
@@ -1455,16 +1439,10 @@ final class AppState: ObservableObject {
         issueExtractionController.clearProgress()
         issueExportController.clearProgress()
 
-        let normalizedError = normalizeError(error, operation: operation, fallback: fallback)
-        let appError = normalizedError.appError
-        logAppError(normalizedError, context: "present_error")
-        setStatus(.error(appError.userMessage), error: appError)
+        let result = errorPresenter.presentError(error, operation: operation, fallback: fallback)
 
-        switch appError {
-        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey, .exportConfigurationMissing:
+        if result.shouldOpenSettingsWindow {
             showSettingsWindow?()
-        default:
-            break
         }
     }
 
@@ -1472,20 +1450,10 @@ final class AppState: ObservableObject {
         _ error: Error,
         operation: AppErrorOperation = .postTranscription
     ) {
-        let normalizedError = normalizeError(
-            error,
-            operation: operation,
-            fallback: { .issueExtractionFailure($0) }
-        )
-        let appError = normalizedError.appError
-        logAppError(normalizedError, context: "present_post_transcription_error")
-        setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+        let result = errorPresenter.presentPostTranscriptionError(error, operation: operation)
 
-        switch appError {
-        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
+        if result.shouldOpenSettingsWindow {
             showSettingsWindow?()
-        default:
-            break
         }
     }
 
@@ -1738,14 +1706,14 @@ final class AppState: ObservableObject {
         cleanupPendingRecordedAudioIfNeeded()
         endActivity()
 
-        let normalizedError = normalizeError(
+        let normalizedError = errorPresenter.normalizeError(
             error,
             operation: .sessionLibrary,
             fallback: { .storageFailure($0) }
         )
         let appError = normalizedError.appError
-        logAppError(normalizedError, context: "transcript_persist_failed")
-        var metadata = appErrorMetadata(for: normalizedError, context: "transcript_persist_failed")
+        errorPresenter.logAppError(normalizedError, context: "transcript_persist_failed")
+        var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "transcript_persist_failed")
         metadata["session_id"] = session.id.uuidString
         sessionLibraryLogger.error(
             "transcript_persist_failed",
@@ -1824,7 +1792,7 @@ final class AppState: ObservableObject {
         endActivity()
 
         let appError = retryFailure.appError
-        logAppError(appError, context: "retry_pending_transcription", operation: .retryTranscription)
+        errorPresenter.logAppError(appError, context: "retry_pending_transcription", operation: .retryTranscription)
         setStatus(.error(retryFailure.statusMessage), error: appError)
         showTranscriptWindow?()
         showSettingsWindow?()
@@ -1847,7 +1815,7 @@ final class AppState: ObservableObject {
             recordingSessionController.clearActiveRecordingSession()
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
-            logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
+            errorPresenter.logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
             setStatus(.error(retryableSession.transcriptionRecoveryMessage ?? appError.userMessage), error: appError)
             showTranscriptWindow?()
             if appError.suggestsOpenAISettings {
@@ -1859,14 +1827,14 @@ final class AppState: ObservableObject {
             cleanupPendingRecordedAudioIfNeeded()
             endActivity()
 
-            let normalizedError = normalizeError(
+            let normalizedError = errorPresenter.normalizeError(
                 error,
                 operation: .sessionLibrary,
                 fallback: { .storageFailure($0) }
             )
             let persistenceError = normalizedError.appError
-            logAppError(normalizedError, context: "retryable_session_persist_failed")
-            var metadata = appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
+            errorPresenter.logAppError(normalizedError, context: "retryable_session_persist_failed")
+            var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
             metadata["session_id"] = retryableSession.id.uuidString
             sessionLibraryLogger.error(
                 "retryable_session_persist_failed",
@@ -1928,146 +1896,6 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func normalizeError(
-        _ error: Error,
-        operation: AppErrorOperation,
-        fallback: (String) -> AppError
-    ) -> AppErrorNormalization {
-        if let appError = error as? AppError {
-            return AppErrorNormalization(
-                appError: appError,
-                operation: operation,
-                underlyingErrorDescription: nil
-            )
-        }
-
-        let underlyingDescription = error.localizedDescription
-        return AppErrorNormalization(
-            appError: fallback(underlyingDescription),
-            operation: operation,
-            underlyingErrorDescription: underlyingDescription
-        )
-    }
-
-    private func logAppError(
-        _ error: AppError,
-        context: String,
-        operation: AppErrorOperation = .generic
-    ) {
-        logAppError(
-            AppErrorNormalization(
-                appError: error,
-                operation: operation,
-                underlyingErrorDescription: nil
-            ),
-            context: context
-        )
-    }
-
-    private func logAppError(_ normalizedError: AppErrorNormalization, context: String) {
-        let error = normalizedError.appError
-        let metadata = appErrorMetadata(for: normalizedError, context: context)
-
-        telemetryRecorder.record(.appError, metadata: metadata)
-
-        switch error {
-        case .microphonePermissionDenied,
-             .microphonePermissionRestricted,
-             .microphoneUnavailable,
-             .systemAudioFeatureDisabled,
-             .systemAudioConsentRequired,
-             .systemAudioUnavailable,
-             .screenRecordingPermissionDenied:
-            permissionsLogger.warning(.appError, error.userMessage, metadata: metadata)
-        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
-            settingsLogger.warning(.appError, error.userMessage, metadata: metadata)
-        case .recordingFailure:
-            recordingLogger.error(.appError, error.userMessage, metadata: metadata)
-        case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure, .rateLimited:
-            transcriptionLogger.error(.appError, error.userMessage, metadata: metadata)
-        case .screenshotCaptureFailure:
-            screenshotLogger.error(.appError, error.userMessage, metadata: metadata)
-        case .exportConfigurationMissing, .exportFailure:
-            exportLogger.error(.appError, error.userMessage, metadata: metadata)
-        case .storageFailure:
-            sessionLibraryLogger.error(.appError, error.userMessage, metadata: metadata)
-        case .noActiveSession:
-            recordingLogger.warning(.appError, error.userMessage, metadata: metadata)
-        case .diagnosticsFailure:
-            settingsLogger.error(.appError, error.userMessage, metadata: metadata)
-        }
-    }
-
-    private func appErrorMetadata(
-        for normalizedError: AppErrorNormalization,
-        context: String
-    ) -> [String: String] {
-        var metadata = [
-            "context": context,
-            "operation": normalizedError.operation.rawValue,
-            "error_type": telemetryErrorType(for: normalizedError.appError)
-        ]
-
-        if let underlyingErrorDescription = normalizedError.underlyingErrorDescription {
-            metadata["underlying_error"] = underlyingErrorDescription
-        }
-
-        return metadata
-    }
-
-    private func telemetryErrorType(for error: AppError) -> String {
-        switch error {
-        case .microphonePermissionDenied:
-            return "microphone_permission_denied"
-        case .microphonePermissionRestricted:
-            return "microphone_permission_restricted"
-        case .microphoneUnavailable:
-            return "microphone_unavailable"
-        case .systemAudioFeatureDisabled:
-            return "system_audio_feature_disabled"
-        case .systemAudioConsentRequired:
-            return "system_audio_consent_required"
-        case .systemAudioUnavailable:
-            return "system_audio_unavailable"
-        case .screenRecordingPermissionDenied:
-            return "screen_recording_permission_denied"
-        case .missingAPIKey:
-            return "missing_api_key"
-        case .invalidAPIKey:
-            return "invalid_api_key"
-        case .revokedAPIKey:
-            return "revoked_api_key"
-        case .recordingFailure:
-            return "recording_failure"
-        case .transcriptionFailure:
-            return "transcription_failure"
-        case .openAIRequestRejected:
-            return "openai_request_rejected"
-        case .issueExtractionFailure:
-            return "issue_extraction_failure"
-        case .emptyTranscript:
-            return "empty_transcript"
-        case .networkTimeout:
-            return "network_timeout"
-        case .networkFailure:
-            return "network_failure"
-        case .rateLimited:
-            return "rate_limited"
-        case .screenshotCaptureFailure:
-            return "screenshot_capture_failure"
-        case .exportConfigurationMissing:
-            return "export_configuration_missing"
-        case .exportFailure:
-            return "export_failure"
-        case .storageFailure:
-            return "storage_failure"
-        case .noActiveSession:
-            return "no_active_session"
-        case .diagnosticsFailure:
-            return "diagnostics_failure"
-        }
-    }
-
     private var currentDebugSessionID: UUID? {
         activeRecordingSession?.sessionID ?? displayedTranscript?.id ?? currentTranscript?.id
     }
@@ -2113,17 +1941,17 @@ final class AppState: ObservableObject {
             setStatus(.error(message), error: error)
             showTranscriptWindow?()
         } catch {
-            let normalizedError = normalizeError(
+            let normalizedError = errorPresenter.normalizeError(
                 error,
                 operation: .recoveredRecordingImport,
                 fallback: { .storageFailure($0) }
             )
             let appError = normalizedError.appError
-            logAppError(normalizedError, context: "recovered_recording_import_failed")
+            errorPresenter.logAppError(normalizedError, context: "recovered_recording_import_failed")
             sessionLibraryLogger.error(
                 "recovered_recording_import_failed",
                 appError.userMessage,
-                metadata: appErrorMetadata(for: normalizedError, context: "recovered_recording_import_failed")
+                metadata: errorPresenter.appErrorMetadata(for: normalizedError, context: "recovered_recording_import_failed")
             )
             setStatus(.error(appError.userMessage), error: appError)
         }

--- a/Sources/BugNarrator/Services/AppErrorPresenter.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresenter.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+enum AppErrorOperation: String {
+    case generic
+    case recordingStart = "recording_start"
+    case recordingStop = "recording_stop"
+    case transcription
+    case retryTranscription = "retry_transcription"
+    case postTranscription = "post_transcription"
+    case screenshotCapture = "screenshot_capture"
+    case diagnosticsExport = "diagnostics_export"
+    case privacyExport = "privacy_export"
+    case export
+    case sessionLibrary = "session_library"
+    case recoveredRecordingImport = "recovered_recording_import"
+}
+
+struct AppErrorNormalization: Equatable {
+    let appError: AppError
+    let operation: AppErrorOperation
+    let underlyingErrorDescription: String?
+}
+
+struct AppErrorPresentationResult: Equatable {
+    let appError: AppError
+    let shouldOpenSettingsWindow: Bool
+}
+
+@MainActor
+final class AppErrorPresenter {
+    private let presentationState: AppPresentationState
+    private let telemetryRecorder: any OperationalTelemetryRecording
+    private let recordingLogger = DiagnosticsLogger(category: .recording)
+    private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
+    private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
+    private let exportLogger = DiagnosticsLogger(category: .export)
+    private let permissionsLogger = DiagnosticsLogger(category: .permissions)
+    private let screenshotLogger = DiagnosticsLogger(category: .screenshots)
+    private let settingsLogger = DiagnosticsLogger(category: .settings)
+
+    init(
+        presentationState: AppPresentationState,
+        telemetryRecorder: any OperationalTelemetryRecording
+    ) {
+        self.presentationState = presentationState
+        self.telemetryRecorder = telemetryRecorder
+    }
+
+    func setStatus(_ status: AppStatus, error: AppError? = nil) {
+        presentationState.setStatus(status, error: error)
+    }
+
+    func presentError(
+        _ error: Error,
+        operation: AppErrorOperation = .generic,
+        fallback: (String) -> AppError = { .transcriptionFailure($0) }
+    ) -> AppErrorPresentationResult {
+        let normalizedError = normalizeError(error, operation: operation, fallback: fallback)
+        let appError = normalizedError.appError
+        logAppError(normalizedError, context: "present_error")
+        setStatus(.error(appError.userMessage), error: appError)
+        return AppErrorPresentationResult(
+            appError: appError,
+            shouldOpenSettingsWindow: shouldOpenSettingsWindowAfterPresenting(appError)
+        )
+    }
+
+    func presentPostTranscriptionError(
+        _ error: Error,
+        operation: AppErrorOperation = .postTranscription
+    ) -> AppErrorPresentationResult {
+        let normalizedError = normalizeError(
+            error,
+            operation: operation,
+            fallback: { .issueExtractionFailure($0) }
+        )
+        let appError = normalizedError.appError
+        logAppError(normalizedError, context: "present_post_transcription_error")
+        setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+        return AppErrorPresentationResult(
+            appError: appError,
+            shouldOpenSettingsWindow: appError.suggestsOpenAISettings
+        )
+    }
+
+    func normalizeError(
+        _ error: Error,
+        operation: AppErrorOperation,
+        fallback: (String) -> AppError
+    ) -> AppErrorNormalization {
+        if let appError = error as? AppError {
+            return AppErrorNormalization(
+                appError: appError,
+                operation: operation,
+                underlyingErrorDescription: nil
+            )
+        }
+
+        let underlyingDescription = error.localizedDescription
+        return AppErrorNormalization(
+            appError: fallback(underlyingDescription),
+            operation: operation,
+            underlyingErrorDescription: underlyingDescription
+        )
+    }
+
+    func logAppError(
+        _ error: AppError,
+        context: String,
+        operation: AppErrorOperation = .generic
+    ) {
+        logAppError(
+            AppErrorNormalization(
+                appError: error,
+                operation: operation,
+                underlyingErrorDescription: nil
+            ),
+            context: context
+        )
+    }
+
+    func logAppError(_ normalizedError: AppErrorNormalization, context: String) {
+        let error = normalizedError.appError
+        let metadata = appErrorMetadata(for: normalizedError, context: context)
+
+        telemetryRecorder.record(.appError, metadata: metadata)
+
+        switch error {
+        case .microphonePermissionDenied,
+             .microphonePermissionRestricted,
+             .microphoneUnavailable,
+             .systemAudioFeatureDisabled,
+             .systemAudioConsentRequired,
+             .systemAudioUnavailable,
+             .screenRecordingPermissionDenied:
+            permissionsLogger.warning(.appError, error.userMessage, metadata: metadata)
+        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
+            settingsLogger.warning(.appError, error.userMessage, metadata: metadata)
+        case .recordingFailure:
+            recordingLogger.error(.appError, error.userMessage, metadata: metadata)
+        case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure, .rateLimited:
+            transcriptionLogger.error(.appError, error.userMessage, metadata: metadata)
+        case .screenshotCaptureFailure:
+            screenshotLogger.error(.appError, error.userMessage, metadata: metadata)
+        case .exportConfigurationMissing, .exportFailure:
+            exportLogger.error(.appError, error.userMessage, metadata: metadata)
+        case .storageFailure:
+            sessionLibraryLogger.error(.appError, error.userMessage, metadata: metadata)
+        case .noActiveSession:
+            recordingLogger.warning(.appError, error.userMessage, metadata: metadata)
+        case .diagnosticsFailure:
+            settingsLogger.error(.appError, error.userMessage, metadata: metadata)
+        }
+    }
+
+    func appErrorMetadata(
+        for normalizedError: AppErrorNormalization,
+        context: String
+    ) -> [String: String] {
+        var metadata = [
+            "context": context,
+            "operation": normalizedError.operation.rawValue,
+            "error_type": telemetryErrorType(for: normalizedError.appError)
+        ]
+
+        if let underlyingErrorDescription = normalizedError.underlyingErrorDescription {
+            metadata["underlying_error"] = underlyingErrorDescription
+        }
+
+        return metadata
+    }
+
+    private func shouldOpenSettingsWindowAfterPresenting(_ error: AppError) -> Bool {
+        switch error {
+        case .missingAPIKey, .invalidAPIKey, .revokedAPIKey, .exportConfigurationMissing:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func telemetryErrorType(for error: AppError) -> String {
+        switch error {
+        case .microphonePermissionDenied:
+            return "microphone_permission_denied"
+        case .microphonePermissionRestricted:
+            return "microphone_permission_restricted"
+        case .microphoneUnavailable:
+            return "microphone_unavailable"
+        case .systemAudioFeatureDisabled:
+            return "system_audio_feature_disabled"
+        case .systemAudioConsentRequired:
+            return "system_audio_consent_required"
+        case .systemAudioUnavailable:
+            return "system_audio_unavailable"
+        case .screenRecordingPermissionDenied:
+            return "screen_recording_permission_denied"
+        case .missingAPIKey:
+            return "missing_api_key"
+        case .invalidAPIKey:
+            return "invalid_api_key"
+        case .revokedAPIKey:
+            return "revoked_api_key"
+        case .recordingFailure:
+            return "recording_failure"
+        case .transcriptionFailure:
+            return "transcription_failure"
+        case .openAIRequestRejected:
+            return "openai_request_rejected"
+        case .issueExtractionFailure:
+            return "issue_extraction_failure"
+        case .emptyTranscript:
+            return "empty_transcript"
+        case .networkTimeout:
+            return "network_timeout"
+        case .networkFailure:
+            return "network_failure"
+        case .rateLimited:
+            return "rate_limited"
+        case .screenshotCaptureFailure:
+            return "screenshot_capture_failure"
+        case .exportConfigurationMissing:
+            return "export_configuration_missing"
+        case .exportFailure:
+            return "export_failure"
+        case .storageFailure:
+            return "storage_failure"
+        case .noActiveSession:
+            return "no_active_session"
+        case .diagnosticsFailure:
+            return "diagnostics_failure"
+        }
+    }
+}

--- a/Tests/BugNarratorTests/AppErrorPresenterTests.swift
+++ b/Tests/BugNarratorTests/AppErrorPresenterTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class AppErrorPresenterTests: XCTestCase {
+    func testSetStatusUpdatesPresentationState() {
+        let harness = AppErrorPresenterHarness()
+
+        harness.presenter.setStatus(.success("Saved."))
+
+        XCTAssertEqual(harness.presentationState.status, .success("Saved."))
+        XCTAssertNil(harness.presentationState.currentError)
+    }
+
+    func testPresentErrorNormalizesFallbackAndRecordsTelemetryMetadata() throws {
+        let harness = AppErrorPresenterHarness()
+        let underlyingError = NSError(
+            domain: "AppErrorPresenterTests",
+            code: 7,
+            userInfo: [NSLocalizedDescriptionKey: "Disk is full"]
+        )
+
+        let result = harness.presenter.presentError(
+            underlyingError,
+            operation: .sessionLibrary,
+            fallback: { .storageFailure($0) }
+        )
+
+        let appError = AppError.storageFailure("Disk is full")
+        XCTAssertEqual(result, AppErrorPresentationResult(appError: appError, shouldOpenSettingsWindow: false))
+        XCTAssertEqual(harness.presentationState.status, .error(appError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, appError)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "session_library")
+        XCTAssertEqual(telemetry.metadata["error_type"], "storage_failure")
+        XCTAssertEqual(telemetry.metadata["underlying_error"], "Disk is full")
+    }
+
+    func testPresentErrorPassesThroughAppErrorAndRecommendsSettingsWhenNeeded() throws {
+        let harness = AppErrorPresenterHarness()
+
+        let result = harness.presenter.presentError(AppError.missingAPIKey, operation: .recordingStart)
+
+        XCTAssertEqual(result, AppErrorPresentationResult(appError: .missingAPIKey, shouldOpenSettingsWindow: true))
+        XCTAssertEqual(harness.presentationState.status, .error(AppError.missingAPIKey.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, .missingAPIKey)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "recording_start")
+        XCTAssertEqual(telemetry.metadata["error_type"], "missing_api_key")
+        XCTAssertNil(telemetry.metadata["underlying_error"])
+    }
+
+    func testPresentPostTranscriptionErrorPrefixesStatusAndRecommendsSettingsForOpenAIErrors() throws {
+        let harness = AppErrorPresenterHarness()
+
+        let result = harness.presenter.presentPostTranscriptionError(AppError.invalidAPIKey)
+
+        XCTAssertEqual(result, AppErrorPresentationResult(appError: .invalidAPIKey, shouldOpenSettingsWindow: true))
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Transcript ready, but \(AppError.invalidAPIKey.userMessage)")
+        )
+        XCTAssertEqual(harness.presentationState.currentError, .invalidAPIKey)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_post_transcription_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "post_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
+    }
+}
+
+@MainActor
+private final class AppErrorPresenterHarness {
+    let presentationState = AppPresentationState()
+    let telemetryRecorder = MockOperationalTelemetryRecorder()
+    let presenter: AppErrorPresenter
+
+    init() {
+        self.presenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
+    }
+
+    func lastAppErrorTelemetry(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> (name: String, metadata: [String: String]) {
+        try XCTUnwrap(
+            telemetryRecorder.recordedEvents.last { $0.name == TelemetryEvent.appError.rawValue },
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- move AppState error operations, normalization, telemetry metadata, and category logging into AppErrorPresenter
- keep AppState responsible for workflow cleanup and settings-window routing through presentation results
- add focused AppErrorPresenter tests for status setting, fallback normalization, settings recommendation, and post-transcription copy

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppErrorPresenterTests\n- ./scripts/validate.sh origin/main\n\nCloses #117