### PR TITLE
Move screenshot file opening out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1175,12 +1175,7 @@ final class AppState: ObservableObject {
     }
 
     func openScreenshot(_ screenshot: SessionScreenshot) {
-        guard FileManager.default.fileExists(atPath: screenshot.fileURL.path) else {
-            appUtilityActionPresenter.presentFailure("The selected screenshot file is no longer available on this Mac.")
-            return
-        }
-
-        NSWorkspace.shared.activateFileViewerSelecting([screenshot.fileURL])
+        appUtilityActionPresenter.present(appUtilityActions.openScreenshot(screenshot))
     }
 
     private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {

--- a/Sources/BugNarrator/Services/AppUtilityActionController.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 enum AppUtilityActionResult: Equatable {
@@ -130,6 +131,15 @@ final class AppUtilityActionController {
 
     func checkForUpdates() -> AppUtilityActionResult {
         openExternalURL(BugNarratorLinks.releases, label: "releases page")
+    }
+
+    func openScreenshot(_ screenshot: SessionScreenshot) -> AppUtilityActionResult {
+        guard FileManager.default.fileExists(atPath: screenshot.fileURL.path) else {
+            return .failed(message: "The selected screenshot file is no longer available on this Mac.")
+        }
+
+        NSWorkspace.shared.activateFileViewerSelecting([screenshot.fileURL])
+        return .opened
     }
 
     private func openExternalURL(_ url: URL, label: String) -> AppUtilityActionResult {


### PR DESCRIPTION
## Summary
- Add AppUtilityActionController.openScreenshot for missing-file checks and Finder reveal behavior
- Update AppState.openScreenshot to delegate and present the utility action result
- Preserve the existing missing screenshot error message

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppUtilityActionControllerTests
- ./scripts/validate.sh origin/main

Closes #171