### PR TITLE
Remove AppState stored clipboard dependency

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -48,7 +48,6 @@ final class AppState: ObservableObject {
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
     private let artifactsService: any SessionArtifactsManaging
-    private let clipboardService: any ClipboardWriting
     private let telemetryRecorder: any OperationalTelemetryRecording
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
@@ -340,7 +339,6 @@ final class AppState: ObservableObject {
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
         self.artifactsService = artifactsService
-        self.clipboardService = clipboardService
         self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
             settingsStore: settingsStore,
@@ -1528,10 +1526,7 @@ final class AppState: ObservableObject {
         case .finishedRecording:
             try persistCompletedTranscript(session)
         case .retry:
-            try persistUpdatedSession(session)
-            if settingsStore.autoCopyTranscript {
-                clipboardService.copy(session.transcript)
-            }
+            try persistUpdatedSession(session, autoCopyTranscript: settingsStore.autoCopyTranscript)
         }
     }
 
@@ -1587,12 +1582,11 @@ final class AppState: ObservableObject {
         _ error: Error,
         session: TranscriptSession
     ) {
-        sessionLibrary.stageCurrentTranscript(session)
+        sessionLibrary.stageCurrentTranscript(
+            session,
+            autoCopyTranscript: settingsStore.autoCopyTranscript
+        )
         recordingSessionController.clearActiveRecordingSession()
-
-        if settingsStore.autoCopyTranscript {
-            clipboardService.copy(session.transcript)
-        }
 
         cleanupPendingRecordedAudioIfNeeded()
         endActivity()
@@ -1757,8 +1751,14 @@ final class AppState: ObservableObject {
         )
     }
 
-    private func persistUpdatedSession(_ session: TranscriptSession) throws {
-        try sessionLibrary.persistUpdatedSession(session)
+    private func persistUpdatedSession(
+        _ session: TranscriptSession,
+        autoCopyTranscript: Bool = false
+    ) throws {
+        try sessionLibrary.persistUpdatedSession(
+            session,
+            autoCopyTranscript: autoCopyTranscript
+        )
     }
 
     private func sessionSnapshot(with sessionID: UUID) -> TranscriptSession? {

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -80,9 +80,16 @@ final class SessionLibraryController: ObservableObject {
         currentTranscript = session
     }
 
-    func stageCurrentTranscript(_ session: TranscriptSession) {
+    func stageCurrentTranscript(
+        _ session: TranscriptSession,
+        autoCopyTranscript: Bool = false
+    ) {
         currentTranscript = session
         selectedTranscriptID = session.id
+
+        if autoCopyTranscript {
+            clipboardService.copy(session.transcript)
+        }
     }
 
     func selectLatestPendingTranscriptionSession() {
@@ -197,7 +204,8 @@ final class SessionLibraryController: ObservableObject {
 
     func persistUpdatedSession(
         _ session: TranscriptSession,
-        updatedAt: Date = Date()
+        updatedAt: Date = Date(),
+        autoCopyTranscript: Bool = false
     ) throws {
         var session = session
         session.updatedAt = updatedAt
@@ -206,6 +214,10 @@ final class SessionLibraryController: ObservableObject {
 
         if transcriptStore.session(with: session.id) != nil {
             try transcriptStore.add(session)
+        }
+
+        if autoCopyTranscript {
+            clipboardService.copy(session.transcript)
         }
 
         selectedTranscriptID = session.id

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -120,6 +120,33 @@ final class SessionLibraryControllerTests: XCTestCase {
         XCTAssertEqual(harness.clipboardService.copiedStrings, ["Copy me"])
     }
 
+    func testStageCurrentTranscriptCopiesWhenRequested() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = makeSession(index: 1, transcript: "Recovered transcript")
+
+        harness.controller.stageCurrentTranscript(session, autoCopyTranscript: true)
+
+        XCTAssertEqual(harness.controller.currentTranscript?.id, session.id)
+        XCTAssertEqual(harness.controller.selectedTranscriptID, session.id)
+        XCTAssertEqual(harness.clipboardService.copiedStrings, ["Recovered transcript"])
+    }
+
+    func testPersistUpdatedSessionCopiesWhenRequested() throws {
+        let harness = try SessionLibraryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = makeSession(index: 1, transcript: "Retried transcript")
+        try harness.transcriptStore.add(session)
+
+        try harness.controller.persistUpdatedSession(session, autoCopyTranscript: true)
+
+        XCTAssertEqual(harness.controller.currentTranscript?.id, session.id)
+        XCTAssertEqual(harness.controller.selectedTranscriptID, session.id)
+        XCTAssertEqual(harness.clipboardService.copiedStrings, ["Retried transcript"])
+    }
+
     func testCopyDisplayedTranscriptWithoutDisplayedTranscriptDoesNothing() throws {
         let harness = try SessionLibraryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Move remaining transcript auto-copy paths into SessionLibraryController
- Remove AppState's stored clipboardService property and direct transcript clipboard writes
- Add SessionLibraryController coverage for staged and updated transcript auto-copy

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #135