### PR TITLE
Extract ApplicationTerminationController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
 		121A00000000000000000001 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000003 /* AppUtilityActionController.swift */; };
 		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
+		125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000003 /* ApplicationTerminationController.swift */; };
+		125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -228,6 +230,8 @@
 		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
 		121A00000000000000000003 /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
 		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
+		125A00000000000000000003 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
+		125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -350,6 +354,7 @@
 				117A00000000000000000004 /* AppErrorPresenterTests.swift */,
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
 				121A00000000000000000004 /* AppUtilityActionControllerTests.swift */,
+				125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
@@ -471,6 +476,7 @@
 				99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */,
 				117A00000000000000000003 /* AppErrorPresenter.swift */,
 				121A00000000000000000003 /* AppUtilityActionController.swift */,
+				125A00000000000000000003 /* ApplicationTerminationController.swift */,
 				C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */,
 				8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */,
 				A663ED1B160E290FCFAC3AED /* ClipboardService.swift */,
@@ -698,6 +704,7 @@
 				117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */,
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
 				121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */,
+				125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
@@ -767,6 +774,7 @@
 				9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */,
 				C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */,
 				121A00000000000000000001 /* AppUtilityActionController.swift in Sources */,
+				125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */,
 				EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */,
 				3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */,
 				456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -22,6 +22,7 @@ final class AppState: ObservableObject {
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
     let appUtilityActions: AppUtilityActionController
+    let applicationTerminationController: ApplicationTerminationController
     let supportDataController: SupportDataController
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
@@ -238,44 +239,51 @@ final class AppState: ObservableObject {
             presentationState: presentationState,
             telemetryRecorder: telemetryRecorder
         )
-        self.transientToastController = TransientToastController(presentationState: presentationState)
-        self.recordingSessionController = RecordingSessionController(
+        let transientToastController = TransientToastController(presentationState: presentationState)
+        self.transientToastController = transientToastController
+        let recordingSessionController = RecordingSessionController(
             audioRecorder: audioRecorder,
             microphonePermissionService: microphonePermissionService,
             artifactsService: artifactsService,
             recordingTimer: recordingTimer
         )
-        self.sessionLibrary = SessionLibraryController(
+        self.recordingSessionController = recordingSessionController
+        let sessionLibrary = SessionLibraryController(
             transcriptStore: transcriptStore,
             artifactsService: artifactsService,
             clipboardService: clipboardService
         )
+        self.sessionLibrary = sessionLibrary
         self.exportHistoryController = ExportHistoryController(exportService: exportService)
         self.recoveredRecordingImportController = RecoveredRecordingImportController(
             transcriptStore: transcriptStore,
-            sessionLibrary: self.sessionLibrary,
+            sessionLibrary: sessionLibrary,
             recoveredRecordingImporter: recoveredRecordingImporter,
             artifactsService: artifactsService
         )
-        self.issueExtractionController = IssueExtractionController(
-            sessionLibrary: self.sessionLibrary,
+        let issueExtractionController = IssueExtractionController(
+            sessionLibrary: sessionLibrary,
             issueExtractionService: issueExtractionService
         )
-        self.issueExportController = IssueExportController(
+        self.issueExtractionController = issueExtractionController
+        let issueExportController = IssueExportController(
             settingsStore: settingsStore,
-            sessionLibrary: self.sessionLibrary,
+            sessionLibrary: sessionLibrary,
             exportService: exportService
         )
-        self.permissionRecoveryController = PermissionRecoveryController(
+        self.issueExportController = issueExportController
+        let permissionRecoveryController = PermissionRecoveryController(
             microphonePermissionService: microphonePermissionService,
             screenCapturePermissionService: screenCapturePermissionService,
             urlHandler: urlHandler,
             runtimeEnvironment: runtimeEnvironment
         )
-        self.appUtilityActions = AppUtilityActionController(
+        self.permissionRecoveryController = permissionRecoveryController
+        let appUtilityActions = AppUtilityActionController(
             urlHandler: urlHandler,
-            permissionRecoveryController: self.permissionRecoveryController
+            permissionRecoveryController: permissionRecoveryController
         )
+        self.appUtilityActions = appUtilityActions
         self.supportDataController = SupportDataController(
             settingsStore: settingsStore,
             transcriptStore: transcriptStore,
@@ -288,20 +296,21 @@ final class AppState: ObservableObject {
         )
         self.localDataDeletionController = LocalDataDeletionController(
             transcriptStore: transcriptStore,
-            sessionLibrary: self.sessionLibrary,
+            sessionLibrary: sessionLibrary,
             supportDataController: self.supportDataController,
             exportHistoryController: self.exportHistoryController
         )
         self.transcriptionRecovery = TranscriptionRecoveryController(
-            sessionLibrary: self.sessionLibrary,
+            sessionLibrary: sessionLibrary,
             artifactsService: artifactsService
         )
-        self.screenshotCoordinator = ScreenshotCoordinator(
+        let screenshotCoordinator = ScreenshotCoordinator(
             screenCapturePermissionService: screenCapturePermissionService,
             screenshotCaptureService: screenshotCaptureService,
             screenshotSelectionService: screenshotSelectionService,
             artifactsService: artifactsService
         )
+        self.screenshotCoordinator = screenshotCoordinator
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
         self.artifactsService = artifactsService
@@ -314,6 +323,33 @@ final class AppState: ObservableObject {
         self.aiProviderSettings = AIProviderSettingsController(
             settingsStore: settingsStore,
             transcriptionClient: transcriptionClient
+        )
+        self.applicationTerminationController = ApplicationTerminationController(
+            statusPhase: { presentationState.status.phase },
+            activeRecordingSession: { recordingSessionController.activeRecordingSession },
+            isExtractingIssues: { issueExtractionController.issueExtractionSessionID != nil },
+            isExporting: { issueExportController.exportDestinationInProgress != nil },
+            cancelPendingScreenshotSelection: { reason in
+                screenshotCoordinator.cancelPendingSelection(reason: reason)
+            },
+            showRecordingControls: {
+                appUtilityActions.openRecordingControls()
+            },
+            showToast: { message, style in
+                transientToastController.showToast(message, style: style)
+            },
+            dismissToast: {
+                transientToastController.dismissToast()
+            },
+            unregisterHotkeys: {
+                hotkeyManager.unregisterAll()
+            },
+            stopTimer: { resetElapsed in
+                recordingSessionController.stopTimer(resetElapsed: resetElapsed)
+            },
+            endActivity: {
+                recordingSessionController.endActivity()
+            }
         )
 
         BugNarratorDiagnostics.setDebugModeEnabled(settingsStore.debugMode)
@@ -760,28 +796,11 @@ final class AppState: ObservableObject {
     }
 
     func requestApplicationTermination() {
-        guard applicationShouldTerminate() == .terminateNow else {
-            return
-        }
-
-        NSApp.terminate(nil)
+        applicationTerminationController.requestApplicationTermination()
     }
 
     func applicationShouldTerminate() -> NSApplication.TerminateReply {
-        guard status.phase == .recording,
-              let activeRecordingSession else {
-            return .terminateNow
-        }
-
-        recordingLogger.warning(
-            "termination_blocked_while_recording",
-            "BugNarrator blocked an app termination request while a recording session was still active.",
-            metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
-        )
-        cancelPendingScreenshotSelection(reason: "Quit was requested while recording, so pending screenshot selection was cancelled.")
-        showRecordingControlWindow?()
-        showToast("Stop recording before quitting BugNarrator.", style: .informational)
-        return .terminateCancel
+        applicationTerminationController.applicationShouldTerminate()
     }
 
     func openAbout() {
@@ -1390,29 +1409,7 @@ final class AppState: ObservableObject {
     }
 
     private func prepareForApplicationTermination() {
-        settingsLogger.info(
-            "application_will_terminate",
-            "BugNarrator is preparing for application shutdown.",
-            metadata: [
-                "status_phase": status.phase.debugName,
-                "has_active_recording_session": activeRecordingSession == nil ? "no" : "yes",
-                "is_extracting_issues": issueExtractionController.issueExtractionSessionID == nil ? "no" : "yes",
-                "is_exporting": issueExportController.exportDestinationInProgress == nil ? "no" : "yes"
-            ]
-        )
-
-        if let activeRecordingSession {
-            recordingLogger.warning(
-                "application_terminating_during_recording",
-                "BugNarrator is terminating while a recording session is still active.",
-                metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
-            )
-        }
-
-        transientToastController.dismissToast()
-        hotkeyManager.unregisterAll()
-        stopTimer(resetElapsed: false)
-        endActivity()
+        applicationTerminationController.prepareForApplicationTermination()
     }
 
     private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {
@@ -1934,22 +1931,4 @@ final class AppState: ObservableObject {
         }
     }
 
-}
-
-
-private extension AppStatus.Phase {
-    var debugName: String {
-        switch self {
-        case .idle:
-            return "idle"
-        case .recording:
-            return "recording"
-        case .transcribing:
-            return "transcribing"
-        case .success:
-            return "success"
-        case .error:
-            return "error"
-        }
-    }
 }

--- a/Sources/BugNarrator/Services/ApplicationTerminationController.swift
+++ b/Sources/BugNarrator/Services/ApplicationTerminationController.swift
@@ -1,0 +1,121 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class ApplicationTerminationController {
+    private let statusPhase: () -> AppStatus.Phase
+    private let activeRecordingSession: () -> RecordingSessionDraft?
+    private let isExtractingIssues: () -> Bool
+    private let isExporting: () -> Bool
+    private let cancelPendingScreenshotSelection: (String) -> Void
+    private let showRecordingControls: () -> Void
+    private let showToast: (String, TransientToastStyle) -> Void
+    private let dismissToast: () -> Void
+    private let unregisterHotkeys: () -> Void
+    private let stopTimer: (Bool) -> Void
+    private let endActivity: () -> Void
+    private let terminateApplication: () -> Void
+    private let recordingLogger: DiagnosticsLogger
+    private let settingsLogger: DiagnosticsLogger
+
+    init(
+        statusPhase: @escaping () -> AppStatus.Phase,
+        activeRecordingSession: @escaping () -> RecordingSessionDraft?,
+        isExtractingIssues: @escaping () -> Bool,
+        isExporting: @escaping () -> Bool,
+        cancelPendingScreenshotSelection: @escaping (String) -> Void,
+        showRecordingControls: @escaping () -> Void,
+        showToast: @escaping (String, TransientToastStyle) -> Void,
+        dismissToast: @escaping () -> Void,
+        unregisterHotkeys: @escaping () -> Void,
+        stopTimer: @escaping (Bool) -> Void,
+        endActivity: @escaping () -> Void,
+        terminateApplication: @escaping () -> Void = { NSApp.terminate(nil) },
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording),
+        settingsLogger: DiagnosticsLogger = DiagnosticsLogger(category: .settings)
+    ) {
+        self.statusPhase = statusPhase
+        self.activeRecordingSession = activeRecordingSession
+        self.isExtractingIssues = isExtractingIssues
+        self.isExporting = isExporting
+        self.cancelPendingScreenshotSelection = cancelPendingScreenshotSelection
+        self.showRecordingControls = showRecordingControls
+        self.showToast = showToast
+        self.dismissToast = dismissToast
+        self.unregisterHotkeys = unregisterHotkeys
+        self.stopTimer = stopTimer
+        self.endActivity = endActivity
+        self.terminateApplication = terminateApplication
+        self.recordingLogger = recordingLogger
+        self.settingsLogger = settingsLogger
+    }
+
+    func requestApplicationTermination() {
+        guard applicationShouldTerminate() == .terminateNow else {
+            return
+        }
+
+        terminateApplication()
+    }
+
+    func applicationShouldTerminate() -> NSApplication.TerminateReply {
+        guard statusPhase() == .recording,
+              let activeRecordingSession = activeRecordingSession() else {
+            return .terminateNow
+        }
+
+        recordingLogger.warning(
+            "termination_blocked_while_recording",
+            "BugNarrator blocked an app termination request while a recording session was still active.",
+            metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
+        )
+        cancelPendingScreenshotSelection("Quit was requested while recording, so pending screenshot selection was cancelled.")
+        showRecordingControls()
+        showToast("Stop recording before quitting BugNarrator.", .informational)
+        return .terminateCancel
+    }
+
+    func prepareForApplicationTermination() {
+        let recordingSession = activeRecordingSession()
+        settingsLogger.info(
+            "application_will_terminate",
+            "BugNarrator is preparing for application shutdown.",
+            metadata: [
+                "status_phase": statusPhase().debugName,
+                "has_active_recording_session": recordingSession == nil ? "no" : "yes",
+                "is_extracting_issues": isExtractingIssues() ? "yes" : "no",
+                "is_exporting": isExporting() ? "yes" : "no"
+            ]
+        )
+
+        if let recordingSession {
+            recordingLogger.warning(
+                "application_terminating_during_recording",
+                "BugNarrator is terminating while a recording session is still active.",
+                metadata: ["session_id": recordingSession.sessionID.uuidString]
+            )
+        }
+
+        dismissToast()
+        unregisterHotkeys()
+        stopTimer(false)
+        endActivity()
+    }
+}
+
+private extension AppStatus.Phase {
+    var debugName: String {
+        switch self {
+        case .idle:
+            return "idle"
+        case .recording:
+            return "recording"
+        case .transcribing:
+            return "transcribing"
+        case .success:
+            return "success"
+        case .error:
+            return "error"
+        }
+    }
+}

--- a/Tests/BugNarratorTests/ApplicationTerminationControllerTests.swift
+++ b/Tests/BugNarratorTests/ApplicationTerminationControllerTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class ApplicationTerminationControllerTests: XCTestCase {
+    func testApplicationShouldTerminateAllowsQuitWhenNotRecording() {
+        let harness = ApplicationTerminationControllerHarness()
+
+        let reply = harness.controller.applicationShouldTerminate()
+
+        XCTAssertEqual(reply, .terminateNow)
+        XCTAssertEqual(harness.cancelReasons, [])
+        XCTAssertEqual(harness.recordingControlsShownCount, 0)
+        XCTAssertEqual(harness.toasts.count, 0)
+    }
+
+    func testApplicationShouldTerminateCancelsQuitWhileRecording() {
+        let harness = ApplicationTerminationControllerHarness()
+        harness.statusPhase = .recording
+        harness.activeRecordingSession = harness.makeRecordingSession()
+
+        let reply = harness.controller.applicationShouldTerminate()
+
+        XCTAssertEqual(reply, .terminateCancel)
+        XCTAssertEqual(harness.cancelReasons, ["Quit was requested while recording, so pending screenshot selection was cancelled."])
+        XCTAssertEqual(harness.recordingControlsShownCount, 1)
+        XCTAssertEqual(harness.toasts.map(\.message), ["Stop recording before quitting BugNarrator."])
+        XCTAssertEqual(harness.toasts.map(\.style), [.informational])
+    }
+
+    func testRequestApplicationTerminationInvokesInjectedTerminateOnlyWhenAllowed() {
+        let allowedHarness = ApplicationTerminationControllerHarness()
+
+        allowedHarness.controller.requestApplicationTermination()
+
+        XCTAssertEqual(allowedHarness.terminateCount, 1)
+
+        let blockedHarness = ApplicationTerminationControllerHarness()
+        blockedHarness.statusPhase = .recording
+        blockedHarness.activeRecordingSession = blockedHarness.makeRecordingSession()
+
+        blockedHarness.controller.requestApplicationTermination()
+
+        XCTAssertEqual(blockedHarness.terminateCount, 0)
+        XCTAssertEqual(blockedHarness.recordingControlsShownCount, 1)
+    }
+
+    func testPrepareForApplicationTerminationRunsCleanup() {
+        let harness = ApplicationTerminationControllerHarness()
+        harness.statusPhase = .recording
+        harness.activeRecordingSession = harness.makeRecordingSession()
+        harness.isExtractingIssues = true
+        harness.isExporting = true
+
+        harness.controller.prepareForApplicationTermination()
+
+        XCTAssertEqual(harness.dismissToastCount, 1)
+        XCTAssertEqual(harness.unregisterHotkeysCount, 1)
+        XCTAssertEqual(harness.stopTimerArguments, [false])
+        XCTAssertEqual(harness.endActivityCount, 1)
+    }
+}
+
+@MainActor
+private final class ApplicationTerminationControllerHarness {
+    struct CapturedToast {
+        let message: String
+        let style: TransientToastStyle
+    }
+
+    var statusPhase: AppStatus.Phase = .idle
+    var activeRecordingSession: RecordingSessionDraft?
+    var isExtractingIssues = false
+    var isExporting = false
+    var cancelReasons: [String] = []
+    var recordingControlsShownCount = 0
+    var toasts: [CapturedToast] = []
+    var dismissToastCount = 0
+    var unregisterHotkeysCount = 0
+    var stopTimerArguments: [Bool] = []
+    var endActivityCount = 0
+    var terminateCount = 0
+
+    lazy var controller = ApplicationTerminationController(
+        statusPhase: { [weak self] in self?.statusPhase ?? .idle },
+        activeRecordingSession: { [weak self] in self?.activeRecordingSession },
+        isExtractingIssues: { [weak self] in self?.isExtractingIssues ?? false },
+        isExporting: { [weak self] in self?.isExporting ?? false },
+        cancelPendingScreenshotSelection: { [weak self] reason in self?.cancelReasons.append(reason) },
+        showRecordingControls: { [weak self] in self?.recordingControlsShownCount += 1 },
+        showToast: { [weak self] message, style in self?.toasts.append(CapturedToast(message: message, style: style)) },
+        dismissToast: { [weak self] in self?.dismissToastCount += 1 },
+        unregisterHotkeys: { [weak self] in self?.unregisterHotkeysCount += 1 },
+        stopTimer: { [weak self] resetElapsed in self?.stopTimerArguments.append(resetElapsed) },
+        endActivity: { [weak self] in self?.endActivityCount += 1 },
+        terminateApplication: { [weak self] in self?.terminateCount += 1 }
+    )
+
+    func makeRecordingSession() -> RecordingSessionDraft {
+        RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("ApplicationTerminationControllerTests", isDirectory: true)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- move quit gating and shutdown cleanup into `ApplicationTerminationController`
- keep AppState public lifecycle methods as delegates while preserving recording quit behavior
- add focused lifecycle controller tests for terminate-now, terminate-cancel, request termination, and cleanup

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/ApplicationTerminationControllerTests`\n- `./scripts/validate.sh origin/main`\n\nCloses #125