### PR TITLE
Extract AppUtilityActionController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000004 /* AppErrorPresenterTests.swift */; };
 		119A00000000000000000001 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000003 /* LocalDataDeletionController.swift */; };
 		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
+		121A00000000000000000001 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000003 /* AppUtilityActionController.swift */; };
+		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
 		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
@@ -222,6 +224,8 @@
 		117A00000000000000000004 /* AppErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenterTests.swift; sourceTree = "<group>"; };
 		119A00000000000000000003 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
 		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
+		121A00000000000000000003 /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
+		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
 		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
@@ -341,6 +345,7 @@
 				C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */,
 				117A00000000000000000004 /* AppErrorPresenterTests.swift */,
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
+				121A00000000000000000004 /* AppUtilityActionControllerTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
@@ -460,6 +465,7 @@
 			children = (
 				99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */,
 				117A00000000000000000003 /* AppErrorPresenter.swift */,
+				121A00000000000000000003 /* AppUtilityActionController.swift */,
 				C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */,
 				8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */,
 				A663ED1B160E290FCFAC3AED /* ClipboardService.swift */,
@@ -685,6 +691,7 @@
 				7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */,
 				117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */,
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
+				121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
@@ -752,6 +759,7 @@
 				292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */,
 				9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */,
 				C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */,
+				121A00000000000000000001 /* AppUtilityActionController.swift in Sources */,
 				EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */,
 				3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */,
 				456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -20,17 +20,19 @@ final class AppState: ObservableObject {
     let issueExtractionController: IssueExtractionController
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
+    let appUtilityActions: AppUtilityActionController
     let supportDataController: SupportDataController
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
 
-    var showTranscriptWindow: (() -> Void)?
-    var showSettingsWindow: (() -> Void)?
-    var showAboutWindow: (() -> Void)?
-    var showChangelogWindow: (() -> Void)?
-    var showSupportWindow: (() -> Void)?
-    var showRecordingControlWindow: (() -> Void)?
+    var showTranscriptWindow: (() -> Void)? { get { appUtilityActions.showTranscriptWindow } set { appUtilityActions.showTranscriptWindow = newValue } }
+    var showSettingsWindow: (() -> Void)? { get { appUtilityActions.showSettingsWindow } set { appUtilityActions.showSettingsWindow = newValue } }
+    var showAboutWindow: (() -> Void)? { get { appUtilityActions.showAboutWindow } set { appUtilityActions.showAboutWindow = newValue } }
+    var showChangelogWindow: (() -> Void)? { get { appUtilityActions.showChangelogWindow } set { appUtilityActions.showChangelogWindow = newValue } }
+    var showSupportWindow: (() -> Void)? { get { appUtilityActions.showSupportWindow } set { appUtilityActions.showSupportWindow = newValue } }
+    var showRecordingControlWindow: (() -> Void)? { get { appUtilityActions.showRecordingControlWindow } set { appUtilityActions.showRecordingControlWindow = newValue } }
+
     var prepareForScreenshotSelection: (() -> Void)?
     var restoreAfterScreenshotSelection: (() -> Void)?
 
@@ -38,7 +40,6 @@ final class AppState: ObservableObject {
     private let hotkeyManager: any HotkeyManaging
     private let artifactsService: any SessionArtifactsManaging
     private let clipboardService: any ClipboardWriting
-    private let urlHandler: any URLOpening
     private let telemetryRecorder: any OperationalTelemetryRecording
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
@@ -270,6 +271,10 @@ final class AppState: ObservableObject {
             urlHandler: urlHandler,
             runtimeEnvironment: runtimeEnvironment
         )
+        self.appUtilityActions = AppUtilityActionController(
+            urlHandler: urlHandler,
+            permissionRecoveryController: self.permissionRecoveryController
+        )
         self.supportDataController = SupportDataController(
             settingsStore: settingsStore,
             transcriptStore: transcriptStore,
@@ -300,7 +305,6 @@ final class AppState: ObservableObject {
         self.hotkeyManager = hotkeyManager
         self.artifactsService = artifactsService
         self.clipboardService = clipboardService
-        self.urlHandler = urlHandler
         self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
             settingsStore: settingsStore,
@@ -733,15 +737,15 @@ final class AppState: ObservableObject {
     }
 
     func openTranscriptHistory() {
-        showTranscriptWindow?()
+        appUtilityActions.openTranscriptHistory()
     }
 
     func openRecordingControls() {
-        showRecordingControlWindow?()
+        appUtilityActions.openRecordingControls()
     }
 
     func openRecordingControlsAndStartSession() async {
-        showRecordingControlWindow?()
+        appUtilityActions.openRecordingControls()
 
         guard status.phase != .recording else {
             return
@@ -751,8 +755,7 @@ final class AppState: ObservableObject {
     }
 
     func openSettings() {
-        settingsLogger.debug("open_settings", "Opening the Settings window.")
-        showSettingsWindow?()
+        appUtilityActions.openSettings()
     }
 
     func requestApplicationTermination() {
@@ -781,47 +784,47 @@ final class AppState: ObservableObject {
     }
 
     func openAbout() {
-        showAboutWindow?()
+        appUtilityActions.openAbout()
     }
 
     func openChangelog() {
-        showChangelogWindow?()
+        appUtilityActions.openChangelog()
     }
 
     func openGitHubRepository() {
-        openExternalURL(BugNarratorLinks.repository, label: "GitHub repository")
+        presentUtilityActionResult(appUtilityActions.openGitHubRepository())
     }
 
     func openDocumentation() {
-        openExternalURL(BugNarratorLinks.documentation, label: "documentation")
+        presentUtilityActionResult(appUtilityActions.openDocumentation())
     }
 
     func openIssueReporter() {
-        openExternalURL(BugNarratorLinks.issues, label: "issue tracker")
+        presentUtilityActionResult(appUtilityActions.openIssueReporter())
     }
 
     func openSupportDevelopment() {
-        showSupportWindow?()
+        appUtilityActions.openSupportDevelopment()
     }
 
     func openSupportDonationPage() {
-        openExternalURL(BugNarratorLinks.supportDevelopment, label: "PayPal donation page")
+        presentUtilityActionResult(appUtilityActions.openSupportDonationPage())
     }
 
     func openMicrophonePrivacySettings() {
-        presentPermissionSettingsResult(permissionRecoveryController.openMicrophonePrivacySettings())
+        presentPermissionSettingsResult(appUtilityActions.openMicrophonePrivacySettings())
     }
 
     func openScreenRecordingPrivacySettings() {
-        presentPermissionSettingsResult(permissionRecoveryController.openScreenRecordingPrivacySettings())
+        presentPermissionSettingsResult(appUtilityActions.openScreenRecordingPrivacySettings())
     }
 
     func openSystemAudioPrivacySettings() {
-        presentPermissionSettingsResult(permissionRecoveryController.openSystemAudioPrivacySettings())
+        presentPermissionSettingsResult(appUtilityActions.openSystemAudioPrivacySettings())
     }
 
     func checkForUpdates() {
-        openExternalURL(BugNarratorLinks.releases, label: "releases page")
+        presentUtilityActionResult(appUtilityActions.checkForUpdates())
     }
 
     func copyDebugInfo() {
@@ -1336,17 +1339,12 @@ final class AppState: ObservableObject {
         }
     }
 
-    private func openExternalURL(_ url: URL, label: String) {
-        guard urlHandler.open(url) else {
-            presentUtilityActionFailure("BugNarrator could not open the \(label).")
+    private func presentUtilityActionResult(_ result: AppUtilityActionResult) {
+        guard case .failed(let message) = result else {
             return
         }
 
-        settingsLogger.info(
-            "external_link_opened",
-            "Opened an external support or documentation link.",
-            metadata: ["label": label]
-        )
+        presentUtilityActionFailure(message)
     }
 
     private func presentPermissionSettingsResult(_ result: PermissionSettingsOpenResult) {

--- a/Sources/BugNarrator/Services/AppUtilityActionController.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionController.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum AppUtilityActionResult: Equatable {
+    case opened
+    case failed(message: String)
+}
+
+@MainActor
+final class AppUtilityActionController {
+    var showTranscriptWindow: (() -> Void)?
+    var showSettingsWindow: (() -> Void)?
+    var showAboutWindow: (() -> Void)?
+    var showChangelogWindow: (() -> Void)?
+    var showSupportWindow: (() -> Void)?
+    var showRecordingControlWindow: (() -> Void)?
+
+    private let urlHandler: any URLOpening
+    private let permissionRecoveryController: PermissionRecoveryController
+    private let settingsLogger = DiagnosticsLogger(category: .settings)
+
+    init(
+        urlHandler: any URLOpening,
+        permissionRecoveryController: PermissionRecoveryController
+    ) {
+        self.urlHandler = urlHandler
+        self.permissionRecoveryController = permissionRecoveryController
+    }
+
+    func openTranscriptHistory() {
+        showTranscriptWindow?()
+    }
+
+    func openRecordingControls() {
+        showRecordingControlWindow?()
+    }
+
+    func openSettings() {
+        settingsLogger.debug("open_settings", "Opening the Settings window.")
+        showSettingsWindow?()
+    }
+
+    func openAbout() {
+        showAboutWindow?()
+    }
+
+    func openChangelog() {
+        showChangelogWindow?()
+    }
+
+    func openGitHubRepository() -> AppUtilityActionResult {
+        openExternalURL(BugNarratorLinks.repository, label: "GitHub repository")
+    }
+
+    func openDocumentation() -> AppUtilityActionResult {
+        openExternalURL(BugNarratorLinks.documentation, label: "documentation")
+    }
+
+    func openIssueReporter() -> AppUtilityActionResult {
+        openExternalURL(BugNarratorLinks.issues, label: "issue tracker")
+    }
+
+    func openSupportDevelopment() {
+        showSupportWindow?()
+    }
+
+    func openSupportDonationPage() -> AppUtilityActionResult {
+        openExternalURL(BugNarratorLinks.supportDevelopment, label: "PayPal donation page")
+    }
+
+    func openMicrophonePrivacySettings() -> PermissionSettingsOpenResult {
+        permissionRecoveryController.openMicrophonePrivacySettings()
+    }
+
+    func openScreenRecordingPrivacySettings() -> PermissionSettingsOpenResult {
+        permissionRecoveryController.openScreenRecordingPrivacySettings()
+    }
+
+    func openSystemAudioPrivacySettings() -> PermissionSettingsOpenResult {
+        permissionRecoveryController.openSystemAudioPrivacySettings()
+    }
+
+    func checkForUpdates() -> AppUtilityActionResult {
+        openExternalURL(BugNarratorLinks.releases, label: "releases page")
+    }
+
+    private func openExternalURL(_ url: URL, label: String) -> AppUtilityActionResult {
+        guard urlHandler.open(url) else {
+            return .failed(message: "BugNarrator could not open the \(label).")
+        }
+
+        settingsLogger.info(
+            "external_link_opened",
+            "Opened an external support or documentation link.",
+            metadata: ["label": label]
+        )
+        return .opened
+    }
+}

--- a/Tests/BugNarratorTests/AppUtilityActionControllerTests.swift
+++ b/Tests/BugNarratorTests/AppUtilityActionControllerTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class AppUtilityActionControllerTests: XCTestCase {
+    func testWindowActionsInvokeRegisteredCallbacks() {
+        let harness = AppUtilityActionControllerHarness()
+        var openedWindows: [String] = []
+        harness.controller.showTranscriptWindow = { openedWindows.append("transcript") }
+        harness.controller.showSettingsWindow = { openedWindows.append("settings") }
+        harness.controller.showSupportWindow = { openedWindows.append("support") }
+        harness.controller.showRecordingControlWindow = { openedWindows.append("recording") }
+
+        harness.controller.openTranscriptHistory()
+        harness.controller.openSettings()
+        harness.controller.openSupportDevelopment()
+        harness.controller.openRecordingControls()
+
+        XCTAssertEqual(openedWindows, ["transcript", "settings", "support", "recording"])
+    }
+
+    func testExternalURLActionOpensExpectedLink() {
+        let harness = AppUtilityActionControllerHarness()
+
+        let result = harness.controller.openDocumentation()
+
+        XCTAssertEqual(result, .opened)
+        XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.documentation])
+    }
+
+    func testExternalURLFailureReturnsFailureMessage() {
+        let harness = AppUtilityActionControllerHarness()
+        harness.urlHandler.shouldSucceed = false
+
+        let result = harness.controller.openIssueReporter()
+
+        XCTAssertEqual(result, .failed(message: "BugNarrator could not open the issue tracker."))
+        XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.issues])
+    }
+
+    func testPrivacySettingsActionDelegatesToPermissionRecoveryController() {
+        let harness = AppUtilityActionControllerHarness()
+
+        let result = harness.controller.openMicrophonePrivacySettings()
+
+        XCTAssertEqual(result, .opened(BugNarratorLinks.microphonePrivacySettings))
+        XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.microphonePrivacySettings])
+    }
+}
+
+@MainActor
+private final class AppUtilityActionControllerHarness {
+    let urlHandler = MockURLHandler()
+    let controller: AppUtilityActionController
+
+    init() {
+        let microphonePermissionService = MicrophonePermissionService(permissionAccess: MockAudioRecorder())
+        let screenCapturePermissionService = ScreenCapturePermissionService(
+            permissionAccess: MockScreenCapturePermissionAccess()
+        )
+        let permissionRecoveryController = PermissionRecoveryController(
+            microphonePermissionService: microphonePermissionService,
+            screenCapturePermissionService: screenCapturePermissionService,
+            urlHandler: urlHandler,
+            runtimeEnvironment: AppRuntimeEnvironment()
+        )
+        self.controller = AppUtilityActionController(
+            urlHandler: urlHandler,
+            permissionRecoveryController: permissionRecoveryController
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- move window callback storage, external link opening, and privacy-settings routing into AppUtilityActionController
- keep AppState responsible for composing recording-control start behavior and presenting utility failures based on status phase
- add focused tests for window callbacks, URL success/failure, and permission settings delegation

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppUtilityActionControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #121