### PR TITLE
Extract transcription session builder from AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */; };
 		131A00000000000000000001 /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000003 /* DebugSessionContextProvider.swift */; };
 		131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000004 /* DebugSessionContextProviderTests.swift */; };
+		137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000003 /* TranscriptionSessionBuilder.swift */; };
+		137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -244,6 +246,8 @@
 		129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
 		131A00000000000000000003 /* DebugSessionContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProvider.swift; sourceTree = "<group>"; };
 		131A00000000000000000004 /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
+		137A00000000000000000003 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
+		137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -409,6 +413,7 @@
 				123A00000000000000000004 /* TransientToastControllerTests.swift */,
 				7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */,
 				F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */,
+				137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */,
 				A31B0939DF668FFC71CD64FD /* TranscriptionRecoveryControllerTests.swift */,
 				8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */,
 				BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */,
@@ -570,6 +575,7 @@
 				57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */,
 				CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */,
 				CCCB5C9DAEB3066CA8E30234 /* SingleInstanceController.swift */,
+				137A00000000000000000003 /* TranscriptionSessionBuilder.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -767,6 +773,7 @@
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
 				38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */,
 				0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */,
+				137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */,
 				3CE176593C0130AB6B4A12BA /* TranscriptionRecoveryControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -872,6 +879,7 @@
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,
 				D0754552F75E1CE6B4128800 /* TranscriptExporter.swift in Sources */,
+				137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */,
 				7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */,
 				AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */,
 				6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -725,7 +725,7 @@ final class AppState: ObservableObject {
                 request: request,
                 apiKey: apiKey
             )
