### PR TITLE
Move post-transcription pipeline types out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -63,30 +63,6 @@ final class AppState: ObservableObject {
     private let permissionsLogger = DiagnosticsLogger(category: .permissions)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
-    private enum PostTranscriptionPipelineMode: Equatable {
-        case finishedRecording
-        case retry
-
-        var savingAction: String {
-            switch self {
-            case .finishedRecording:
-                return "Saving the finished session locally..."
-            case .retry:
-                return "Saving the recovered session locally..."
-            }
-        }
-
-        var recordsCompletionTelemetry: Bool {
-            self == .finishedRecording
-        }
-    }
-
-    private enum PostTranscriptionPipelineResult {
-        case success(TranscriptSession)
-        case persistenceFailure(session: TranscriptSession, error: Error)
-        case postTranscriptionFailure(Error)
-    }
-
     var status: AppStatus {
         presentationState.status
     }

--- a/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
+++ b/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+enum PostTranscriptionPipelineMode: Equatable {
+    case finishedRecording
+    case retry
+
+    var savingAction: String {
+        switch self {
+        case .finishedRecording:
+            return "Saving the finished session locally..."
+        case .retry:
+            return "Saving the recovered session locally..."
+        }
+    }
+
+    var recordsCompletionTelemetry: Bool {
+        self == .finishedRecording
+    }
+}
+
+enum PostTranscriptionPipelineResult {
+    case success(TranscriptSession)
+    case persistenceFailure(session: TranscriptSession, error: Error)
+    case postTranscriptionFailure(Error)
+}
+
 enum TranscriptionSessionBuilder {
     static func completedSession(
         from recordingSession: RecordingSessionDraft,


### PR DESCRIPTION
## Summary
- Move PostTranscriptionPipelineMode and PostTranscriptionPipelineResult out of AppState
- Keep pipeline case names, savingAction text, and telemetry behavior unchanged
- Leave post-transcription pipeline logic untouched

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main

Closes #169