### PR TITLE
Move transcription progress action messages out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -667,7 +667,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            setStatus(.transcribing(recordingStatusMessages.transcriptionProgressMessage(step: 1, action: "Uploading audio to OpenAI for transcription...")))
+            setStatus(.transcribing(recordingStatusMessages.transcriptionUploadProgressMessage()))
             recordingSessionController.swapActivity(reason: "Uploading audio for transcription")
 
             let transcriptionResult = try await transcriptionClient.transcribe(
@@ -928,7 +928,7 @@ final class AppState: ObservableObject {
 
         let request = settingsStore.transcriptionRequest
         sessionLibrary.stageCurrentTranscript(retryContext.session)
-        setStatus(.transcribing(recordingStatusMessages.transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")))
+        setStatus(.transcribing(recordingStatusMessages.transcriptionRetryProgressMessage()))
         recordingSessionController.swapActivity(reason: "Retrying transcription from preserved audio")
         logPendingTranscriptionRetryRequested(retryContext)
 
@@ -1250,7 +1250,7 @@ final class AppState: ObservableObject {
     ) async -> PostTranscriptionPipelineResult {
         var session = session
         recordCompletedTranscriptionIfNeeded(session, mode: mode)
-        setStatus(.transcribing(recordingStatusMessages.transcriptionProgressMessage(step: 2, action: mode.savingAction)))
+        setStatus(.transcribing(recordingStatusMessages.transcriptionSavingProgressMessage(mode: mode)))
 
         do {
             try persistInitialPostTranscriptionSession(session, mode: mode)
@@ -1335,7 +1335,7 @@ final class AppState: ObservableObject {
         apiKey: String
     ) async throws -> TranscriptSession {
         var session = session
-        setStatus(.transcribing(recordingStatusMessages.transcriptionProgressMessage(step: 3, action: "Extracting reviewable issues...")))
+        setStatus(.transcribing(recordingStatusMessages.transcriptionIssueExtractionProgressMessage()))
         recordingSessionController.swapActivity(reason: "Extracting review issues")
 
         let extraction = try await issueExtractionController.extractIssues(

--- a/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
+++ b/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
@@ -99,6 +99,22 @@ final class RecordingStatusMessageProvider {
         )
     }
 
+    func transcriptionUploadProgressMessage() -> String {
+        transcriptionProgressMessage(step: 1, action: "Uploading audio to OpenAI for transcription...")
+    }
+
+    func transcriptionRetryProgressMessage() -> String {
+        transcriptionProgressMessage(step: 1, action: "Retrying transcription from the preserved recording...")
+    }
+
+    func transcriptionSavingProgressMessage(mode: PostTranscriptionPipelineMode) -> String {
+        transcriptionProgressMessage(step: 2, action: mode.savingAction)
+    }
+
+    func transcriptionIssueExtractionProgressMessage() -> String {
+        transcriptionProgressMessage(step: 3, action: "Extracting reviewable issues...")
+    }
+
     func transcriptionSuccessMessage() -> String {
         let snapshot = snapshot()
         return RecordingStatusMessageBuilder.transcriptionSuccessMessage(

--- a/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
+++ b/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
@@ -150,4 +150,46 @@ final class RecordingStatusMessageBuilderTests: XCTestCase {
         )
         XCTAssertEqual(provider.transcriptionSuccessMessage(), "Session saved. Transcript and extracted issues are ready.")
     }
+
+    func testProviderBuildsNamedTranscriptionProgressMessages() {
+        let providerWithoutIssueExtraction = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: false,
+                autoCopyTranscript: false
+            )
+        }
+        let providerWithIssueExtraction = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: true,
+                autoCopyTranscript: false
+            )
+        }
+
+        XCTAssertEqual(
+            providerWithoutIssueExtraction.transcriptionUploadProgressMessage(),
+            "Step 1 of 2: Uploading audio to OpenAI for transcription..."
+        )
+        XCTAssertEqual(
+            providerWithoutIssueExtraction.transcriptionRetryProgressMessage(),
+            "Step 1 of 2: Retrying transcription from the preserved recording..."
+        )
+        XCTAssertEqual(
+            providerWithoutIssueExtraction.transcriptionSavingProgressMessage(mode: .finishedRecording),
+            "Step 2 of 2: Saving the finished session locally..."
+        )
+        XCTAssertEqual(
+            providerWithIssueExtraction.transcriptionSavingProgressMessage(mode: .retry),
+            "Step 2 of 3: Saving the recovered session locally..."
+        )
+        XCTAssertEqual(
+            providerWithIssueExtraction.transcriptionIssueExtractionProgressMessage(),
+            "Step 3 of 3: Extracting reviewable issues..."
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add named RecordingStatusMessageProvider helpers for transcription progress actions
- Move upload, retry, save, and issue-extraction progress action text out of AppState
- Preserve existing progress step counts and user-facing messages

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingStatusMessageBuilderTests\n- ./scripts/validate.sh origin/main\n\nCloses #187