### PR TITLE
Move support data status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -27,6 +27,7 @@ final class AppState: ObservableObject {
     let appUtilityActionPresenter: AppUtilityActionResultPresenter
     let applicationTerminationController: ApplicationTerminationController
     let supportDataController: SupportDataController
+    let supportDataActionPresenter: SupportDataActionPresenter
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let screenshotCoordinator: ScreenshotCoordinator
@@ -302,6 +303,11 @@ final class AppState: ObservableObject {
             }
         )
         self.appUtilityActionPresenter = appUtilityActionPresenter
+        self.supportDataActionPresenter = SupportDataActionPresenter(
+            presentationState: presentationState,
+            utilityActions: appUtilityActions,
+            utilityResultPresenter: appUtilityActionPresenter
+        )
         self.supportDataController = SupportDataController(
             settingsStore: settingsStore,
             transcriptStore: transcriptStore,
@@ -798,7 +804,7 @@ final class AppState: ObservableObject {
 
     func copyDebugInfo() {
         let result = supportDataController.copyDebugInfo(sessionID: currentDebugSessionID)
-        setStatus(.success(result.statusMessage))
+        supportDataActionPresenter.presentCopyDebugInfo(result)
     }
 
     func exportDebugBundle() async {
@@ -809,8 +815,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            appUtilityActionPresenter.present(appUtilityActions.revealInFinder(completion.bundleURL))
-            setStatus(.success(completion.statusMessage))
+            supportDataActionPresenter.presentDebugBundleExport(completion)
         } catch {
             presentError(
                 error,
@@ -828,8 +833,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            appUtilityActionPresenter.present(appUtilityActions.revealInFinder(completion.bundleURL))
-            setStatus(.success(completion.statusMessage))
+            supportDataActionPresenter.presentPrivacyDataExport(completion)
         } catch {
             presentError(
                 error,
@@ -847,7 +851,7 @@ final class AppState: ObservableObject {
 
         do {
             let outcome = try await localDataDeletionController.deleteAllLocalData(currentTranscript: currentTranscript)
-            setStatus(.success(outcome.statusMessage))
+            supportDataActionPresenter.presentLocalDataDeletion(outcome)
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -16,6 +16,66 @@ struct PrivacyDataExportCompletion {
 }
 
 @MainActor
+final class SupportDataActionPresenter {
+    private let setStatus: (AppStatus) -> Void
+    private let revealInFinder: (URL) -> AppUtilityActionResult
+    private let presentUtilityActionResult: (AppUtilityActionResult) -> Void
+
+    init(
+        setStatus: @escaping (AppStatus) -> Void,
+        revealInFinder: @escaping (URL) -> AppUtilityActionResult,
+        presentUtilityActionResult: @escaping (AppUtilityActionResult) -> Void
+    ) {
+        self.setStatus = setStatus
+        self.revealInFinder = revealInFinder
+        self.presentUtilityActionResult = presentUtilityActionResult
+    }
+
+    convenience init(
+        presentationState: AppPresentationState,
+        utilityActions: AppUtilityActionController,
+        utilityResultPresenter: AppUtilityActionResultPresenter
+    ) {
+        self.init(
+            setStatus: { status in
+                presentationState.setStatus(status, error: nil)
+            },
+            revealInFinder: { url in
+                utilityActions.revealInFinder(url)
+            },
+            presentUtilityActionResult: { result in
+                utilityResultPresenter.present(result)
+            }
+        )
+    }
+
+    func presentCopyDebugInfo(_ result: DebugInfoCopyResult) {
+        presentSuccess(result.statusMessage)
+    }
+
+    func presentDebugBundleExport(_ completion: DebugBundleExportCompletion) {
+        presentExportedBundle(at: completion.bundleURL, statusMessage: completion.statusMessage)
+    }
+
+    func presentPrivacyDataExport(_ completion: PrivacyDataExportCompletion) {
+        presentExportedBundle(at: completion.bundleURL, statusMessage: completion.statusMessage)
+    }
+
+    func presentLocalDataDeletion(_ outcome: LocalDataDeletionOutcome) {
+        presentSuccess(outcome.statusMessage)
+    }
+
+    private func presentExportedBundle(at bundleURL: URL, statusMessage: String) {
+        presentUtilityActionResult(revealInFinder(bundleURL))
+        presentSuccess(statusMessage)
+    }
+
+    private func presentSuccess(_ message: String) {
+        setStatus(.success(message))
+    }
+}
+
+@MainActor
 final class SupportDataController {
     private let settingsStore: SettingsStore
     private let transcriptStore: TranscriptStore

--- a/Tests/BugNarratorTests/SupportDataControllerTests.swift
+++ b/Tests/BugNarratorTests/SupportDataControllerTests.swift
@@ -110,6 +110,48 @@ final class SupportDataControllerTests: XCTestCase {
 
         XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
     }
+
+    func testActionPresenterAppliesStatusesAndRevealsExportedBundles() {
+        let harness = SupportDataControllerHarness()
+        defer { harness.cleanup() }
+        var statuses: [AppStatus] = []
+        var revealedURLs: [URL] = []
+        var presentedUtilityResults: [AppUtilityActionResult] = []
+        let presenter = SupportDataActionPresenter(
+            setStatus: { statuses.append($0) },
+            revealInFinder: { url in
+                revealedURLs.append(url)
+                return .opened
+            },
+            presentUtilityActionResult: { presentedUtilityResults.append($0) }
+        )
+        let debugBundleURL = URL(fileURLWithPath: "/tmp/bugnarrator-debug-bundle")
+        let privacyBundleURL = URL(fileURLWithPath: "/tmp/bugnarrator-privacy-export")
+
+        presenter.presentCopyDebugInfo(harness.controller.copyDebugInfo(sessionID: nil))
+        presenter.presentDebugBundleExport(
+            DebugBundleExportCompletion(bundleURL: debugBundleURL, statusMessage: "Debug bundle exported.")
+        )
+        presenter.presentPrivacyDataExport(
+            PrivacyDataExportCompletion(
+                bundleURL: privacyBundleURL,
+                statusMessage: "Data export created. API keys and tracker credentials were not included."
+            )
+        )
+        presenter.presentLocalDataDeletion(LocalDataDeletionOutcome(deletedSessionCount: 2))
+
+        XCTAssertEqual(
+            statuses,
+            [
+                .success("Debug info copied to the clipboard."),
+                .success("Debug bundle exported."),
+                .success("Data export created. API keys and tracker credentials were not included."),
+                .success("Deleted 2 local sessions and cleared local diagnostics.")
+            ]
+        )
+        XCTAssertEqual(revealedURLs, [debugBundleURL, privacyBundleURL])
+        XCTAssertEqual(presentedUtilityResults, [.opened, .opened])
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Add SupportDataActionPresenter for support/debug/local-data success presentation
- Delegate copy-debug-info, export bundle, privacy export, and delete-local-data success handling from AppState
- Keep exported bundle reveal behavior routed through AppUtilityActionController

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SupportDataControllerTests -only-testing:BugNarratorTests/LocalDataDeletionControllerTests -only-testing:BugNarratorTests/AppUtilityActionControllerTests
- ./scripts/validate.sh origin/main

Closes #175