### PR TITLE
Move AppState lifecycle notification binding into helper

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -51,6 +51,7 @@ final class AppState: ObservableObject {
     private let hotkeyManager: any HotkeyManaging
     private let hotkeySettingsBinder: HotkeySettingsBinder
     private let objectChangeForwarder: ObservableObjectChangeForwarder
+    private let lifecycleNotificationBinder: AppLifecycleNotificationBinder
     private let artifactsService: any SessionArtifactsManaging
     private let telemetryRecorder: any OperationalTelemetryRecording
 
@@ -59,8 +60,6 @@ final class AppState: ObservableObject {
     private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
     private let permissionsLogger = DiagnosticsLogger(category: .permissions)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
-
-    private var cancellables = Set<AnyCancellable>()
 
     private enum PostTranscriptionPipelineMode: Equatable {
         case finishedRecording
@@ -357,6 +356,7 @@ final class AppState: ObservableObject {
         self.hotkeyManager = hotkeyManager
         self.hotkeySettingsBinder = HotkeySettingsBinder(hotkeyManager: hotkeyManager)
         self.objectChangeForwarder = ObservableObjectChangeForwarder()
+        self.lifecycleNotificationBinder = AppLifecycleNotificationBinder()
         self.artifactsService = artifactsService
         self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
@@ -430,17 +430,14 @@ final class AppState: ObservableObject {
             }
         )
 
-        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
-            .sink { [weak self] _ in
+        lifecycleNotificationBinder.bind(
+            didBecomeActive: { [weak self] in
                 self?.refreshPermissionRecoveryState()
-            }
-            .store(in: &cancellables)
-
-        NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)
-            .sink { [weak self] _ in
+            },
+            willTerminate: { [weak self] in
                 self?.prepareForApplicationTermination()
             }
-            .store(in: &cancellables)
+        )
 
         hotkeySettingsBinder.bind(settingsStore: settingsStore)
 

--- a/Sources/BugNarrator/Utilities/AppPresentationState.swift
+++ b/Sources/BugNarrator/Utilities/AppPresentationState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import Foundation
 
@@ -15,6 +16,32 @@ final class ObservableObjectChangeForwarder {
                 }
                 .store(in: &cancellables)
         }
+    }
+}
+
+@MainActor
+final class AppLifecycleNotificationBinder {
+    private let notificationCenter: NotificationCenter
+    private var cancellables = Set<AnyCancellable>()
+
+    init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
+    }
+
+    func bind(didBecomeActive: @escaping () -> Void, willTerminate: @escaping () -> Void) {
+        cancellables.removeAll()
+
+        notificationCenter.publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { _ in
+                didBecomeActive()
+            }
+            .store(in: &cancellables)
+
+        notificationCenter.publisher(for: NSApplication.willTerminateNotification)
+            .sink { _ in
+                willTerminate()
+            }
+            .store(in: &cancellables)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add AppLifecycleNotificationBinder to own macOS lifecycle notification subscriptions
- Replace direct NotificationCenter publisher setup in AppState with explicit lifecycle callbacks
- Remove AppState's private Combine cancellables storage while preserving termination and activation behavior

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #157