### PR TITLE
Move manual issue extraction status messages out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1029,7 +1029,7 @@ final class AppState: ObservableObject {
             aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue,
             statusPhase: status.phase
         ) else {
-            setStatus(.transcribing("Running issue extraction with a 10-second time limit..."))
+            setStatus(IssueExtractionStatusPresenter.manualProgressStatus)
             recordingSessionController.beginActivity(reason: "Extracting review issues")
             transcriptionLogger.info(
                 "issue_extraction_requested",
@@ -1051,7 +1051,7 @@ final class AppState: ObservableObject {
                 )
 
                 recordingSessionController.endActivity()
-                setStatus(.success("Extracted \(extraction.issues.count) review issues."))
+                setStatus(IssueExtractionStatusPresenter.manualCompletionStatus(issueCount: extraction.issues.count))
                 showTranscriptWindow?()
             } catch {
                 presentError(error, operation: .postTranscription, fallback: { .issueExtractionFailure($0) })

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -1,6 +1,16 @@
 import Combine
 import Foundation
 
+enum IssueExtractionStatusPresenter {
+    static var manualProgressStatus: AppStatus {
+        .transcribing("Running issue extraction with a 10-second time limit...")
+    }
+
+    static func manualCompletionStatus(issueCount: Int) -> AppStatus {
+        .success("Extracted \(issueCount) review issues.")
+    }
+}
+
 @MainActor
 final class IssueExtractionController: ObservableObject {
     @Published private(set) var issueExtractionSessionID: UUID?

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -3,6 +3,17 @@ import XCTest
 
 @MainActor
 final class IssueExtractionControllerTests: XCTestCase {
+    func testStatusPresenterMapsManualExtractionStatuses() {
+        XCTAssertEqual(
+            IssueExtractionStatusPresenter.manualProgressStatus,
+            .transcribing("Running issue extraction with a 10-second time limit...")
+        )
+        XCTAssertEqual(
+            IssueExtractionStatusPresenter.manualCompletionStatus(issueCount: 3),
+            .success("Extracted 3 review issues.")
+        )
+    }
+
     func testPreflightMapsCredentialTranscriptAndRecordingFailures() throws {
         let harness = try IssueExtractionControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add IssueExtractionStatusPresenter for manual extraction progress and completion statuses
- Move manual issue extraction status strings out of AppState
- Preserve existing manual extraction behavior and messages

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExtractionControllerTests
- ./scripts/validate.sh origin/main

Closes #183