### PR TITLE
Move utility action status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -23,6 +23,7 @@ final class AppState: ObservableObject {
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
     let appUtilityActions: AppUtilityActionController
+    let appUtilityActionPresenter: AppUtilityActionResultPresenter
     let applicationTerminationController: ApplicationTerminationController
     let supportDataController: SupportDataController
     let localDataDeletionController: LocalDataDeletionController
@@ -300,6 +301,13 @@ final class AppState: ObservableObject {
             permissionRecoveryController: permissionRecoveryController
         )
         self.appUtilityActions = appUtilityActions
+        let appUtilityActionPresenter = AppUtilityActionResultPresenter(
+            statusPhase: { presentationState.status.phase },
+            setStatus: { status in
+                presentationState.setStatus(status, error: nil)
+            }
+        )
+        self.appUtilityActionPresenter = appUtilityActionPresenter
         self.supportDataController = SupportDataController(
             settingsStore: settingsStore,
             transcriptStore: transcriptStore,
@@ -810,15 +818,15 @@ final class AppState: ObservableObject {
     }
 
     func openGitHubRepository() {
-        presentUtilityActionResult(appUtilityActions.openGitHubRepository())
+        appUtilityActionPresenter.present(appUtilityActions.openGitHubRepository())
     }
 
     func openDocumentation() {
-        presentUtilityActionResult(appUtilityActions.openDocumentation())
+        appUtilityActionPresenter.present(appUtilityActions.openDocumentation())
     }
 
     func openIssueReporter() {
-        presentUtilityActionResult(appUtilityActions.openIssueReporter())
+        appUtilityActionPresenter.present(appUtilityActions.openIssueReporter())
     }
 
     func openSupportDevelopment() {
@@ -826,23 +834,23 @@ final class AppState: ObservableObject {
     }
 
     func openSupportDonationPage() {
-        presentUtilityActionResult(appUtilityActions.openSupportDonationPage())
+        appUtilityActionPresenter.present(appUtilityActions.openSupportDonationPage())
     }
 
     func openMicrophonePrivacySettings() {
-        presentPermissionSettingsResult(appUtilityActions.openMicrophonePrivacySettings())
+        appUtilityActionPresenter.present(appUtilityActions.openMicrophonePrivacySettings())
     }
 
     func openScreenRecordingPrivacySettings() {
-        presentPermissionSettingsResult(appUtilityActions.openScreenRecordingPrivacySettings())
+        appUtilityActionPresenter.present(appUtilityActions.openScreenRecordingPrivacySettings())
     }
 
     func openSystemAudioPrivacySettings() {
-        presentPermissionSettingsResult(appUtilityActions.openSystemAudioPrivacySettings())
+        appUtilityActionPresenter.present(appUtilityActions.openSystemAudioPrivacySettings())
     }
 
     func checkForUpdates() {
-        presentUtilityActionResult(appUtilityActions.checkForUpdates())
+        appUtilityActionPresenter.present(appUtilityActions.checkForUpdates())
     }
 
     func copyDebugInfo() {
@@ -1225,7 +1233,7 @@ final class AppState: ObservableObject {
 
     func openScreenshot(_ screenshot: SessionScreenshot) {
         guard FileManager.default.fileExists(atPath: screenshot.fileURL.path) else {
-            presentUtilityActionFailure("The selected screenshot file is no longer available on this Mac.")
+            appUtilityActionPresenter.presentFailure("The selected screenshot file is no longer available on this Mac.")
             return
         }
 
@@ -1249,35 +1257,6 @@ final class AppState: ObservableObject {
             Task {
                 await captureScreenshot()
             }
-        }
-    }
-
-    private func presentUtilityActionResult(_ result: AppUtilityActionResult) {
-        guard case .failed(let message) = result else {
-            return
-        }
-
-        presentUtilityActionFailure(message)
-    }
-
-    private func presentPermissionSettingsResult(_ result: PermissionSettingsOpenResult) {
-        switch result {
-        case .opened:
-            return
-        case .failed(let message):
-            presentUtilityActionFailure(message)
-        }
-    }
-
-    private func presentUtilityActionFailure(_ message: String) {
-        settingsLogger.warning("utility_action_failed", message)
-        switch status.phase {
-        case .recording:
-            setStatus(.recording("\(message) Recording is still active."))
-        case .transcribing:
-            setStatus(.transcribing("\(message) Background work is still in progress."))
-        case .idle, .success, .error:
-            setStatus(.error(message))
         }
     }
 

--- a/Sources/BugNarrator/Services/AppUtilityActionController.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionController.swift
@@ -6,6 +6,55 @@ enum AppUtilityActionResult: Equatable {
 }
 
 @MainActor
+final class AppUtilityActionResultPresenter {
+    private let statusPhase: () -> AppStatus.Phase
+    private let setStatus: (AppStatus) -> Void
+    private let logger: DiagnosticsLogger
+
+    init(
+        statusPhase: @escaping () -> AppStatus.Phase,
+        setStatus: @escaping (AppStatus) -> Void,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .settings)
+    ) {
+        self.statusPhase = statusPhase
+        self.setStatus = setStatus
+        self.logger = logger
+    }
+
+    func present(_ result: AppUtilityActionResult) {
+        guard case .failed(let message) = result else {
+            return
+        }
+
+        presentFailure(message)
+    }
+
+    func present(_ result: PermissionSettingsOpenResult) {
+        guard case .failed(let message) = result else {
+            return
+        }
+
+        presentFailure(message)
+    }
+
+    func presentFailure(_ message: String) {
+        logger.warning("utility_action_failed", message)
+        setStatus(Self.failureStatus(message: message, statusPhase: statusPhase()))
+    }
+
+    static func failureStatus(message: String, statusPhase: AppStatus.Phase) -> AppStatus {
+        switch statusPhase {
+        case .recording:
+            return .recording("\(message) Recording is still active.")
+        case .transcribing:
+            return .transcribing("\(message) Background work is still in progress.")
+        case .idle, .success, .error:
+            return .error(message)
+        }
+    }
+}
+
+@MainActor
 final class AppUtilityActionController {
     var showTranscriptWindow: (() -> Void)?
     var showSettingsWindow: (() -> Void)?

--- a/Tests/BugNarratorTests/AppUtilityActionControllerTests.swift
+++ b/Tests/BugNarratorTests/AppUtilityActionControllerTests.swift
@@ -46,6 +46,61 @@ final class AppUtilityActionControllerTests: XCTestCase {
         XCTAssertEqual(result, .opened(BugNarratorLinks.microphonePrivacySettings))
         XCTAssertEqual(harness.urlHandler.openedURLs, [BugNarratorLinks.microphonePrivacySettings])
     }
+
+    func testFailureStatusPreservesActiveWorkPhases() {
+        let message = "BugNarrator could not open the documentation."
+
+        XCTAssertEqual(
+            AppUtilityActionResultPresenter.failureStatus(message: message, statusPhase: .recording),
+            .recording("BugNarrator could not open the documentation. Recording is still active.")
+        )
+        XCTAssertEqual(
+            AppUtilityActionResultPresenter.failureStatus(message: message, statusPhase: .transcribing),
+            .transcribing("BugNarrator could not open the documentation. Background work is still in progress.")
+        )
+    }
+
+    func testFailureStatusMapsInactivePhasesToError() {
+        let message = "The selected screenshot file is no longer available on this Mac."
+
+        XCTAssertEqual(
+            AppUtilityActionResultPresenter.failureStatus(message: message, statusPhase: .idle),
+            .error(message)
+        )
+        XCTAssertEqual(
+            AppUtilityActionResultPresenter.failureStatus(message: message, statusPhase: .success),
+            .error(message)
+        )
+        XCTAssertEqual(
+            AppUtilityActionResultPresenter.failureStatus(message: message, statusPhase: .error),
+            .error(message)
+        )
+    }
+
+    func testPresenterAppliesFailedResultsAndIgnoresOpenedResults() {
+        var phase = AppStatus.Phase.idle
+        var statuses: [AppStatus] = []
+        let presenter = AppUtilityActionResultPresenter(
+            statusPhase: { phase },
+            setStatus: { statuses.append($0) }
+        )
+
+        presenter.present(AppUtilityActionResult.opened)
+        presenter.present(PermissionSettingsOpenResult.opened(BugNarratorLinks.microphonePrivacySettings))
+        XCTAssertTrue(statuses.isEmpty)
+
+        presenter.present(AppUtilityActionResult.failed(message: "BugNarrator could not open the issue tracker."))
+        phase = .recording
+        presenter.present(PermissionSettingsOpenResult.failed("BugNarrator could not open System Settings."))
+
+        XCTAssertEqual(
+            statuses,
+            [
+                .error("BugNarrator could not open the issue tracker."),
+                .recording("BugNarrator could not open System Settings. Recording is still active.")
+            ]
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Add an AppUtilityActionResultPresenter for utility and permission settings result failures
- Move phase-specific utility action failure status mapping out of AppState
- Route missing screenshot-file presentation through the same presenter and cover status mapping in tests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppUtilityActionControllerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #147