### PR TITLE
Move exported bundle reveal actions out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -809,7 +809,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            NSWorkspace.shared.activateFileViewerSelecting([completion.bundleURL])
+            appUtilityActionPresenter.present(appUtilityActions.revealInFinder(completion.bundleURL))
             setStatus(.success(completion.statusMessage))
         } catch {
             presentError(
@@ -828,7 +828,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            NSWorkspace.shared.activateFileViewerSelecting([completion.bundleURL])
+            appUtilityActionPresenter.present(appUtilityActions.revealInFinder(completion.bundleURL))
             setStatus(.success(completion.statusMessage))
         } catch {
             presentError(

--- a/Sources/BugNarrator/Services/AppUtilityActionController.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionController.swift
@@ -138,7 +138,11 @@ final class AppUtilityActionController {
             return .failed(message: "The selected screenshot file is no longer available on this Mac.")
         }
 
-        NSWorkspace.shared.activateFileViewerSelecting([screenshot.fileURL])
+        return revealInFinder(screenshot.fileURL)
+    }
+
+    func revealInFinder(_ url: URL) -> AppUtilityActionResult {
+        NSWorkspace.shared.activateFileViewerSelecting([url])
         return .opened
     }
 


### PR DESCRIPTION
## Summary
- Add AppUtilityActionController.revealInFinder for Finder reveal behavior
- Use the utility action from debug bundle and privacy export flows
- Preserve export success status handling and screenshot reveal behavior

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppUtilityActionControllerTests
- ./scripts/validate.sh origin/main

Closes #173