### PR TITLE
Move AppState launch diagnostics into reporter

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -52,6 +52,7 @@ final class AppState: ObservableObject {
     private let hotkeySettingsBinder: HotkeySettingsBinder
     private let objectChangeForwarder: ObservableObjectChangeForwarder
     private let lifecycleNotificationBinder: AppLifecycleNotificationBinder
+    private let launchDiagnosticsReporter: AppLaunchDiagnosticsReporter
     private let artifactsService: any SessionArtifactsManaging
     private let telemetryRecorder: any OperationalTelemetryRecording
 
@@ -297,6 +298,10 @@ final class AppState: ObservableObject {
             runtimeEnvironment: runtimeEnvironment
         )
         self.permissionRecoveryController = permissionRecoveryController
+        self.launchDiagnosticsReporter = AppLaunchDiagnosticsReporter(
+            permissionRecoveryController: permissionRecoveryController,
+            transcriptStore: transcriptStore
+        )
         let appUtilityActions = AppUtilityActionController(
             urlHandler: urlHandler,
             permissionRecoveryController: permissionRecoveryController
@@ -456,7 +461,7 @@ final class AppState: ObservableObject {
         Task { [weak self] in
             await self?.refreshExportHistory()
         }
-        logLaunchDiagnostics()
+        launchDiagnosticsReporter.logLaunchDiagnostics(selectedTranscriptID: selectedTranscriptID)
     }
 
     var elapsedTimeString: String {
@@ -1571,19 +1576,6 @@ final class AppState: ObservableObject {
 
     private func validateRuntimeConfiguration() {
         permissionRecoveryController.validateRuntimeConfiguration()
-    }
-
-    private func logLaunchDiagnostics() {
-        permissionRecoveryController.logLaunchPermissionSnapshot()
-
-        sessionLibraryLogger.info(
-            "launch_session_store_snapshot",
-            "Captured the initial session library state at launch.",
-            metadata: [
-                "stored_session_count": "\(transcriptStore.sessionCount)",
-                "selected_transcript_id": selectedTranscriptID?.uuidString ?? "none"
-            ]
-        )
     }
 
     private func importRecoveredRecordingsAtLaunch() {

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -315,6 +315,36 @@ struct DiagnosticsLogger: Sendable {
     }
 }
 
+@MainActor
+final class AppLaunchDiagnosticsReporter {
+    private let permissionRecoveryController: PermissionRecoveryController
+    private let transcriptStore: TranscriptStore
+    private let sessionLibraryLogger: DiagnosticsLogger
+
+    init(
+        permissionRecoveryController: PermissionRecoveryController,
+        transcriptStore: TranscriptStore,
+        sessionLibraryLogger: DiagnosticsLogger = DiagnosticsLogger(category: .sessionLibrary)
+    ) {
+        self.permissionRecoveryController = permissionRecoveryController
+        self.transcriptStore = transcriptStore
+        self.sessionLibraryLogger = sessionLibraryLogger
+    }
+
+    func logLaunchDiagnostics(selectedTranscriptID: UUID?) {
+        permissionRecoveryController.logLaunchPermissionSnapshot()
+
+        sessionLibraryLogger.info(
+            "launch_session_store_snapshot",
+            "Captured the initial session library state at launch.",
+            metadata: [
+                "stored_session_count": "\(transcriptStore.sessionCount)",
+                "selected_transcript_id": selectedTranscriptID?.uuidString ?? "none"
+            ]
+        )
+    }
+}
+
 enum BugNarratorDiagnostics {
     static let subsystem = "com.abdenterprises.bugnarrator"
     static let store = DiagnosticsLogStore()


### PR DESCRIPTION
## Summary
- Add AppLaunchDiagnosticsReporter to own launch permission and session-store diagnostics
- Replace AppState's private launch diagnostics implementation with a reporter call
- Preserve existing diagnostics event names, messages, metadata keys, and initialization ordering

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #159