### PR TITLE
Extract LocalDataDeletionController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
 		117A00000000000000000001 /* AppErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000003 /* AppErrorPresenter.swift */; };
 		117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000004 /* AppErrorPresenterTests.swift */; };
+		119A00000000000000000001 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000003 /* LocalDataDeletionController.swift */; };
+		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
 		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
@@ -218,6 +220,8 @@
 		115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredRecordingImportControllerTests.swift; sourceTree = "<group>"; };
 		117A00000000000000000003 /* AppErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenter.swift; sourceTree = "<group>"; };
 		117A00000000000000000004 /* AppErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenterTests.swift; sourceTree = "<group>"; };
+		119A00000000000000000003 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
+		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
 		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
@@ -347,6 +351,7 @@
 				DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */,
 				B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */,
 				C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */,
+				119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */,
 				EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */,
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
@@ -471,6 +476,7 @@
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
+				119A00000000000000000003 /* LocalDataDeletionController.swift */,
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
 				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
@@ -689,6 +695,7 @@
 				57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */,
 				6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */,
 				5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */,
+				119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */,
 				0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */,
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
@@ -776,6 +783,7 @@
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
 				099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */,
+				119A00000000000000000001 /* LocalDataDeletionController.swift in Sources */,
 				E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */,
 				E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */,
 				821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -21,6 +21,7 @@ final class AppState: ObservableObject {
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
     let supportDataController: SupportDataController
+    let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
@@ -278,6 +279,12 @@ final class AppState: ObservableObject {
             privacyDataExporter: privacyDataExporter,
             telemetryRecorder: telemetryRecorder,
             localPrivacyDataManager: localPrivacyDataManager
+        )
+        self.localDataDeletionController = LocalDataDeletionController(
+            transcriptStore: transcriptStore,
+            sessionLibrary: self.sessionLibrary,
+            supportDataController: self.supportDataController,
+            exportHistoryController: self.exportHistoryController
         )
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: self.sessionLibrary,
@@ -866,26 +873,12 @@ final class AppState: ObservableObject {
             return
         }
 
-        let idsToDelete = Set(transcriptStore.allStoredSessionIDs())
-            .union(currentTranscript.map { [$0.id] } ?? [])
-        let deletedSessionCount = idsToDelete.count
-
-        if !idsToDelete.isEmpty {
-            deleteSessions(withIDs: idsToDelete)
+        do {
+            let outcome = try await localDataDeletionController.deleteAllLocalData(currentTranscript: currentTranscript)
+            setStatus(.success(outcome.statusMessage))
+        } catch {
+            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
-
-        await clearLocalPrivacyArtifacts()
-
-        let message: String
-        if deletedSessionCount == 0 {
-            message = "Cleared local diagnostics and export history."
-        } else if deletedSessionCount == 1 {
-            message = "Deleted 1 local session and cleared local diagnostics."
-        } else {
-            message = "Deleted \(deletedSessionCount) local sessions and cleared local diagnostics."
-        }
-
-        setStatus(.success(message))
     }
 
     func validateAPIKey() async {
@@ -1872,11 +1865,6 @@ final class AppState: ObservableObject {
 
     private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {
         sessionLibrary.sessionSnapshot(with: sessionID)
-    }
-
-    private func clearLocalPrivacyArtifacts() async {
-        await supportDataController.clearLocalPrivacyArtifacts()
-        await refreshExportHistory()
     }
 
     private func cancelPendingScreenshotSelection(reason: String) {

--- a/Sources/BugNarrator/Services/LocalDataDeletionController.swift
+++ b/Sources/BugNarrator/Services/LocalDataDeletionController.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct LocalDataDeletionOutcome: Equatable {
+    let deletedSessionCount: Int
+
+    var statusMessage: String {
+        if deletedSessionCount == 0 {
+            return "Cleared local diagnostics and export history."
+        }
+
+        if deletedSessionCount == 1 {
+            return "Deleted 1 local session and cleared local diagnostics."
+        }
+
+        return "Deleted \(deletedSessionCount) local sessions and cleared local diagnostics."
+    }
+}
+
+@MainActor
+final class LocalDataDeletionController {
+    private let transcriptStore: TranscriptStore
+    private let sessionLibrary: SessionLibraryController
+    private let supportDataController: SupportDataController
+    private let exportHistoryController: ExportHistoryController
+
+    init(
+        transcriptStore: TranscriptStore,
+        sessionLibrary: SessionLibraryController,
+        supportDataController: SupportDataController,
+        exportHistoryController: ExportHistoryController
+    ) {
+        self.transcriptStore = transcriptStore
+        self.sessionLibrary = sessionLibrary
+        self.supportDataController = supportDataController
+        self.exportHistoryController = exportHistoryController
+    }
+
+    func deleteAllLocalData(currentTranscript: TranscriptSession?) async throws -> LocalDataDeletionOutcome {
+        let idsToDelete = Set(transcriptStore.allStoredSessionIDs())
+            .union(currentTranscript.map { [$0.id] } ?? [])
+        let deletedSessionCount: Int
+
+        if idsToDelete.isEmpty {
+            deletedSessionCount = 0
+        } else {
+            deletedSessionCount = try sessionLibrary.deleteSessions(withIDs: idsToDelete)
+        }
+
+        await supportDataController.clearLocalPrivacyArtifacts()
+        await exportHistoryController.refreshExportHistory()
+
+        return LocalDataDeletionOutcome(deletedSessionCount: deletedSessionCount)
+    }
+}

--- a/Tests/BugNarratorTests/LocalDataDeletionControllerTests.swift
+++ b/Tests/BugNarratorTests/LocalDataDeletionControllerTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class LocalDataDeletionControllerTests: XCTestCase {
+    func testDeleteAllLocalDataClearsPrivacyArtifactsWhenNoSessionsExist() async throws {
+        let harness = LocalDataDeletionControllerHarness()
+        defer { harness.cleanup() }
+
+        let outcome = try await harness.controller.deleteAllLocalData(currentTranscript: nil)
+
+        XCTAssertEqual(outcome.deletedSessionCount, 0)
+        XCTAssertEqual(outcome.statusMessage, "Cleared local diagnostics and export history.")
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
+    }
+
+    func testDeleteAllLocalDataDeletesOneStoredSession() async throws {
+        let harness = LocalDataDeletionControllerHarness()
+        defer { harness.cleanup() }
+        let session = harness.makeSession()
+        try harness.transcriptStore.add(session)
+        harness.sessionLibrary.stageCurrentTranscript(session)
+
+        let outcome = try await harness.controller.deleteAllLocalData(currentTranscript: harness.sessionLibrary.currentTranscript)
+
+        XCTAssertEqual(outcome.deletedSessionCount, 1)
+        XCTAssertEqual(outcome.statusMessage, "Deleted 1 local session and cleared local diagnostics.")
+        XCTAssertTrue(harness.transcriptStore.sessions.isEmpty)
+        XCTAssertNil(harness.sessionLibrary.currentTranscript)
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
+    }
+
+    func testDeleteAllLocalDataDeletesStoredAndUnsavedCurrentSessions() async throws {
+        let harness = LocalDataDeletionControllerHarness()
+        defer { harness.cleanup() }
+        let storedSession = harness.makeSession()
+        let unsavedSession = harness.makeSession()
+        try harness.transcriptStore.add(storedSession)
+        harness.sessionLibrary.stageCurrentTranscript(unsavedSession)
+
+        let outcome = try await harness.controller.deleteAllLocalData(currentTranscript: harness.sessionLibrary.currentTranscript)
+
+        XCTAssertEqual(outcome.deletedSessionCount, 2)
+        XCTAssertEqual(outcome.statusMessage, "Deleted 2 local sessions and cleared local diagnostics.")
+        XCTAssertTrue(harness.transcriptStore.sessions.isEmpty)
+        XCTAssertNil(harness.sessionLibrary.currentTranscript)
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
+    }
+}
+
+@MainActor
+private final class LocalDataDeletionControllerHarness {
+    let rootDirectoryURL: URL
+    let defaultsSuiteName: String
+    let defaults: UserDefaults
+    let transcriptStore: TranscriptStore
+    let artifactsService: MockArtifactsService
+    let sessionLibrary: SessionLibraryController
+    let localPrivacyDataManager: MockLocalPrivacyDataManager
+    let controller: LocalDataDeletionController
+
+    init() {
+        let fileManager = FileManager.default
+        let rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("LocalDataDeletionControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try? fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        let defaultsSuiteName = "LocalDataDeletionControllerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+
+        let keychainService = MockKeychainService()
+        let settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: keychainService,
+            launchAtLoginService: MockLaunchAtLoginService()
+        )
+        let transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json")
+        )
+        let artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        let sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: MockClipboardService()
+        )
+        let exportService = MockExportService()
+        let exportHistoryController = ExportHistoryController(exportService: exportService)
+        let localPrivacyDataManager = MockLocalPrivacyDataManager()
+        let supportDataController = SupportDataController(
+            settingsStore: settingsStore,
+            transcriptStore: transcriptStore,
+            exportService: exportService,
+            clipboardService: MockClipboardService(),
+            debugBundleExporter: MockDebugBundleExporter(),
+            privacyDataExporter: MockPrivacyDataExporter(),
+            telemetryRecorder: MockOperationalTelemetryRecorder(),
+            localPrivacyDataManager: localPrivacyDataManager
+        )
+
+        self.rootDirectoryURL = rootDirectoryURL
+        self.defaultsSuiteName = defaultsSuiteName
+        self.defaults = defaults
+        self.transcriptStore = transcriptStore
+        self.artifactsService = artifactsService
+        self.sessionLibrary = sessionLibrary
+        self.localPrivacyDataManager = localPrivacyDataManager
+        self.controller = LocalDataDeletionController(
+            transcriptStore: transcriptStore,
+            sessionLibrary: sessionLibrary,
+            supportDataController: supportDataController,
+            exportHistoryController: exportHistoryController
+        )
+    }
+
+    func makeSession() -> TranscriptSession {
+        TranscriptSession(
+            createdAt: Date(),
+            transcript: "A local transcript.",
+            duration: 10,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+}


### PR DESCRIPTION
## Summary
- move all-local-data deletion orchestration into LocalDataDeletionController
- keep AppState responsible for the recording/transcribing guard and error presentation
- add focused tests for zero, one, and multiple deleted-session success messages

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/LocalDataDeletionControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #119