### PR TITLE
Move issue export status messages out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1109,7 +1109,7 @@ final class AppState: ObservableObject {
             return
         }
 
-        setStatus(.transcribing("Checking \(destination.rawValue) for similar open issues..."))
+        setStatus(IssueExportStatusPresenter.reviewPreparationStatus(destination: destination))
         recordingSessionController.beginActivity(reason: "Reviewing similar issues before export")
 
         do {
@@ -1121,7 +1121,7 @@ final class AppState: ObservableObject {
             recordingSessionController.endActivity()
 
             if review.hasMatches {
-                setStatus(.success("Review the similar \(destination.rawValue) issues before export."))
+                setStatus(IssueExportStatusPresenter.reviewReadyStatus(destination: destination))
             } else {
                 await finalizeIssueExport(using: review)
             }
@@ -1155,7 +1155,7 @@ final class AppState: ObservableObject {
         do {
             let requiresRemoteExport = try issueExportController.pendingReviewRequiresRemoteExport(review)
             if requiresRemoteExport {
-                setStatus(.transcribing("Exporting reviewed issues to \(review.destination.rawValue)..."))
+                setStatus(IssueExportStatusPresenter.remoteExportStatus(destination: review.destination))
                 recordingSessionController.beginActivity(reason: "Exporting extracted issues")
             }
 
@@ -1164,7 +1164,7 @@ final class AppState: ObservableObject {
                 recordingSessionController.endActivity()
             }
 
-            setStatus(.success(completion.summary))
+            setStatus(IssueExportStatusPresenter.completionStatus(completion))
             await refreshExportHistory()
         } catch {
             recordingSessionController.endActivity()

--- a/Sources/BugNarrator/Services/IssueExportController.swift
+++ b/Sources/BugNarrator/Services/IssueExportController.swift
@@ -1,6 +1,24 @@
 import Combine
 import Foundation
 
+enum IssueExportStatusPresenter {
+    static func reviewPreparationStatus(destination: ExportDestination) -> AppStatus {
+        .transcribing("Checking \(destination.rawValue) for similar open issues...")
+    }
+
+    static func reviewReadyStatus(destination: ExportDestination) -> AppStatus {
+        .success("Review the similar \(destination.rawValue) issues before export.")
+    }
+
+    static func remoteExportStatus(destination: ExportDestination) -> AppStatus {
+        .transcribing("Exporting reviewed issues to \(destination.rawValue)...")
+    }
+
+    static func completionStatus(_ completion: IssueExportCompletion) -> AppStatus {
+        .success(completion.summary)
+    }
+}
+
 @MainActor
 final class IssueExportController: ObservableObject {
     @Published private(set) var exportDestinationInProgress: ExportDestination?

--- a/Tests/BugNarratorTests/IssueExportControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExportControllerTests.swift
@@ -3,6 +3,33 @@ import XCTest
 
 @MainActor
 final class IssueExportControllerTests: XCTestCase {
+    func testStatusPresenterMapsIssueExportStatuses() {
+        let completion = IssueExportCompletion(
+            destination: .github,
+            sessionID: UUID(),
+            results: [],
+            duplicateCount: 1,
+            performedRemoteExport: false
+        )
+
+        XCTAssertEqual(
+            IssueExportStatusPresenter.reviewPreparationStatus(destination: .github),
+            .transcribing("Checking GitHub for similar open issues...")
+        )
+        XCTAssertEqual(
+            IssueExportStatusPresenter.reviewReadyStatus(destination: .jira),
+            .success("Review the similar Jira issues before export.")
+        )
+        XCTAssertEqual(
+            IssueExportStatusPresenter.remoteExportStatus(destination: .github),
+            .transcribing("Exporting reviewed issues to GitHub...")
+        )
+        XCTAssertEqual(
+            IssueExportStatusPresenter.completionStatus(completion),
+            .success(completion.summary)
+        )
+    }
+
     func testReadinessAndDefaultGitHubRouting() throws {
         let harness = try IssueExportControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add IssueExportStatusPresenter for export review/progress/completion statuses
- Move issue export status strings out of AppState
- Preserve existing export flow behavior and messages

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExportControllerTests
- ./scripts/validate.sh origin/main

Closes #185