### PR TITLE
Move retryable session construction into TranscriptionSessionBuilder

### DIFF
--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -162,7 +162,7 @@ final class TranscriptionRecoveryController: ObservableObject {
                 recordedAudio,
                 in: recordingSession.artifactsDirectoryURL
             )
-            let retryableSession = makeRetryableSession(
+            let retryableSession = TranscriptionSessionBuilder.retryableSession(
                 from: recordingSession,
                 recordedAudio: recordedAudio,
                 request: request,
@@ -242,34 +242,6 @@ final class TranscriptionRecoveryController: ObservableObject {
         return preservedAudioURL
     }
 
-    private func makeRetryableSession(
-        from recordingSession: RecordingSessionDraft,
-        recordedAudio: RecordedAudio,
-        request: TranscriptionRequest,
-        failureReason: PendingTranscriptionFailureReason,
-        preservedAudioURL: URL
-    ) -> TranscriptSession {
-        TranscriptSession(
-            id: recordingSession.sessionID,
-            createdAt: Date(),
-            transcript: "",
-            duration: recordedAudio.duration,
-            model: request.model,
-            languageHint: request.languageHint,
-            prompt: request.prompt,
-            markers: recordingSession.markers,
-            screenshots: recordingSession.screenshots,
-            sections: [],
-            issueExtraction: nil,
-            pendingTranscription: PendingTranscription(
-                audioFileName: preservedAudioURL.lastPathComponent,
-                failureReason: failureReason,
-                preservedAt: Date()
-            ),
-            updatedAt: Date(),
-            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
-        )
-    }
 }
 
 struct PendingTranscriptionRetryContext {

--- a/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
+++ b/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
@@ -61,4 +61,35 @@ enum TranscriptionSessionBuilder {
             artifactsDirectoryPath: session.artifactsDirectoryPath
         )
     }
+
+    static func retryableSession(
+        from recordingSession: RecordingSessionDraft,
+        recordedAudio: RecordedAudio,
+        request: TranscriptionRequest,
+        failureReason: PendingTranscriptionFailureReason,
+        preservedAudioURL: URL,
+        createdAt: Date = Date(),
+        preservedAt: Date = Date()
+    ) -> TranscriptSession {
+        TranscriptSession(
+            id: recordingSession.sessionID,
+            createdAt: createdAt,
+            transcript: "",
+            duration: recordedAudio.duration,
+            model: request.model,
+            languageHint: request.languageHint,
+            prompt: request.prompt,
+            markers: recordingSession.markers,
+            screenshots: recordingSession.screenshots,
+            sections: [],
+            issueExtraction: nil,
+            pendingTranscription: PendingTranscription(
+                audioFileName: preservedAudioURL.lastPathComponent,
+                failureReason: failureReason,
+                preservedAt: preservedAt
+            ),
+            updatedAt: createdAt,
+            artifactsDirectoryPath: recordingSession.artifactsDirectoryURL.path
+        )
+    }
 }

--- a/Tests/BugNarratorTests/TranscriptionSessionBuilderTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionSessionBuilderTests.swift
@@ -147,4 +147,65 @@ final class TranscriptionSessionBuilderTests: XCTestCase {
         XCTAssertNil(session.pendingTranscription)
         XCTAssertEqual(session.sections.last?.title, marker.title)
     }
+
+    func testRetryableSessionPreservesRecordingContextAndPendingTranscriptionMetadata() {
+        let screenshotID = UUID()
+        let marker = SessionMarker(
+            index: 1,
+            elapsedTime: 3,
+            title: "Failure point",
+            screenshotID: screenshotID
+        )
+        let screenshot = SessionScreenshot(
+            id: screenshotID,
+            elapsedTime: 3,
+            filePath: "/tmp/failure-point.png",
+            associatedMarkerID: marker.id
+        )
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/retry-artifacts", isDirectory: true),
+            markers: [marker],
+            screenshots: [screenshot]
+        )
+        let recordedAudio = RecordedAudio(
+            fileURL: URL(fileURLWithPath: "/tmp/original-recording.m4a"),
+            duration: 12
+        )
+        let request = TranscriptionRequest(
+            model: "whisper-1",
+            languageHint: "en",
+            prompt: "Retry later"
+        )
+        let preservedAudioURL = URL(fileURLWithPath: "/tmp/retry-artifacts/preserved-recording.m4a")
+        let createdAt = Date(timeIntervalSince1970: 200)
+        let preservedAt = Date(timeIntervalSince1970: 205)
+
+        let session = TranscriptionSessionBuilder.retryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: request,
+            failureReason: .missingAPIKey,
+            preservedAudioURL: preservedAudioURL,
+            createdAt: createdAt,
+            preservedAt: preservedAt
+        )
+
+        XCTAssertEqual(session.id, recordingSession.sessionID)
+        XCTAssertEqual(session.createdAt, createdAt)
+        XCTAssertEqual(session.updatedAt, createdAt)
+        XCTAssertEqual(session.transcript, "")
+        XCTAssertEqual(session.duration, recordedAudio.duration)
+        XCTAssertEqual(session.model, request.model)
+        XCTAssertEqual(session.languageHint, request.languageHint)
+        XCTAssertEqual(session.prompt, request.prompt)
+        XCTAssertEqual(session.markers, [marker])
+        XCTAssertEqual(session.screenshots, [screenshot])
+        XCTAssertTrue(session.sections.isEmpty)
+        XCTAssertNil(session.issueExtraction)
+        XCTAssertEqual(session.pendingTranscription?.audioFileName, preservedAudioURL.lastPathComponent)
+        XCTAssertEqual(session.pendingTranscription?.failureReason, .missingAPIKey)
+        XCTAssertEqual(session.pendingTranscription?.preservedAt, preservedAt)
+        XCTAssertEqual(session.artifactsDirectoryPath, recordingSession.artifactsDirectoryURL.path)
+    }
 }


### PR DESCRIPTION
## Summary
- Add retryable pending-transcription session construction to TranscriptionSessionBuilder
- Remove duplicate retryable session mapping from TranscriptionRecoveryController
- Add deterministic builder coverage for pending transcription metadata and preserved recording context

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/TranscriptionSessionBuilderTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests
- ./scripts/validate.sh origin/main

Closes #139