-            let session = makeTranscriptSession(
+            let session = TranscriptionSessionBuilder.completedSession(
                 from: recordingSession,
                 recordedAudio: recordedAudio,
                 request: request,
@@ -998,7 +998,7 @@ final class AppState: ObservableObject {
                 request: request,
                 apiKey: apiKey
             )
-            let updatedSession = makeRecoveredTranscriptSession(
+            let updatedSession = TranscriptionSessionBuilder.recoveredSession(
                 from: retryContext.session,
                 request: request,
                 result: result
@@ -1400,66 +1400,6 @@ final class AppState: ObservableObject {
         apiKey: String
     ) async throws -> TranscriptionResult {
         try await transcriptionClient.transcribe(fileURL: fileURL, apiKey: apiKey, request: request)
-    }
-
-    private func makeTranscriptSession(
-        from recordingSession: RecordingSessionDraft,
-        recordedAudio: RecordedAudio,
-        request: TranscriptionRequest,
-        result: TranscriptionResult
-    ) -> TranscriptSession {
-        let sections = TranscriptSectionBuilder.buildSections(
-            transcript: result.text,
-            segments: result.segments,
-            markers: recordingSession.markers,
-            duration: recordedAudio.duration
-        )
-
-        return TranscriptSession(
-            id: recordingSession.sessionID,
-            createdAt: Date(),
-            transcript: result.text,
-            duration: recordedAudio.duration,
-            model: request.model,
-            languageHint: request.languageHint,
-            prompt: request.prompt,
-            markers: recordingSession.markers,
-            screenshots: recordingSession.screenshots,
-            sections: sections,
-            transcriptQualityFindings: result.qualityFindings,
-            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
-        )
-    }
-
-    private func makeRecoveredTranscriptSession(
-        from session: TranscriptSession,
-        request: TranscriptionRequest,
-        result: TranscriptionResult
-    ) -> TranscriptSession {
-        let sections = TranscriptSectionBuilder.buildSections(
-            transcript: result.text,
-            segments: result.segments,
-            markers: session.markers,
-            duration: session.duration
-        )
-
-        return TranscriptSession(
-            id: session.id,
-            createdAt: session.createdAt,
-            transcript: result.text,
-            duration: session.duration,
-            model: request.model,
-            languageHint: request.languageHint,
-            prompt: request.prompt,
-            markers: session.markers,
-            screenshots: session.screenshots,
-            sections: sections,
-            issueExtraction: nil,
-            pendingTranscription: nil,
-            transcriptQualityFindings: result.qualityFindings,
-            updatedAt: Date(),
-            artifactsDirectoryPath: session.artifactsDirectoryPath
-        )
     }
 
     private func completePostTranscriptionPipeline(

--- a/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
+++ b/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum TranscriptionSessionBuilder {
+    static func completedSession(
+        from recordingSession: RecordingSessionDraft,
+        recordedAudio: RecordedAudio,
+        request: TranscriptionRequest,
+        result: TranscriptionResult,
+        createdAt: Date = Date()
+    ) -> TranscriptSession {
+        let sections = TranscriptSectionBuilder.buildSections(
+            transcript: result.text,
+            segments: result.segments,
+            markers: recordingSession.markers,
+            duration: recordedAudio.duration
+        )
+
+        return TranscriptSession(
+            id: recordingSession.sessionID,
+            createdAt: createdAt,
+            transcript: result.text,
+            duration: recordedAudio.duration,
+            model: request.model,
+            languageHint: request.languageHint,
+            prompt: request.prompt,
+            markers: recordingSession.markers,
+            screenshots: recordingSession.screenshots,
+            sections: sections,
+            transcriptQualityFindings: result.qualityFindings,
+            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
+        )
+    }
+
+    static func recoveredSession(
+        from session: TranscriptSession,
+        request: TranscriptionRequest,
+        result: TranscriptionResult
+    ) -> TranscriptSession {
+        let sections = TranscriptSectionBuilder.buildSections(
+            transcript: result.text,
+            segments: result.segments,
+            markers: session.markers,
+            duration: session.duration
+        )
+
+        return TranscriptSession(
+            id: session.id,
+            createdAt: session.createdAt,
+            transcript: result.text,
+            duration: session.duration,
+            model: request.model,
+            languageHint: request.languageHint,
+            prompt: request.prompt,
+            markers: session.markers,
+            screenshots: session.screenshots,
+            sections: sections,
+            issueExtraction: nil,
+            pendingTranscription: nil,
+            transcriptQualityFindings: result.qualityFindings,
+            updatedAt: Date(),
+            artifactsDirectoryPath: session.artifactsDirectoryPath
+        )
+    }
+}

--- a/Tests/BugNarratorTests/TranscriptionSessionBuilderTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionSessionBuilderTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import BugNarrator
+
+final class TranscriptionSessionBuilderTests: XCTestCase {
+    func testCompletedSessionPreservesRecordingContextAndBuildsSections() {
+        let screenshotID = UUID()
+        let marker = SessionMarker(
+            id: UUID(),
+            index: 1,
+            elapsedTime: 4,
+            createdAt: Date(timeIntervalSince1970: 90),
+            title: "Opened command center",
+            note: "Refresh crashed",
+            screenshotID: screenshotID
+        )
+        let screenshot = SessionScreenshot(
+            id: screenshotID,
+            createdAt: Date(timeIntervalSince1970: 95),
+            elapsedTime: 5,
+            filePath: "/tmp/command-center.png",
+            associatedMarkerID: marker.id
+        )
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/session-artifacts", isDirectory: true),
+            markers: [marker],
+            screenshots: [screenshot]
+        )
+        let recordedAudio = RecordedAudio(
+            fileURL: URL(fileURLWithPath: "/tmp/recording.m4a"),
+            duration: 10
+        )
+        let request = TranscriptionRequest(
+            model: "whisper-1",
+            languageHint: "en",
+            prompt: "Focus on tester narration."
+        )
+        let qualityFinding = TranscriptQualityFinding(
+            kind: .abruptEnding,
+            severity: .warning,
+            message: "Transcript may end abruptly."
+        )
+        let result = TranscriptionResult(
+            text: "The refresh button crashed after opening command center.",
+            segments: [
+                TranscriptionSegment(start: 0, end: 3, text: "The refresh button crashed"),
+                TranscriptionSegment(start: 4, end: 8, text: "after opening command center.")
+            ],
+            qualityFindings: [qualityFinding]
+        )
+        let createdAt = Date(timeIntervalSince1970: 100)
+
+        let session = TranscriptionSessionBuilder.completedSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: request,
+            result: result,
+            createdAt: createdAt
+        )
+
+        XCTAssertEqual(session.id, recordingSession.sessionID)
+        XCTAssertEqual(session.createdAt, createdAt)
+        XCTAssertEqual(session.updatedAt, createdAt)
+        XCTAssertEqual(session.transcript, result.text)
+        XCTAssertEqual(session.duration, recordedAudio.duration)
+        XCTAssertEqual(session.model, request.model)
+        XCTAssertEqual(session.languageHint, request.languageHint)
+        XCTAssertEqual(session.prompt, request.prompt)
+        XCTAssertEqual(session.markers, [marker])
+        XCTAssertEqual(session.screenshots, [screenshot])
+        XCTAssertEqual(session.transcriptQualityFindings, [qualityFinding])
+        XCTAssertEqual(session.artifactsDirectoryPath, recordingSession.artifactsDirectoryURL.path)
+        XCTAssertNil(session.issueExtraction)
+        XCTAssertNil(session.pendingTranscription)
+        XCTAssertEqual(session.sections.count, 2)
+        XCTAssertEqual(session.sections.last?.markerID, marker.id)
+        XCTAssertEqual(session.sections.last?.screenshotIDs, [screenshotID])
+    }
+
+    func testRecoveredSessionPreservesRecoverableContextAndClearsRetryState() {
+        let originalID = UUID()
+        let originalCreatedAt = Date(timeIntervalSince1970: 50)
+        let marker = SessionMarker(
+            index: 1,
+            elapsedTime: 2,
+            title: "Retry point",
+            screenshotID: nil
+        )
+        let original = TranscriptSession(
+            id: originalID,
+            createdAt: originalCreatedAt,
+            transcript: "",
+            duration: 8,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            markers: [marker],
+            screenshots: [],
+            issueExtraction: IssueExtractionResult(
+                summary: "Old extracted issue summary",
+                issues: []
+            ),
+            pendingTranscription: PendingTranscription(
+                audioFileName: "recording.m4a",
+                failureReason: .missingAPIKey,
+                preservedAt: Date(timeIntervalSince1970: 60)
+            ),
+            recoveredSourceFileName: "crash-recovery-recording.m4a",
+            artifactsDirectoryPath: "/tmp/recovered-session"
+        )
+        let request = TranscriptionRequest(
+            model: "gpt-4o-transcribe",
+            languageHint: "en",
+            prompt: "Recovered session prompt"
+        )
+        let qualityFinding = TranscriptQualityFinding(
+            kind: .shortTranscript,
+            severity: .warning,
+            message: "Short transcript."
+        )
+        let result = TranscriptionResult(
+            text: "Recovered retry transcript.",
+            segments: [],
+            qualityFindings: [qualityFinding]
+        )
+
+        let session = TranscriptionSessionBuilder.recoveredSession(
+            from: original,
+            request: request,
+            result: result
+        )
+
+        XCTAssertEqual(session.id, originalID)
+        XCTAssertEqual(session.createdAt, originalCreatedAt)
+        XCTAssertGreaterThanOrEqual(session.updatedAt, originalCreatedAt)
+        XCTAssertEqual(session.transcript, result.text)
+        XCTAssertEqual(session.duration, original.duration)
+        XCTAssertEqual(session.model, request.model)
+        XCTAssertEqual(session.languageHint, request.languageHint)
+        XCTAssertEqual(session.prompt, request.prompt)
+        XCTAssertEqual(session.markers, original.markers)
+        XCTAssertEqual(session.screenshots, original.screenshots)
+        XCTAssertEqual(session.transcriptQualityFindings, [qualityFinding])
+        XCTAssertNil(session.recoveredSourceFileName)
+        XCTAssertEqual(session.artifactsDirectoryPath, original.artifactsDirectoryPath)
+        XCTAssertNil(session.issueExtraction)
+        XCTAssertNil(session.pendingTranscription)
+        XCTAssertEqual(session.sections.last?.title, marker.title)
+    }
+}


### PR DESCRIPTION
## Summary
- Add TranscriptionSessionBuilder for completed and recovered transcript session mapping
- Update AppState to delegate session construction to the builder
- Add focused builder tests for field preservation, retry state clearing, section generation, and quality findings

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/TranscriptionSessionBuilderTests
- ./scripts/validate.sh origin/main

Closes #137