### PR TITLE
Move local data deletion readiness out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -844,14 +844,12 @@ final class AppState: ObservableObject {
     }
 
     func deleteAllLocalData() async {
-        guard status.phase != .recording, status.phase != .transcribing else {
-            setStatus(.error("Stop recording or transcription before deleting local data."))
-            return
-        }
-
         do {
-            let outcome = try await localDataDeletionController.deleteAllLocalData(currentTranscript: currentTranscript)
-            supportDataActionPresenter.presentLocalDataDeletion(outcome)
+            let result = try await localDataDeletionController.deleteAllLocalData(
+                currentTranscript: currentTranscript,
+                statusPhase: status.phase
+            )
+            supportDataActionPresenter.presentLocalDataDeletion(result)
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
         }

--- a/Sources/BugNarrator/Services/LocalDataDeletionController.swift
+++ b/Sources/BugNarrator/Services/LocalDataDeletionController.swift
@@ -16,6 +16,11 @@ struct LocalDataDeletionOutcome: Equatable {
     }
 }
 
+enum LocalDataDeletionResult: Equatable {
+    case blocked(message: String)
+    case deleted(LocalDataDeletionOutcome)
+}
+
 @MainActor
 final class LocalDataDeletionController {
     private let transcriptStore: TranscriptStore
@@ -33,6 +38,17 @@ final class LocalDataDeletionController {
         self.sessionLibrary = sessionLibrary
         self.supportDataController = supportDataController
         self.exportHistoryController = exportHistoryController
+    }
+
+    func deleteAllLocalData(
+        currentTranscript: TranscriptSession?,
+        statusPhase: AppStatus.Phase
+    ) async throws -> LocalDataDeletionResult {
+        guard statusPhase != .recording, statusPhase != .transcribing else {
+            return .blocked(message: "Stop recording or transcription before deleting local data.")
+        }
+
+        return .deleted(try await deleteAllLocalData(currentTranscript: currentTranscript))
     }
 
     func deleteAllLocalData(currentTranscript: TranscriptSession?) async throws -> LocalDataDeletionOutcome {

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -65,6 +65,15 @@ final class SupportDataActionPresenter {
         presentSuccess(outcome.statusMessage)
     }
 
+    func presentLocalDataDeletion(_ result: LocalDataDeletionResult) {
+        switch result {
+        case .blocked(let message):
+            setStatus(.error(message))
+        case .deleted(let outcome):
+            presentLocalDataDeletion(outcome)
+        }
+    }
+
     private func presentExportedBundle(at bundleURL: URL, statusMessage: String) {
         presentUtilityActionResult(revealInFinder(bundleURL))
         presentSuccess(statusMessage)

--- a/Tests/BugNarratorTests/LocalDataDeletionControllerTests.swift
+++ b/Tests/BugNarratorTests/LocalDataDeletionControllerTests.swift
@@ -3,6 +3,38 @@ import XCTest
 
 @MainActor
 final class LocalDataDeletionControllerTests: XCTestCase {
+    func testDeleteAllLocalDataReportsBlockedResultWhileRecording() async throws {
+        let harness = LocalDataDeletionControllerHarness()
+        defer { harness.cleanup() }
+
+        let result = try await harness.controller.deleteAllLocalData(
+            currentTranscript: nil,
+            statusPhase: .recording
+        )
+
+        XCTAssertEqual(
+            result,
+            .blocked(message: "Stop recording or transcription before deleting local data.")
+        )
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 0)
+    }
+
+    func testDeleteAllLocalDataReportsBlockedResultWhileTranscribing() async throws {
+        let harness = LocalDataDeletionControllerHarness()
+        defer { harness.cleanup() }
+
+        let result = try await harness.controller.deleteAllLocalData(
+            currentTranscript: nil,
+            statusPhase: .transcribing
+        )
+
+        XCTAssertEqual(
+            result,
+            .blocked(message: "Stop recording or transcription before deleting local data.")
+        )
+        XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 0)
+    }
+
     func testDeleteAllLocalDataClearsPrivacyArtifactsWhenNoSessionsExist() async throws {
         let harness = LocalDataDeletionControllerHarness()
         defer { harness.cleanup() }
@@ -21,7 +53,11 @@ final class LocalDataDeletionControllerTests: XCTestCase {
         try harness.transcriptStore.add(session)
         harness.sessionLibrary.stageCurrentTranscript(session)
 
-        let outcome = try await harness.controller.deleteAllLocalData(currentTranscript: harness.sessionLibrary.currentTranscript)
+        let result = try await harness.controller.deleteAllLocalData(
+            currentTranscript: harness.sessionLibrary.currentTranscript,
+            statusPhase: .idle
+        )
+        let outcome = try XCTUnwrap(result.deletedOutcome)
 
         XCTAssertEqual(outcome.deletedSessionCount, 1)
         XCTAssertEqual(outcome.statusMessage, "Deleted 1 local session and cleared local diagnostics.")
@@ -45,6 +81,16 @@ final class LocalDataDeletionControllerTests: XCTestCase {
         XCTAssertTrue(harness.transcriptStore.sessions.isEmpty)
         XCTAssertNil(harness.sessionLibrary.currentTranscript)
         XCTAssertEqual(harness.localPrivacyDataManager.clearCallCount, 1)
+    }
+}
+
+private extension LocalDataDeletionResult {
+    var deletedOutcome: LocalDataDeletionOutcome? {
+        guard case .deleted(let outcome) = self else {
+            return nil
+        }
+
+        return outcome
     }
 }
 

--- a/Tests/BugNarratorTests/SupportDataControllerTests.swift
+++ b/Tests/BugNarratorTests/SupportDataControllerTests.swift
@@ -139,6 +139,9 @@ final class SupportDataControllerTests: XCTestCase {
             )
         )
         presenter.presentLocalDataDeletion(LocalDataDeletionOutcome(deletedSessionCount: 2))
+        presenter.presentLocalDataDeletion(
+            LocalDataDeletionResult.blocked(message: "Stop recording or transcription before deleting local data.")
+        )
 
         XCTAssertEqual(
             statuses,
@@ -146,7 +149,8 @@ final class SupportDataControllerTests: XCTestCase {
                 .success("Debug info copied to the clipboard."),
                 .success("Debug bundle exported."),
                 .success("Data export created. API keys and tracker credentials were not included."),
-                .success("Deleted 2 local sessions and cleared local diagnostics.")
+                .success("Deleted 2 local sessions and cleared local diagnostics."),
+                .error("Stop recording or transcription before deleting local data.")
             ]
         )
         XCTAssertEqual(revealedURLs, [debugBundleURL, privacyBundleURL])


### PR DESCRIPTION
## Summary
- Add LocalDataDeletionResult so the controller reports blocked and deleted outcomes
- Move active recording/transcription deletion readiness checks out of AppState
- Let SupportDataActionPresenter render blocked and successful deletion results

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/LocalDataDeletionControllerTests -only-testing:BugNarratorTests/SupportDataControllerTests
- ./scripts/validate.sh origin/main

Closes #177