### PR TITLE
Extract RecordingStatusMessageBuilder from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */; };
 		127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000003 /* ScreenshotCaptureController.swift */; };
 		127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */; };
+		129A00000000000000000001 /* RecordingStatusMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */; };
+		129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -236,6 +238,8 @@
 		125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
 		127A00000000000000000003 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
 		127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
+		129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilder.swift; sourceTree = "<group>"; };
+		129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -377,6 +381,7 @@
 				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
+				129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */,
 				3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */,
 				115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */,
 				2DE808CBBBE2F1EEE4FF5BEC /* RecoveredRecordingImporterTests.swift */,
@@ -553,6 +558,7 @@
 				6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */,
 				9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */,
 				17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */,
+				129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */,
 				002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */,
 				60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */,
 				57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */,
@@ -729,6 +735,7 @@
 				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
+				129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */,
 				2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */,
 				115A00000000000000000002 /* RecoveredRecordingImportControllerTests.swift in Sources */,
 				62313F663336184217D1020B /* RecoveredRecordingImporterTests.swift in Sources */,
@@ -828,6 +835,7 @@
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,
 				EA159F21E891A76BE6A4E825 /* RecordingSessionController.swift in Sources */,
+				129A00000000000000000001 /* RecordingStatusMessageBuilder.swift in Sources */,
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				A31A0BF8A4486E52DEA38F29 /* RecoveredRecordingImporter.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -324,25 +324,11 @@ final class AppState: ObservableObject {
             statusPhase: { presentationState.status.phase },
             elapsedDuration: { recordingTimer.elapsedDuration },
             recordingDetailMessage: {
-                let prefix: String
-                switch settingsStore.recordingAudioSource {
-                case .microphone:
-                    prefix = "Recording in progress."
-                case .systemAudio:
-                    prefix = "Recording system audio."
-                case .microphoneAndSystemAudio:
-                    prefix = "Recording microphone and system audio."
-                }
-
-                if settingsStore.hasUsableAIProviderCredential && settingsStore.aiProviderCompatibilityIssue == nil {
-                    return prefix
-                }
-
-                if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-                    return "\(prefix) \(compatibilityIssue)"
-                }
-
-                return "\(prefix) Finish the AI provider setup in Settings before stopping to transcribe this session."
+                RecordingStatusMessageBuilder.recordingDetailMessage(
+                    audioSource: settingsStore.recordingAudioSource,
+                    hasUsableAIProviderCredential: settingsStore.hasUsableAIProviderCredential,
+                    aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue
+                )
             },
             setStatus: { status, error in
                 presentationState.setStatus(status, error: error)
@@ -697,36 +683,15 @@ final class AppState: ObservableObject {
     }
 
     private func recordingDetailMessage() -> String {
-        let prefix: String
-        switch settingsStore.recordingAudioSource {
-        case .microphone:
-            prefix = "Recording in progress."
-        case .systemAudio:
-            prefix = "Recording system audio."
-        case .microphoneAndSystemAudio:
-            prefix = "Recording microphone and system audio."
-        }
-
-        if settingsStore.hasUsableAIProviderCredential && settingsStore.aiProviderCompatibilityIssue == nil {
-            return prefix
-        }
-
-        if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-            return "\(prefix) \(compatibilityIssue)"
-        }
-
-        return "\(prefix) Finish the AI provider setup in Settings before stopping to transcribe this session."
+        RecordingStatusMessageBuilder.recordingDetailMessage(
+            audioSource: settingsStore.recordingAudioSource,
+            hasUsableAIProviderCredential: settingsStore.hasUsableAIProviderCredential,
+            aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue
+        )
     }
 
     private func recordingActivityReason() -> String {
-        switch settingsStore.recordingAudioSource {
-        case .microphone:
-            return "Recording a spoken feedback session"
-        case .systemAudio:
-            return "Recording system audio for a feedback session"
-        case .microphoneAndSystemAudio:
-            return "Recording microphone and system audio for a feedback session"
-        }
+        RecordingStatusMessageBuilder.recordingActivityReason(audioSource: settingsStore.recordingAudioSource)
     }
 
     func stopSession() async {
@@ -1115,8 +1080,11 @@ final class AppState: ObservableObject {
     }
 
     private func transcriptionProgressMessage(step: Int, action: String) -> String {
-        let totalSteps = settingsStore.autoExtractIssues ? 3 : 2
-        return "Step \(step) of \(totalSteps): \(action)"
+        RecordingStatusMessageBuilder.transcriptionProgressMessage(
+            step: step,
+            action: action,
+            autoExtractIssues: settingsStore.autoExtractIssues
+        )
     }
 
     func extractIssuesForDisplayedTranscript() async {
@@ -1612,15 +1580,10 @@ final class AppState: ObservableObject {
     }
 
     private func transcriptionSuccessMessage() -> String {
-        if settingsStore.autoExtractIssues {
-            return "Session saved. Transcript and extracted issues are ready."
-        }
-
-        if settingsStore.autoCopyTranscript {
-            return "Session saved. Transcript copied to the clipboard."
-        }
-
-        return "Session saved locally and ready for review."
+        RecordingStatusMessageBuilder.transcriptionSuccessMessage(
+            autoExtractIssues: settingsStore.autoExtractIssues,
+            autoCopyTranscript: settingsStore.autoCopyTranscript
+        )
     }
 
     private func handleCompletedTranscriptPersistenceFailure(

--- a/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
+++ b/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum RecordingStatusMessageBuilder {
+    static func recordingDetailMessage(
+        audioSource: RecordingAudioSource,
+        hasUsableAIProviderCredential: Bool,
+        aiProviderCompatibilityIssue: String?
+    ) -> String {
+        let prefix: String
+        switch audioSource {
+        case .microphone:
+            prefix = "Recording in progress."
+        case .systemAudio:
+            prefix = "Recording system audio."
+        case .microphoneAndSystemAudio:
+            prefix = "Recording microphone and system audio."
+        }
+
+        if hasUsableAIProviderCredential && aiProviderCompatibilityIssue == nil {
+            return prefix
+        }
+
+        if let aiProviderCompatibilityIssue {
+            return "\(prefix) \(aiProviderCompatibilityIssue)"
+        }
+
+        return "\(prefix) Finish the AI provider setup in Settings before stopping to transcribe this session."
+    }
+
+    static func recordingActivityReason(audioSource: RecordingAudioSource) -> String {
+        switch audioSource {
+        case .microphone:
+            return "Recording a spoken feedback session"
+        case .systemAudio:
+            return "Recording system audio for a feedback session"
+        case .microphoneAndSystemAudio:
+            return "Recording microphone and system audio for a feedback session"
+        }
+    }
+
+    static func transcriptionProgressMessage(
+        step: Int,
+        action: String,
+        autoExtractIssues: Bool
+    ) -> String {
+        let totalSteps = autoExtractIssues ? 3 : 2
+        return "Step \(step) of \(totalSteps): \(action)"
+    }
+
+    static func transcriptionSuccessMessage(
+        autoExtractIssues: Bool,
+        autoCopyTranscript: Bool
+    ) -> String {
+        if autoExtractIssues {
+            return "Session saved. Transcript and extracted issues are ready."
+        }
+
+        if autoCopyTranscript {
+            return "Session saved. Transcript copied to the clipboard."
+        }
+
+        return "Session saved locally and ready for review."
+    }
+}

--- a/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
+++ b/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import BugNarrator
+
+final class RecordingStatusMessageBuilderTests: XCTestCase {
+    func testRecordingDetailMessageForAudioSources() {
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingDetailMessage(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil
+            ),
+            "Recording in progress."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingDetailMessage(
+                audioSource: .systemAudio,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil
+            ),
+            "Recording system audio."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingDetailMessage(
+                audioSource: .microphoneAndSystemAudio,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil
+            ),
+            "Recording microphone and system audio."
+        )
+    }
+
+    func testRecordingDetailMessageIncludesSetupAndCompatibilityGuidance() {
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingDetailMessage(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: false,
+                aiProviderCompatibilityIssue: nil
+            ),
+            "Recording in progress. Finish the AI provider setup in Settings before stopping to transcribe this session."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingDetailMessage(
+                audioSource: .systemAudio,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: "Choose a non-default API base URL for the OpenAI-Compatible provider."
+            ),
+            "Recording system audio. Choose a non-default API base URL for the OpenAI-Compatible provider."
+        )
+    }
+
+    func testRecordingActivityReasonForAudioSources() {
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingActivityReason(audioSource: .microphone),
+            "Recording a spoken feedback session"
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingActivityReason(audioSource: .systemAudio),
+            "Recording system audio for a feedback session"
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.recordingActivityReason(audioSource: .microphoneAndSystemAudio),
+            "Recording microphone and system audio for a feedback session"
+        )
+    }
+
+    func testTranscriptionProgressMessageUsesAutoExtractionStepCount() {
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.transcriptionProgressMessage(
+                step: 1,
+                action: "Uploading audio to OpenAI for transcription...",
+                autoExtractIssues: false
+            ),
+            "Step 1 of 2: Uploading audio to OpenAI for transcription..."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.transcriptionProgressMessage(
+                step: 3,
+                action: "Extracting reviewable issues...",
+                autoExtractIssues: true
+            ),
+            "Step 3 of 3: Extracting reviewable issues..."
+        )
+    }
+
+    func testTranscriptionSuccessMessageVariants() {
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.transcriptionSuccessMessage(
+                autoExtractIssues: true,
+                autoCopyTranscript: false
+            ),
+            "Session saved. Transcript and extracted issues are ready."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.transcriptionSuccessMessage(
+                autoExtractIssues: false,
+                autoCopyTranscript: true
+            ),
+            "Session saved. Transcript copied to the clipboard."
+        )
+        XCTAssertEqual(
+            RecordingStatusMessageBuilder.transcriptionSuccessMessage(
+                autoExtractIssues: false,
+                autoCopyTranscript: false
+            ),
+            "Session saved locally and ready for review."
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- move recording detail, activity reason, transcription progress, and success message policy into `RecordingStatusMessageBuilder`
- wire AppState and screenshot cancellation through the builder without changing user-facing text
- add focused tests for audio-source branches, setup/compatibility guidance, progress step counts, and success variants

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingStatusMessageBuilderTests`\n- `./scripts/validate.sh origin/main`\n\nCloses #129