### PR TITLE
Move displayed transcript copy action out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -946,17 +946,14 @@ final class AppState: ObservableObject {
     }
 
     func copyDisplayedTranscript() {
-        guard let transcript = displayedTranscript else {
+        switch sessionLibrary.copyDisplayedTranscript() {
+        case .noDisplayedTranscript:
             return
-        }
-
-        guard transcript.hasTranscriptContent else {
+        case .transcriptUnavailable:
             setStatus(.error("Transcription is not available yet. Retry the preserved session first."))
-            return
+        case .copied:
+            setStatus(.success("Transcript copied to the clipboard."))
         }
-
-        clipboardService.copy(transcript.transcript)
-        setStatus(.success("Transcript copied to the clipboard."))
     }
 
     func retryPendingTranscription(for sessionID: UUID) async {

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -1,6 +1,12 @@
 import Combine
 import Foundation
 
+enum DisplayedTranscriptCopyResult: Equatable {
+    case noDisplayedTranscript
+    case transcriptUnavailable
+    case copied
+}
+
 @MainActor
 final class SessionLibraryController: ObservableObject {
     @Published var currentTranscript: TranscriptSession?
@@ -169,6 +175,19 @@ final class SessionLibraryController: ObservableObject {
                 "auto_copied": autoCopyTranscript ? "yes" : "no"
             ]
         )
+    }
+
+    func copyDisplayedTranscript() -> DisplayedTranscriptCopyResult {
+        guard let transcript = displayedTranscript else {
+            return .noDisplayedTranscript
+        }
+
+        guard transcript.hasTranscriptContent else {
+            return .transcriptUnavailable
+        }
+
+        clipboardService.copy(transcript.transcript)
+        return .copied
     }
 
     func persistRetryableSession(_ session: TranscriptSession) throws {

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -120,9 +120,58 @@ final class SessionLibraryControllerTests: XCTestCase {
         XCTAssertEqual(harness.clipboardService.copiedStrings, ["Copy me"])
     }
 
+    func testCopyDisplayedTranscriptWithoutDisplayedTranscriptDoesNothing() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let result = harness.controller.copyDisplayedTranscript()
+
+        XCTAssertEqual(result, .noDisplayedTranscript)
+        XCTAssertTrue(harness.clipboardService.copiedStrings.isEmpty)
+    }
+
+    func testCopyDisplayedTranscriptWithoutTranscriptContentReturnsUnavailable() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let pendingSession = makeSession(
+            index: 1,
+            transcript: "   ",
+            pendingTranscription: PendingTranscription(
+                audioFileName: "recording.m4a",
+                failureReason: .missingAPIKey,
+                preservedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+        try harness.transcriptStore.add(pendingSession)
+        harness.controller.selectedTranscriptID = pendingSession.id
+
+        let result = harness.controller.copyDisplayedTranscript()
+
+        XCTAssertEqual(result, .transcriptUnavailable)
+        XCTAssertTrue(harness.clipboardService.copiedStrings.isEmpty)
+    }
+
+    func testCopyDisplayedTranscriptCopiesDisplayedTranscript() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let older = makeSession(index: 1, transcript: "Older transcript")
+        let displayed = makeSession(index: 2, transcript: "Displayed transcript")
+        try harness.transcriptStore.add(older)
+        try harness.transcriptStore.add(displayed)
+        harness.controller.selectedTranscriptID = displayed.id
+
+        let result = harness.controller.copyDisplayedTranscript()
+
+        XCTAssertEqual(result, .copied)
+        XCTAssertEqual(harness.clipboardService.copiedStrings, ["Displayed transcript"])
+    }
+
     private func makeSession(
         index: Int,
         transcript: String? = nil,
+        pendingTranscription: PendingTranscription? = nil,
         artifactsDirectoryPath: String? = nil
     ) -> TranscriptSession {
         TranscriptSession(
@@ -133,6 +182,7 @@ final class SessionLibraryControllerTests: XCTestCase {
             model: "whisper-1",
             languageHint: nil,
             prompt: nil,
+            pendingTranscription: pendingTranscription,
             artifactsDirectoryPath: artifactsDirectoryPath
         )
     }


### PR DESCRIPTION
## Summary
- Move displayed transcript copy validation and clipboard write into SessionLibraryController
- Keep AppState responsible for mapping copy results to existing status messages
- Add SessionLibraryController coverage for no transcript, unavailable transcript content, and successful copy

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #133