### PR TITLE
Remove AppState runtime configuration passthrough

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -456,7 +456,7 @@ final class AppState: ObservableObject {
                 "debug_mode": settingsStore.debugMode ? "enabled" : "disabled"
             ]
         )
-        validateRuntimeConfiguration()
+        permissionRecoveryController.validateRuntimeConfiguration()
         importRecoveredRecordingsAtLaunch()
         Task { [weak self] in
             await self?.refreshExportHistory()
@@ -1572,10 +1572,6 @@ final class AppState: ObservableObject {
 
     private var microphoneRecoveryGuidanceDetails: MicrophoneRecoveryGuidance {
         permissionRecoveryController.microphoneRecoveryGuidance(currentError: currentError)
-    }
-
-    private func validateRuntimeConfiguration() {
-        permissionRecoveryController.validateRuntimeConfiguration()
     }
 
     private func importRecoveredRecordingsAtLaunch() {


### PR DESCRIPTION
## Summary
- Replace AppState's runtime-configuration passthrough with a direct PermissionRecoveryController call
- Remove the private validateRuntimeConfiguration helper from AppState
- Keep launch initialization ordering unchanged

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #161