### PR TITLE
Extract TransientToastController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
 		121A00000000000000000001 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000003 /* AppUtilityActionController.swift */; };
 		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
+		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
+		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
 		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
 		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
@@ -226,6 +228,8 @@
 		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
 		121A00000000000000000003 /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
 		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
+		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
+		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
 		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
@@ -382,6 +386,7 @@
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
 				111A00000000000000000004 /* SupportDataControllerTests.swift */,
 				22447E5581818B8003AA49F8 /* TestSupport.swift */,
+				123A00000000000000000004 /* TransientToastControllerTests.swift */,
 				7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */,
 				F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */,
 				A31B0939DF668FFC71CD64FD /* TranscriptionRecoveryControllerTests.swift */,
@@ -510,6 +515,7 @@
 				BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */,
 				800BFCC6407B534886C65D77 /* TranscriptionClient.swift */,
 				2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */,
+				123A00000000000000000003 /* TransientToastController.swift */,
 				04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */,
 				7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */,
 				9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */,
@@ -728,6 +734,7 @@
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
 				111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */,
 				5090A54144CACF59295F137C /* TestSupport.swift in Sources */,
+				123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */,
 				683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */,
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
 				38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */,
@@ -844,6 +851,7 @@
 				33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */,
 				A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */,
 				5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */,
+				123A00000000000000000001 /* TransientToastController.swift in Sources */,
 				3B4F5CCC16AB9837DD0BD0F4 /* URLHandler.swift in Sources */,
 				B3F726638452CBD7F5A4DC16 /* WindowCoordinator.swift in Sources */,
 			);

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -13,6 +13,7 @@ final class AppState: ObservableObject {
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
     let errorPresenter: AppErrorPresenter
+    let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
     let sessionLibrary: SessionLibraryController
     let exportHistoryController: ExportHistoryController
@@ -50,7 +51,6 @@ final class AppState: ObservableObject {
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
     private var cancellables = Set<AnyCancellable>()
-    private var toastDismissTask: Task<Void, Never>?
 
     private enum PostTranscriptionPipelineMode: Equatable {
         case finishedRecording
@@ -238,6 +238,7 @@ final class AppState: ObservableObject {
             presentationState: presentationState,
             telemetryRecorder: telemetryRecorder
         )
+        self.transientToastController = TransientToastController(presentationState: presentationState)
         self.recordingSessionController = RecordingSessionController(
             audioRecorder: audioRecorder,
             microphonePermissionService: microphonePermissionService,
@@ -1408,8 +1409,7 @@ final class AppState: ObservableObject {
             )
         }
 
-        toastDismissTask?.cancel()
-        presentationState.dismissToast()
+        transientToastController.dismissToast()
         hotkeyManager.unregisterAll()
         stopTimer(resetElapsed: false)
         endActivity()
@@ -1870,16 +1870,7 @@ final class AppState: ObservableObject {
     }
 
     private func showToast(_ message: String, style: TransientToastStyle = .success) {
-        toastDismissTask?.cancel()
-        presentationState.showToast(TransientToast(message: message, style: style))
-        toastDismissTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            guard !Task.isCancelled else {
-                return
-            }
-
-            self?.presentationState.dismissToast()
-        }
+        transientToastController.showToast(message, style: style)
     }
 
     private var currentDebugSessionID: UUID? {

--- a/Sources/BugNarrator/Services/TransientToastController.swift
+++ b/Sources/BugNarrator/Services/TransientToastController.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@MainActor
+final class TransientToastController {
+    private let presentationState: AppPresentationState
+    private var dismissTask: Task<Void, Never>?
+
+    init(presentationState: AppPresentationState) {
+        self.presentationState = presentationState
+    }
+
+    deinit {
+        dismissTask?.cancel()
+    }
+
+    func showToast(
+        _ message: String,
+        style: TransientToastStyle = .success,
+        durationNanoseconds: UInt64 = 2_000_000_000
+    ) {
+        dismissTask?.cancel()
+        presentationState.showToast(TransientToast(message: message, style: style))
+        dismissTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: durationNanoseconds)
+            guard !Task.isCancelled else {
+                return
+            }
+
+            self?.presentationState.dismissToast()
+        }
+    }
+
+    func dismissToast() {
+        dismissTask?.cancel()
+        presentationState.dismissToast()
+    }
+}

--- a/Tests/BugNarratorTests/TransientToastControllerTests.swift
+++ b/Tests/BugNarratorTests/TransientToastControllerTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class TransientToastControllerTests: XCTestCase {
+    func testShowToastPresentsToastImmediately() {
+        let presentationState = AppPresentationState()
+        let controller = TransientToastController(presentationState: presentationState)
+
+        controller.showToast("Saved", style: .success)
+
+        XCTAssertEqual(presentationState.transientToast?.message, "Saved")
+        XCTAssertEqual(presentationState.transientToast?.style, .success)
+    }
+
+    func testShowToastReplacesActiveToastAndCancelsPriorDismissal() async {
+        let presentationState = AppPresentationState()
+        let controller = TransientToastController(presentationState: presentationState)
+
+        controller.showToast("First", style: .success, durationNanoseconds: 5_000_000)
+        controller.showToast("Second", style: .informational, durationNanoseconds: 1_000_000_000)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(presentationState.transientToast?.message, "Second")
+        XCTAssertEqual(presentationState.transientToast?.style, .informational)
+    }
+
+    func testShowToastDismissesAfterDelay() async {
+        let presentationState = AppPresentationState()
+        let controller = TransientToastController(presentationState: presentationState)
+
+        controller.showToast("Saved", durationNanoseconds: 5_000_000)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertNil(presentationState.transientToast)
+    }
+
+    func testDismissToastCancelsScheduledDismissal() async {
+        let presentationState = AppPresentationState()
+        let controller = TransientToastController(presentationState: presentationState)
+
+        controller.showToast("Saved", durationNanoseconds: 1_000_000_000)
+        controller.dismissToast()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertNil(presentationState.transientToast)
+    }
+}


### PR DESCRIPTION
## Summary
- move transient toast presentation and scheduled dismissal into `TransientToastController`
- keep AppState as the caller while removing its private toast task ownership
- add focused controller tests for presentation, replacement, delayed dismissal, and manual dismissal

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/TransientToastControllerTests`\n- `./scripts/validate.sh origin/main`\n\nCloses #123