### PR TITLE
Move displayed transcript copy status out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -892,13 +892,9 @@ final class AppState: ObservableObject {
     }
 
     func copyDisplayedTranscript() {
-        switch sessionLibrary.copyDisplayedTranscript() {
-        case .noDisplayedTranscript:
-            return
-        case .transcriptUnavailable:
-            setStatus(.error("Transcription is not available yet. Retry the preserved session first."))
-        case .copied:
-            setStatus(.success("Transcript copied to the clipboard."))
+        let result = sessionLibrary.copyDisplayedTranscript()
+        if let status = DisplayedTranscriptCopyStatusPresenter.status(for: result) {
+            setStatus(status)
         }
     }
 

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -7,6 +7,19 @@ enum DisplayedTranscriptCopyResult: Equatable {
     case copied
 }
 
+enum DisplayedTranscriptCopyStatusPresenter {
+    static func status(for result: DisplayedTranscriptCopyResult) -> AppStatus? {
+        switch result {
+        case .noDisplayedTranscript:
+            return nil
+        case .transcriptUnavailable:
+            return .error("Transcription is not available yet. Retry the preserved session first.")
+        case .copied:
+            return .success("Transcript copied to the clipboard.")
+        }
+    }
+}
+
 enum SessionDeletionStatusPresenter {
     static func status(deletedCount: Int) -> AppStatus? {
         guard deletedCount > 0 else {

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -119,6 +119,18 @@ final class SessionLibraryControllerTests: XCTestCase {
         )
     }
 
+    func testDisplayedTranscriptCopyStatusPresenterMapsResults() {
+        XCTAssertNil(DisplayedTranscriptCopyStatusPresenter.status(for: .noDisplayedTranscript))
+        XCTAssertEqual(
+            DisplayedTranscriptCopyStatusPresenter.status(for: .transcriptUnavailable),
+            .error("Transcription is not available yet. Retry the preserved session first.")
+        )
+        XCTAssertEqual(
+            DisplayedTranscriptCopyStatusPresenter.status(for: .copied),
+            .success("Transcript copied to the clipboard.")
+        )
+    }
+
     func testPersistCompletedTranscriptCopiesWhenRequested() throws {
         let harness = try SessionLibraryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add DisplayedTranscriptCopyStatusPresenter beside the session-library copy result
- Move transcript-copy success/error status mapping out of AppState
- Preserve clipboard behavior and existing user-facing copy messages

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #179