### PR TITLE
Move deleted session status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1057,7 +1057,10 @@ final class AppState: ObservableObject {
 
     func deleteDisplayedTranscript() {
         do {
-            presentDeletedSessionStatus(try sessionLibrary.deleteDisplayedTranscript())
+            let deletedCount = try sessionLibrary.deleteDisplayedTranscript()
+            if let status = SessionDeletionStatusPresenter.status(deletedCount: deletedCount) {
+                setStatus(status)
+            }
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }
@@ -1065,15 +1068,12 @@ final class AppState: ObservableObject {
 
     func deleteSessions(withIDs ids: Set<UUID>) {
         do {
-            presentDeletedSessionStatus(try sessionLibrary.deleteSessions(withIDs: ids))
+            let deletedCount = try sessionLibrary.deleteSessions(withIDs: ids)
+            if let status = SessionDeletionStatusPresenter.status(deletedCount: deletedCount) {
+                setStatus(status)
+            }
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
-        }
-    }
-
-    private func presentDeletedSessionStatus(_ deletedCount: Int) {
-        if deletedCount > 0 {
-            setStatus(.success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions."))
         }
     }
 

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -7,6 +7,16 @@ enum DisplayedTranscriptCopyResult: Equatable {
     case copied
 }
 
+enum SessionDeletionStatusPresenter {
+    static func status(deletedCount: Int) -> AppStatus? {
+        guard deletedCount > 0 else {
+            return nil
+        }
+
+        return .success(deletedCount == 1 ? "Deleted 1 session." : "Deleted \(deletedCount) sessions.")
+    }
+}
+
 @MainActor
 final class SessionLibraryController: ObservableObject {
     @Published var currentTranscript: TranscriptSession?

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -107,6 +107,18 @@ final class SessionLibraryControllerTests: XCTestCase {
         XCTAssertEqual(harness.artifactsService.removedDirectories, [artifactsDirectoryURL])
     }
 
+    func testSessionDeletionStatusPresenterMapsDeletedCounts() {
+        XCTAssertNil(SessionDeletionStatusPresenter.status(deletedCount: 0))
+        XCTAssertEqual(
+            SessionDeletionStatusPresenter.status(deletedCount: 1),
+            .success("Deleted 1 session.")
+        )
+        XCTAssertEqual(
+            SessionDeletionStatusPresenter.status(deletedCount: 3),
+            .success("Deleted 3 sessions.")
+        )
+    }
+
     func testPersistCompletedTranscriptCopiesWhenRequested() throws {
         let harness = try SessionLibraryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add SessionDeletionStatusPresenter beside the session library deletion code
- Update AppState deletion paths to apply the presenter result directly
- Remove AppState presentDeletedSessionStatus and cover zero/singular/plural mapping in tests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/SessionLibraryControllerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #151