### PR TITLE
Move hotkey settings binding out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -49,6 +49,7 @@ final class AppState: ObservableObject {
 
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
+    private let hotkeySettingsBinder: HotkeySettingsBinder
     private let artifactsService: any SessionArtifactsManaging
     private let telemetryRecorder: any OperationalTelemetryRecording
 
@@ -353,6 +354,7 @@ final class AppState: ObservableObject {
         )
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
+        self.hotkeySettingsBinder = HotkeySettingsBinder(hotkeyManager: hotkeyManager)
         self.artifactsService = artifactsService
         self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
@@ -473,27 +475,6 @@ final class AppState: ObservableObject {
             }
             .store(in: &cancellables)
 
-        settingsStore.$startRecordingHotkeyShortcut
-            .removeDuplicates()
-            .sink { [weak self] shortcut in
-                self?.hotkeyManager.register(shortcut: shortcut, for: .startRecording)
-            }
-            .store(in: &cancellables)
-
-        settingsStore.$stopRecordingHotkeyShortcut
-            .removeDuplicates()
-            .sink { [weak self] shortcut in
-                self?.hotkeyManager.register(shortcut: shortcut, for: .stopRecording)
-            }
-            .store(in: &cancellables)
-
-        settingsStore.$screenshotHotkeyShortcut
-            .removeDuplicates()
-            .sink { [weak self] shortcut in
-                self?.hotkeyManager.register(shortcut: shortcut, for: .captureScreenshot)
-            }
-            .store(in: &cancellables)
-
         NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
                 self?.refreshPermissionRecoveryState()
@@ -506,9 +487,7 @@ final class AppState: ObservableObject {
             }
             .store(in: &cancellables)
 
-        hotkeyManager.register(shortcut: settingsStore.startRecordingHotkeyShortcut, for: .startRecording)
-        hotkeyManager.register(shortcut: settingsStore.stopRecordingHotkeyShortcut, for: .stopRecording)
-        hotkeyManager.register(shortcut: settingsStore.screenshotHotkeyShortcut, for: .captureScreenshot)
+        hotkeySettingsBinder.bind(settingsStore: settingsStore)
 
         settingsLogger.info(
             "app_state_initialized",

--- a/Sources/BugNarrator/Services/HotkeyManager.swift
+++ b/Sources/BugNarrator/Services/HotkeyManager.swift
@@ -1,5 +1,49 @@
 import Carbon.HIToolbox
+import Combine
 import Foundation
+
+@MainActor
+final class HotkeySettingsBinder {
+    private let hotkeyManager: any HotkeyManaging
+    private var cancellables = Set<AnyCancellable>()
+
+    init(hotkeyManager: any HotkeyManaging) {
+        self.hotkeyManager = hotkeyManager
+    }
+
+    func bind(settingsStore: SettingsStore) {
+        cancellables.removeAll()
+
+        settingsStore.$startRecordingHotkeyShortcut
+            .removeDuplicates()
+            .sink { [weak self] shortcut in
+                self?.hotkeyManager.register(shortcut: shortcut, for: .startRecording)
+            }
+            .store(in: &cancellables)
+
+        settingsStore.$stopRecordingHotkeyShortcut
+            .removeDuplicates()
+            .sink { [weak self] shortcut in
+                self?.hotkeyManager.register(shortcut: shortcut, for: .stopRecording)
+            }
+            .store(in: &cancellables)
+
+        settingsStore.$screenshotHotkeyShortcut
+            .removeDuplicates()
+            .sink { [weak self] shortcut in
+                self?.hotkeyManager.register(shortcut: shortcut, for: .captureScreenshot)
+            }
+            .store(in: &cancellables)
+
+        register(assignments: settingsStore.hotkeyAssignments)
+    }
+
+    private func register(assignments: [(action: HotkeyAction, shortcut: HotkeyShortcut)]) {
+        for assignment in assignments {
+            hotkeyManager.register(shortcut: assignment.shortcut, for: assignment.action)
+        }
+    }
+}
 
 final class HotkeyManager: HotkeyManaging {
     var onHotKeyPressed: ((HotkeyAction) -> Void)?

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -144,6 +144,20 @@ final class AppStateTests: XCTestCase {
         )
     }
 
+    func testAppStateUpdatesRegisteredHotkeysWhenSettingsChange() {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        let updatedShortcut = HotkeyShortcut(
+            keyCode: 7,
+            modifiers: NSEvent.ModifierFlags.command.union(.option).rawValue
+        )
+
+        harness.settingsStore.startRecordingHotkeyShortcut = updatedShortcut
+
+        XCTAssertEqual(harness.hotkeyManager.registeredShortcuts[.startRecording], updatedShortcut)
+    }
+
     func testApplicationTerminationUnregistersHotkeys() {
         let harness = AppStateHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add HotkeySettingsBinder to own SettingsStore hotkey subscriptions and initial registration
- Remove repeated hotkey publisher wiring and initial register calls from AppState
- Add AppState coverage for subsequent hotkey setting changes reaching HotkeyManaging

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SettingsStoreTests
- ./scripts/validate.sh origin/main

Closes #153