### PR TITLE
Move AppState object change forwarding into helper

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -50,6 +50,7 @@ final class AppState: ObservableObject {
     private let transcriptionClient: any TranscriptionServing
     private let hotkeyManager: any HotkeyManaging
     private let hotkeySettingsBinder: HotkeySettingsBinder
+    private let objectChangeForwarder: ObservableObjectChangeForwarder
     private let artifactsService: any SessionArtifactsManaging
     private let telemetryRecorder: any OperationalTelemetryRecording
 
@@ -355,6 +356,7 @@ final class AppState: ObservableObject {
         self.transcriptionClient = transcriptionClient
         self.hotkeyManager = hotkeyManager
         self.hotkeySettingsBinder = HotkeySettingsBinder(hotkeyManager: hotkeyManager)
+        self.objectChangeForwarder = ObservableObjectChangeForwarder()
         self.artifactsService = artifactsService
         self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
@@ -409,71 +411,24 @@ final class AppState: ObservableObject {
             self?.showSettingsWindow?()
         }
 
-        trackerIntegration.objectWillChange
-            .sink { [weak self] _ in
+        objectChangeForwarder.forward(
+            [
+                trackerIntegration.objectWillChange,
+                aiProviderSettings.objectWillChange,
+                presentationState.objectWillChange,
+                recordingSessionController.objectWillChange,
+                sessionLibrary.objectWillChange,
+                exportHistoryController.objectWillChange,
+                recoveredRecordingImportController.objectWillChange,
+                issueExtractionController.objectWillChange,
+                issueExportController.objectWillChange,
+                transcriptionRecovery.objectWillChange,
+                screenshotCoordinator.objectWillChange
+            ],
+            notify: { [weak self] in
                 self?.objectWillChange.send()
             }
-            .store(in: &cancellables)
-
-        aiProviderSettings.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        presentationState.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        recordingSessionController.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        sessionLibrary.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        exportHistoryController.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        recoveredRecordingImportController.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        issueExtractionController.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        issueExportController.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        transcriptionRecovery.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
-
-        screenshotCoordinator.objectWillChange
-            .sink { [weak self] _ in
-                self?.objectWillChange.send()
-            }
-            .store(in: &cancellables)
+        )
 
         NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in

--- a/Sources/BugNarrator/Utilities/AppPresentationState.swift
+++ b/Sources/BugNarrator/Utilities/AppPresentationState.swift
@@ -2,6 +2,23 @@ import Combine
 import Foundation
 
 @MainActor
+final class ObservableObjectChangeForwarder {
+    private var cancellables = Set<AnyCancellable>()
+
+    func forward(_ publishers: [ObservableObjectPublisher], notify: @escaping () -> Void) {
+        cancellables.removeAll()
+
+        for publisher in publishers {
+            publisher
+                .sink { _ in
+                    notify()
+                }
+                .store(in: &cancellables)
+        }
+    }
+}
+
+@MainActor
 final class AppPresentationState: ObservableObject {
     @Published private(set) var status: AppStatus
     @Published private(set) var currentError: AppError?


### PR DESCRIPTION
## Summary
- Add ObservableObjectChangeForwarder to own child objectWillChange forwarding subscriptions
- Replace repeated AppState child forwarding sink blocks with one binding call
- Preserve notification observers and existing AppState object change behavior

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #155