### PR TITLE
Move hotkey action dispatch out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -415,9 +415,23 @@ final class AppState: ObservableObject {
 
         BugNarratorDiagnostics.setDebugModeEnabled(settingsStore.debugMode)
 
-        self.hotkeyManager.onHotKeyPressed = { [weak self] action in
-            Task { @MainActor [weak self] in
-                self?.handleHotKeyPressed(action)
+        let hotkeyActionDispatcher = HotkeyActionDispatcher(
+            statusPhase: { [weak self] in
+                self?.status.phase ?? .idle
+            },
+            startRecording: { [weak self] in
+                await self?.openRecordingControlsAndStartSession()
+            },
+            stopRecording: { [weak self] in
+                await self?.stopSession()
+            },
+            captureScreenshot: { [weak self] in
+                await self?.captureScreenshot()
+            }
+        )
+        self.hotkeyManager.onHotKeyPressed = { action in
+            Task { @MainActor in
+                hotkeyActionDispatcher.handle(action)
             }
         }
 
@@ -1191,26 +1205,6 @@ final class AppState: ObservableObject {
         }
 
         NSWorkspace.shared.activateFileViewerSelecting([screenshot.fileURL])
-    }
-
-    private func handleHotKeyPressed(_ action: HotkeyAction) {
-        switch action {
-        case .startRecording:
-            Task {
-                await openRecordingControlsAndStartSession()
-            }
-        case .stopRecording:
-            guard status.phase == .recording else {
-                return
-            }
-            Task {
-                await stopSession()
-            }
-        case .captureScreenshot:
-            Task {
-                await captureScreenshot()
-            }
-        }
     }
 
     private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {

--- a/Sources/BugNarrator/Services/HotkeyManager.swift
+++ b/Sources/BugNarrator/Services/HotkeyManager.swift
@@ -45,6 +45,46 @@ final class HotkeySettingsBinder {
     }
 }
 
+@MainActor
+final class HotkeyActionDispatcher {
+    private let statusPhase: () -> AppStatus.Phase
+    private let startRecording: () async -> Void
+    private let stopRecording: () async -> Void
+    private let captureScreenshot: () async -> Void
+
+    init(
+        statusPhase: @escaping () -> AppStatus.Phase,
+        startRecording: @escaping () async -> Void,
+        stopRecording: @escaping () async -> Void,
+        captureScreenshot: @escaping () async -> Void
+    ) {
+        self.statusPhase = statusPhase
+        self.startRecording = startRecording
+        self.stopRecording = stopRecording
+        self.captureScreenshot = captureScreenshot
+    }
+
+    func handle(_ action: HotkeyAction) {
+        switch action {
+        case .startRecording:
+            Task {
+                await startRecording()
+            }
+        case .stopRecording:
+            guard statusPhase() == .recording else {
+                return
+            }
+            Task {
+                await stopRecording()
+            }
+        case .captureScreenshot:
+            Task {
+                await captureScreenshot()
+            }
+        }
+    }
+}
+
 final class HotkeyManager: HotkeyManaging {
     var onHotKeyPressed: ((HotkeyAction) -> Void)?
 


### PR DESCRIPTION
## Summary
- Add HotkeyActionDispatcher to own start/stop/screenshot hotkey routing
- Keep HotkeyManager callbacks crossing onto the main actor before dispatch
- Remove AppState's private handleHotKeyPressed switch while preserving weak AppState captures

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #167