### PR TITLE
Move transcript save status out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -984,8 +984,8 @@ final class AppState: ObservableObject {
 
     func saveCurrentTranscriptToHistory() {
         do {
-            if try sessionLibrary.saveCurrentTranscriptToHistory() != nil {
-                setStatus(.success("Transcript saved to session history."))
+            if let status = TranscriptSaveStatusPresenter.status(savedSession: try sessionLibrary.saveCurrentTranscriptToHistory()) {
+                setStatus(status)
             }
         } catch {
             presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -20,6 +20,16 @@ enum DisplayedTranscriptCopyStatusPresenter {
     }
 }
 
+enum TranscriptSaveStatusPresenter {
+    static func status(savedSession: TranscriptSession?) -> AppStatus? {
+        guard savedSession != nil else {
+            return nil
+        }
+
+        return .success("Transcript saved to session history.")
+    }
+}
+
 enum SessionDeletionStatusPresenter {
     static func status(deletedCount: Int) -> AppStatus? {
         guard deletedCount > 0 else {

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -131,6 +131,14 @@ final class SessionLibraryControllerTests: XCTestCase {
         )
     }
 
+    func testTranscriptSaveStatusPresenterMapsResults() {
+        XCTAssertNil(TranscriptSaveStatusPresenter.status(savedSession: nil))
+        XCTAssertEqual(
+            TranscriptSaveStatusPresenter.status(savedSession: makeSession(index: 1)),
+            .success("Transcript saved to session history.")
+        )
+    }
+
     func testPersistCompletedTranscriptCopiesWhenRequested() throws {
         let harness = try SessionLibraryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add TranscriptSaveStatusPresenter for save-current-transcript outcomes
- Move the transcript save success status out of AppState
- Preserve no-op save behavior and existing save success text

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #181