### PR TITLE
Extract ScreenshotCaptureController from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
 		125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000003 /* ApplicationTerminationController.swift */; };
 		125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */; };
+		127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000003 /* ScreenshotCaptureController.swift */; };
+		127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -232,6 +234,8 @@
 		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
 		125A00000000000000000003 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
 		125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
+		127A00000000000000000003 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
+		127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -381,6 +385,7 @@
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
 				8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */,
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
+				127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */,
 				92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */,
 				20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
@@ -507,6 +512,7 @@
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
+				127A00000000000000000003 /* ScreenshotCaptureController.swift */,
 				440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */,
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
 				6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */,
@@ -731,6 +737,7 @@
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
 				28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */,
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
+				127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */,
 				52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */,
 				6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
@@ -829,6 +836,7 @@
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,
 				6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */,
+				127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */,
 				71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */,
 				CBE08ABB1F52871FE33471BA /* ScreenshotPreviewCache.swift in Sources */,
 				B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -27,6 +27,7 @@ final class AppState: ObservableObject {
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
+    let screenshotCaptureController: ScreenshotCaptureController
 
     var showTranscriptWindow: (() -> Void)? { get { appUtilityActions.showTranscriptWindow } set { appUtilityActions.showTranscriptWindow = newValue } }
     var showSettingsWindow: (() -> Void)? { get { appUtilityActions.showSettingsWindow } set { appUtilityActions.showSettingsWindow = newValue } }
@@ -35,8 +36,14 @@ final class AppState: ObservableObject {
     var showSupportWindow: (() -> Void)? { get { appUtilityActions.showSupportWindow } set { appUtilityActions.showSupportWindow = newValue } }
     var showRecordingControlWindow: (() -> Void)? { get { appUtilityActions.showRecordingControlWindow } set { appUtilityActions.showRecordingControlWindow = newValue } }
 
-    var prepareForScreenshotSelection: (() -> Void)?
-    var restoreAfterScreenshotSelection: (() -> Void)?
+    var prepareForScreenshotSelection: (() -> Void)? {
+        get { screenshotCaptureController.prepareForScreenshotSelection }
+        set { screenshotCaptureController.prepareForScreenshotSelection = newValue }
+    }
+    var restoreAfterScreenshotSelection: (() -> Void)? {
+        get { screenshotCaptureController.restoreAfterScreenshotSelection }
+        set { screenshotCaptureController.restoreAfterScreenshotSelection = newValue }
+    }
 
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
@@ -48,7 +55,6 @@ final class AppState: ObservableObject {
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
     private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
     private let permissionsLogger = DiagnosticsLogger(category: .permissions)
-    private let screenshotLogger = DiagnosticsLogger(category: .screenshots)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
     private var cancellables = Set<AnyCancellable>()
@@ -311,6 +317,40 @@ final class AppState: ObservableObject {
             artifactsService: artifactsService
         )
         self.screenshotCoordinator = screenshotCoordinator
+        self.screenshotCaptureController = ScreenshotCaptureController(
+            screenshotCoordinator: screenshotCoordinator,
+            recordingSessionController: recordingSessionController,
+            errorPresenter: self.errorPresenter,
+            statusPhase: { presentationState.status.phase },
+            elapsedDuration: { recordingTimer.elapsedDuration },
+            recordingDetailMessage: {
+                let prefix: String
+                switch settingsStore.recordingAudioSource {
+                case .microphone:
+                    prefix = "Recording in progress."
+                case .systemAudio:
+                    prefix = "Recording system audio."
+                case .microphoneAndSystemAudio:
+                    prefix = "Recording microphone and system audio."
+                }
+
+                if settingsStore.hasUsableAIProviderCredential && settingsStore.aiProviderCompatibilityIssue == nil {
+                    return prefix
+                }
+
+                if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
+                    return "\(prefix) \(compatibilityIssue)"
+                }
+
+                return "\(prefix) Finish the AI provider setup in Settings before stopping to transcribe this session."
+            },
+            setStatus: { status, error in
+                presentationState.setStatus(status, error: error)
+            },
+            showToast: { message, style in
+                transientToastController.showToast(message, style: style)
+            }
+        )
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
         self.artifactsService = artifactsService
@@ -552,7 +592,7 @@ final class AppState: ObservableObject {
     }
 
     var isScreenshotCaptureInProgress: Bool {
-        screenshotCoordinator.isCaptureInProgress
+        screenshotCaptureController.isCaptureInProgress
     }
 
     func isExtractingIssues(for session: TranscriptSession) -> Bool {
@@ -1071,104 +1111,7 @@ final class AppState: ObservableObject {
     }
 
     func captureScreenshot() async {
-        guard status.phase == .recording, let recordingSession = activeRecordingSession else {
-            let error = AppError.noActiveSession("Start a feedback session before capturing a screenshot.")
-            screenshotLogger.warning("screenshot_rejected_no_session", error.userMessage)
-            setStatus(.error(error.userMessage), error: error)
-            return
-        }
-
-        if isScreenshotCaptureInProgress {
-            let error = AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
-            screenshotLogger.warning("screenshot_rejected_busy", error.userMessage)
-            setStatus(.recording(error.userMessage), error: error)
-            return
-        }
-
-        let screenshotIndex = recordingSession.screenshots.count + 1
-        let markerIndex = recordingSession.markers.count + 1
-        let elapsedTime = max(recordingSessionController.currentDuration, elapsedDuration)
-        let markerID = UUID()
-        let markerTitle = "Screenshot \(screenshotIndex)"
-
-        do {
-            let captureResult = try await screenshotCoordinator.captureScreenshot(
-                in: recordingSession,
-                prefix: "capture",
-                index: screenshotIndex,
-                elapsedTime: elapsedTime,
-                associatedMarkerID: markerID,
-                onSelectionWillBegin: { [weak self] in
-                    self?.setStatus(.recording("Drag to select a screenshot region. Press Esc to cancel."))
-                    self?.prepareForScreenshotSelection?()
-                },
-                onSelectionDidEnd: { [weak self] in
-                    self?.restoreAfterScreenshotSelection?()
-                },
-                isSessionActive: { [weak self] sessionID in
-                    guard let self else {
-                        return false
-                    }
-                    return status.phase == .recording && activeRecordingSession?.sessionID == sessionID
-                }
-            )
-            guard case let .captured(screenshot) = captureResult else {
-                guard status.phase == .recording,
-                      activeRecordingSession?.sessionID == recordingSession.sessionID else {
-                    return
-                }
-                setStatus(.recording(recordingDetailMessage()))
-                showToast("Screenshot canceled", style: .informational)
-                return
-            }
-            guard status.phase == .recording,
-                  var latestRecordingSession = activeRecordingSession,
-                  latestRecordingSession.sessionID == recordingSession.sessionID else {
-                return
-            }
-            latestRecordingSession.markers.append(
-                SessionMarker(
-                    id: markerID,
-                    index: markerIndex,
-                    elapsedTime: elapsedTime,
-                    title: markerTitle,
-                    note: nil,
-                    screenshotID: screenshot.id
-                )
-            )
-            latestRecordingSession.screenshots.append(screenshot)
-            recordingSessionController.updateActiveRecordingSession(latestRecordingSession)
-            screenshotLogger.info(
-                "screenshot_captured",
-                "Captured a screenshot and inserted the automatic marker.",
-                metadata: [
-                    "session_id": recordingSession.sessionID.uuidString,
-                    "screenshot_index": "\(screenshotIndex)",
-                    "marker_index": "\(markerIndex)"
-                ]
-            )
-            setStatus(.recording("Captured \(markerTitle)."))
-            showToast("Screenshot captured")
-        } catch {
-            let normalizedError = errorPresenter.normalizeError(
-                error,
-                operation: .screenshotCapture,
-                fallback: { .screenshotCaptureFailure($0) }
-            )
-            let appError = normalizedError.appError
-            guard status.phase == .recording else {
-                return
-            }
-            errorPresenter.logAppError(normalizedError, context: "screenshot_capture_failed")
-            var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "screenshot_capture_failed")
-            metadata["session_id"] = recordingSession.sessionID.uuidString
-            screenshotLogger.error(
-                "screenshot_capture_failed",
-                appError.userMessage,
-                metadata: metadata
-            )
-            setStatus(.recording(appError.userMessage), error: appError)
-        }
+        await screenshotCaptureController.captureScreenshot()
     }
 
     private func transcriptionProgressMessage(step: Int, action: String) -> String {
@@ -1863,7 +1806,7 @@ final class AppState: ObservableObject {
     }
 
     private func cancelPendingScreenshotSelection(reason: String) {
-        screenshotCoordinator.cancelPendingSelection(reason: reason)
+        screenshotCaptureController.cancelPendingSelection(reason: reason)
     }
 
     private func showToast(_ message: String, style: TransientToastStyle = .success) {

--- a/Sources/BugNarrator/Services/ScreenshotCaptureController.swift
+++ b/Sources/BugNarrator/Services/ScreenshotCaptureController.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+@MainActor
+final class ScreenshotCaptureController {
+    var prepareForScreenshotSelection: (() -> Void)?
+    var restoreAfterScreenshotSelection: (() -> Void)?
+
+    private let screenshotCoordinator: ScreenshotCoordinator
+    private let recordingSessionController: RecordingSessionController
+    private let errorPresenter: AppErrorPresenter
+    private let statusPhase: () -> AppStatus.Phase
+    private let elapsedDuration: () -> TimeInterval
+    private let recordingDetailMessage: () -> String
+    private let setStatus: (AppStatus, AppError?) -> Void
+    private let showToast: (String, TransientToastStyle) -> Void
+    private let logger: DiagnosticsLogger
+
+    init(
+        screenshotCoordinator: ScreenshotCoordinator,
+        recordingSessionController: RecordingSessionController,
+        errorPresenter: AppErrorPresenter,
+        statusPhase: @escaping () -> AppStatus.Phase,
+        elapsedDuration: @escaping () -> TimeInterval,
+        recordingDetailMessage: @escaping () -> String,
+        setStatus: @escaping (AppStatus, AppError?) -> Void,
+        showToast: @escaping (String, TransientToastStyle) -> Void,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .screenshots)
+    ) {
+        self.screenshotCoordinator = screenshotCoordinator
+        self.recordingSessionController = recordingSessionController
+        self.errorPresenter = errorPresenter
+        self.statusPhase = statusPhase
+        self.elapsedDuration = elapsedDuration
+        self.recordingDetailMessage = recordingDetailMessage
+        self.setStatus = setStatus
+        self.showToast = showToast
+        self.logger = logger
+    }
+
+    var isCaptureInProgress: Bool {
+        screenshotCoordinator.isCaptureInProgress
+    }
+
+    func captureScreenshot() async {
+        guard statusPhase() == .recording,
+              let recordingSession = recordingSessionController.activeRecordingSession else {
+            let error = AppError.noActiveSession("Start a feedback session before capturing a screenshot.")
+            logger.warning("screenshot_rejected_no_session", error.userMessage)
+            setStatus(.error(error.userMessage), error)
+            return
+        }
+
+        if isCaptureInProgress {
+            let error = AppError.screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+            logger.warning("screenshot_rejected_busy", error.userMessage)
+            setStatus(.recording(error.userMessage), error)
+            return
+        }
+
+        let screenshotIndex = recordingSession.screenshots.count + 1
+        let markerIndex = recordingSession.markers.count + 1
+        let elapsedTime = max(recordingSessionController.currentDuration, elapsedDuration())
+        let markerID = UUID()
+        let markerTitle = "Screenshot \(screenshotIndex)"
+
+        do {
+            let captureResult = try await screenshotCoordinator.captureScreenshot(
+                in: recordingSession,
+                prefix: "capture",
+                index: screenshotIndex,
+                elapsedTime: elapsedTime,
+                associatedMarkerID: markerID,
+                onSelectionWillBegin: { [weak self] in
+                    self?.setStatus(.recording("Drag to select a screenshot region. Press Esc to cancel."), nil)
+                    self?.prepareForScreenshotSelection?()
+                },
+                onSelectionDidEnd: { [weak self] in
+                    self?.restoreAfterScreenshotSelection?()
+                },
+                isSessionActive: { [weak self] sessionID in
+                    guard let self else {
+                        return false
+                    }
+
+                    return statusPhase() == .recording
+                        && recordingSessionController.activeRecordingSession?.sessionID == sessionID
+                }
+            )
+            guard case let .captured(screenshot) = captureResult else {
+                guard statusPhase() == .recording,
+                      recordingSessionController.activeRecordingSession?.sessionID == recordingSession.sessionID else {
+                    return
+                }
+
+                setStatus(.recording(recordingDetailMessage()), nil)
+                showToast("Screenshot canceled", .informational)
+                return
+            }
+            guard statusPhase() == .recording,
+                  var latestRecordingSession = recordingSessionController.activeRecordingSession,
+                  latestRecordingSession.sessionID == recordingSession.sessionID else {
+                return
+            }
+            latestRecordingSession.markers.append(
+                SessionMarker(
+                    id: markerID,
+                    index: markerIndex,
+                    elapsedTime: elapsedTime,
+                    title: markerTitle,
+                    note: nil,
+                    screenshotID: screenshot.id
+                )
+            )
+            latestRecordingSession.screenshots.append(screenshot)
+            recordingSessionController.updateActiveRecordingSession(latestRecordingSession)
+            logger.info(
+                "screenshot_captured",
+                "Captured a screenshot and inserted the automatic marker.",
+                metadata: [
+                    "session_id": recordingSession.sessionID.uuidString,
+                    "screenshot_index": "\(screenshotIndex)",
+                    "marker_index": "\(markerIndex)"
+                ]
+            )
+            setStatus(.recording("Captured \(markerTitle)."), nil)
+            showToast("Screenshot captured", .success)
+        } catch {
+            let normalizedError = errorPresenter.normalizeError(
+                error,
+                operation: .screenshotCapture,
+                fallback: { .screenshotCaptureFailure($0) }
+            )
+            let appError = normalizedError.appError
+            guard statusPhase() == .recording else {
+                return
+            }
+
+            errorPresenter.logAppError(normalizedError, context: "screenshot_capture_failed")
+            var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "screenshot_capture_failed")
+            metadata["session_id"] = recordingSession.sessionID.uuidString
+            logger.error(
+                "screenshot_capture_failed",
+                appError.userMessage,
+                metadata: metadata
+            )
+            setStatus(.recording(appError.userMessage), appError)
+        }
+    }
+
+    func cancelPendingSelection(reason: String) {
+        screenshotCoordinator.cancelPendingSelection(reason: reason)
+    }
+}

--- a/Tests/BugNarratorTests/ScreenshotCaptureControllerTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotCaptureControllerTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class ScreenshotCaptureControllerTests: XCTestCase {
+    func testCaptureScreenshotWithoutActiveSessionShowsNoActiveSessionError() async throws {
+        let harness = try ScreenshotCaptureControllerHarness()
+        defer { harness.cleanup() }
+
+        await harness.controller.captureScreenshot()
+
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(
+            harness.presentationState.currentError,
+            .noActiveSession("Start a feedback session before capturing a screenshot.")
+        )
+        XCTAssertEqual(harness.selectionService.selectRegionCallCount, 0)
+    }
+
+    func testCaptureScreenshotStoresMetadataAndCreatesAutoMarker() async throws {
+        let harness = try ScreenshotCaptureControllerHarness()
+        defer { harness.cleanup() }
+        try await harness.startRecording()
+        harness.audioRecorder.currentDuration = 12
+
+        await harness.controller.captureScreenshot()
+
+        let recordingSession = try XCTUnwrap(harness.recordingSessionController.activeRecordingSession)
+        let screenshot = try XCTUnwrap(recordingSession.screenshots.first)
+        let autoMarker = try XCTUnwrap(recordingSession.markers.last)
+
+        XCTAssertEqual(recordingSession.screenshots.count, 1)
+        XCTAssertEqual(recordingSession.markers.count, 1)
+        XCTAssertEqual(screenshot.elapsedTime, 12)
+        XCTAssertEqual(screenshot.associatedMarkerID, autoMarker.id)
+        XCTAssertEqual(autoMarker.title, "Screenshot 1")
+        XCTAssertNil(autoMarker.note)
+        XCTAssertEqual(autoMarker.screenshotID, screenshot.id)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: screenshot.filePath))
+        XCTAssertEqual(harness.selectionService.selectRegionCallCount, 1)
+        XCTAssertEqual(harness.presentationState.status.phase, .recording)
+        XCTAssertEqual(harness.presentationState.status.detail, "Captured Screenshot 1.")
+        XCTAssertEqual(harness.presentationState.transientToast?.message, "Screenshot captured")
+    }
+
+    func testCaptureScreenshotCancellationKeepsRecordingWithoutCreatingMarkerOrScreenshot() async throws {
+        let selectionService = MockScreenshotSelectionService()
+        selectionService.nextResult = .cancelled
+        let harness = try ScreenshotCaptureControllerHarness(selectionService: selectionService)
+        defer { harness.cleanup() }
+        try await harness.startRecording()
+
+        await harness.controller.captureScreenshot()
+
+        XCTAssertEqual(harness.presentationState.status.phase, .recording)
+        XCTAssertEqual(harness.presentationState.status.detail, "Recording in progress.")
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.screenshots.count, 0)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.markers.count, 0)
+        XCTAssertEqual(harness.presentationState.transientToast?.message, "Screenshot canceled")
+        XCTAssertEqual(harness.presentationState.transientToast?.style, .informational)
+    }
+
+    func testCaptureScreenshotBusyKeepsRecordingAndShowsBusyError() async throws {
+        let selectionStarted = expectation(description: "selection started")
+        let selectionService = MockScreenshotSelectionService()
+        selectionService.suspendUntilCancelled = true
+        selectionService.onSelectRegionStart = {
+            selectionStarted.fulfill()
+        }
+        let harness = try ScreenshotCaptureControllerHarness(selectionService: selectionService)
+        defer { harness.cleanup() }
+        try await harness.startRecording()
+
+        async let firstCapture: Void = harness.controller.captureScreenshot()
+        await fulfillment(of: [selectionStarted], timeout: 1.0)
+        await harness.controller.captureScreenshot()
+
+        XCTAssertEqual(harness.presentationState.status.phase, .recording)
+        XCTAssertEqual(
+            harness.presentationState.currentError,
+            .screenshotCaptureFailure("Wait for the current screenshot to finish, then try again.")
+        )
+        harness.controller.cancelPendingSelection(reason: "Test cleanup cancels pending screenshot selection.")
+        _ = await firstCapture
+
+        XCTAssertEqual(selectionService.cancelActiveSelectionCallCount, 1)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.screenshots.count, 0)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.markers.count, 0)
+    }
+
+    func testCaptureScreenshotFailureKeepsRecordingAndShowsMessage() async throws {
+        let harness = try ScreenshotCaptureControllerHarness(
+            screenshotCaptureService: MockScreenshotCaptureService(
+                error: AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
+            )
+        )
+        defer { harness.cleanup() }
+        try await harness.startRecording()
+
+        await harness.controller.captureScreenshot()
+
+        XCTAssertEqual(harness.presentationState.status.phase, .recording)
+        XCTAssertEqual(
+            harness.presentationState.status.detail,
+            AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.").userMessage
+        )
+        XCTAssertEqual(
+            harness.presentationState.currentError,
+            AppError.screenshotCaptureFailure("The screenshot file could not be written to disk.")
+        )
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.screenshots.count, 0)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.markers.count, 0)
+    }
+}
+
+@MainActor
+private final class ScreenshotCaptureControllerHarness {
+    let rootDirectoryURL: URL
+    let audioRecorder: MockAudioRecorder
+    let artifactsService: MockArtifactsService
+    let presentationState: AppPresentationState
+    let recordingSessionController: RecordingSessionController
+    let screenshotCoordinator: ScreenshotCoordinator
+    let selectionService: MockScreenshotSelectionService
+    let controller: ScreenshotCaptureController
+
+    init(
+        screenshotCaptureService: MockScreenshotCaptureService = MockScreenshotCaptureService(),
+        selectionService: MockScreenshotSelectionService = MockScreenshotSelectionService()
+    ) throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("BugNarratorScreenshotCaptureControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        audioRecorder = MockAudioRecorder()
+        artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        presentationState = AppPresentationState()
+        recordingSessionController = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            artifactsService: artifactsService,
+            recordingTimer: RecordingTimerViewModel()
+        )
+        self.selectionService = selectionService
+        let permissionAccess = MockScreenCapturePermissionAccess()
+        permissionAccess.permissionState = .granted
+        screenshotCoordinator = ScreenshotCoordinator(
+            screenCapturePermissionService: ScreenCapturePermissionService(permissionAccess: permissionAccess),
+            screenshotCaptureService: screenshotCaptureService,
+            screenshotSelectionService: selectionService,
+            artifactsService: artifactsService
+        )
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: MockOperationalTelemetryRecorder()
+        )
+        controller = ScreenshotCaptureController(
+            screenshotCoordinator: screenshotCoordinator,
+            recordingSessionController: recordingSessionController,
+            errorPresenter: errorPresenter,
+            statusPhase: { [weak presentationState] in presentationState?.status.phase ?? .idle },
+            elapsedDuration: { 0 },
+            recordingDetailMessage: { "Recording in progress." },
+            setStatus: { [weak presentationState] status, error in
+                presentationState?.setStatus(status, error: error)
+            },
+            showToast: { [weak presentationState] message, style in
+                presentationState?.showToast(TransientToast(message: message, style: style))
+            }
+        )
+    }
+
+    func startRecording() async throws {
+        let outcome = await recordingSessionController.startSession(
+            statusPhase: presentationState.status.phase,
+            activityReason: "Recording test session"
+        )
+        guard case .started = outcome else {
+            throw AppError.recordingFailure("The test recording session did not start.")
+        }
+
+        presentationState.setStatus(.recording("Recording in progress."))
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}


### PR DESCRIPTION
## Summary
- move screenshot capture workflow out of AppState into `ScreenshotCaptureController`
- keep ScreenshotCoordinator as the capture primitive while the new controller owns status, marker insertion, callbacks, toast, and error presentation
- add focused controller tests for no-session, success, cancellation, busy, and failure paths

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/ScreenshotCaptureControllerTests`\n- `./scripts/validate.sh origin/main`\n\nCloses #127