### PR TITLE
Move transcription request construction out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -701,7 +701,7 @@ final class AppState: ObservableObject {
 
         cancelPendingScreenshotSelection(reason: "Stopping the active session cancels pending screenshot selection.")
         recordingSessionController.prepareForStopSession()
-        let request = makeTranscriptionRequest()
+        let request = settingsStore.transcriptionRequest
 
         do {
             logSessionStopRequested(recordingSession)
@@ -982,7 +982,7 @@ final class AppState: ObservableObject {
             return
         }
 
-        let request = makeTranscriptionRequest()
+        let request = settingsStore.transcriptionRequest
         sessionLibrary.stageCurrentTranscript(retryContext.session)
         setStatus(.transcribing(transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
         swapActivity(reason: "Retrying transcription from preserved audio")
@@ -1353,15 +1353,6 @@ final class AppState: ObservableObject {
 
     private func cleanupPendingRecordedAudioIfNeeded() {
         recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
-    }
-
-    private func makeTranscriptionRequest() -> TranscriptionRequest {
-        TranscriptionRequest(
-            model: settingsStore.preferredModelValue,
-            languageHint: settingsStore.normalizedLanguageHint,
-            prompt: settingsStore.normalizedPrompt,
-            apiBaseURL: settingsStore.openAIBaseURLValue
-        )
     }
 
     private func logSessionStopRequested(_ recordingSession: RecordingSessionDraft) {

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -474,6 +474,15 @@ final class SettingsStore: ObservableObject {
         normalizeOptional(transcriptionPrompt)
     }
 
+    var transcriptionRequest: TranscriptionRequest {
+        TranscriptionRequest(
+            model: preferredModelValue,
+            languageHint: normalizedLanguageHint,
+            prompt: normalizedPrompt,
+            apiBaseURL: openAIBaseURLValue
+        )
+    }
+
     var issueExtractionModelValue: String {
         let value = issueExtractionModel.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? "gpt-4.1-mini" : value

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -218,6 +218,26 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testTranscriptionRequestUsesNormalizedTranscriptionSettings() {
+        let suiteName = "BugNarrator-TranscriptionRequestSettingsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        store.preferredModel = "  gpt-4o-transcribe  "
+        store.languageHint = "  en  "
+        store.transcriptionPrompt = "  Focus on tester narration.  "
+        store.openAIBaseURL = "gateway.example.com/openai/"
+
+        let request = store.transcriptionRequest
+
+        XCTAssertEqual(request.model, "gpt-4o-transcribe")
+        XCTAssertEqual(request.languageHint, "en")
+        XCTAssertEqual(request.prompt, "Focus on tester narration.")
+        XCTAssertEqual(request.apiBaseURL.absoluteString, "https://gateway.example.com/openai")
+    }
+
     func testLocalCompatibleProviderRequiresExplicitBaseURLAndModels() {
         let suiteName = "BugNarrator-SettingsProviderCompatibility-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Summary
- Add a SettingsStore transcriptionRequest snapshot using existing normalized settings
- Replace AppState transcription request mapping with settingsStore.transcriptionRequest
- Add SettingsStore coverage for model, language hint, prompt, and API base URL mapping

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SettingsStoreTests
- ./scripts/validate.sh origin/main

Closes #141