### PR TITLE
Move retry transcription status presentation out of AppState

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */; };
 		129A00000000000000000001 /* RecordingStatusMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */; };
 		129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */; };
+		189A00000000000000000001 /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */; };
 		131A00000000000000000001 /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000003 /* DebugSessionContextProvider.swift */; };
 		131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000004 /* DebugSessionContextProviderTests.swift */; };
 		137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000003 /* TranscriptionSessionBuilder.swift */; };
@@ -244,6 +245,7 @@
 		127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilder.swift; sourceTree = "<group>"; };
 		129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
+		189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
 		131A00000000000000000003 /* DebugSessionContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProvider.swift; sourceTree = "<group>"; };
 		131A00000000000000000004 /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
 		137A00000000000000000003 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 				3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */,
 				115A00000000000000000004 /* RecoveredRecordingImportControllerTests.swift */,
 				2DE808CBBBE2F1EEE4FF5BEC /* RecoveredRecordingImporterTests.swift */,
+				189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
 				4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */,
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
@@ -752,6 +755,7 @@
 				2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */,
 				115A00000000000000000002 /* RecoveredRecordingImportControllerTests.swift in Sources */,
 				62313F663336184217D1020B /* RecoveredRecordingImporterTests.swift in Sources */,
+				189A00000000000000000001 /* RetryTranscriptionStatusPresenterTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
 				79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */,
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -30,6 +30,7 @@ final class AppState: ObservableObject {
     let supportDataActionPresenter: SupportDataActionPresenter
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
+    let retryTranscriptionStatusPresenter: RetryTranscriptionStatusPresenter
     let screenshotCoordinator: ScreenshotCoordinator
     let screenshotCaptureController: ScreenshotCaptureController
 
@@ -327,6 +328,11 @@ final class AppState: ObservableObject {
         self.transcriptionRecovery = TranscriptionRecoveryController(
             sessionLibrary: sessionLibrary,
             artifactsService: artifactsService
+        )
+        self.retryTranscriptionStatusPresenter = RetryTranscriptionStatusPresenter(
+            errorPresenter: self.errorPresenter,
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() },
+            showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
         )
         let screenshotCoordinator = ScreenshotCoordinator(
             screenCapturePermissionService: screenCapturePermissionService,
@@ -911,14 +917,11 @@ final class AppState: ObservableObject {
         case .duplicate:
             return
         case .failure(let appError, let opensSettings, let statusMessage):
-            if let statusMessage {
-                setStatus(.error(statusMessage), error: appError)
-            } else {
-                presentError(appError, operation: .retryTranscription)
-            }
-            if opensSettings {
-                showSettingsWindow?()
-            }
+            retryTranscriptionStatusPresenter.presentRetryContextFailure(
+                appError: appError,
+                opensSettings: opensSettings,
+                statusMessage: statusMessage
+            )
             return
         }
 
@@ -1455,12 +1458,7 @@ final class AppState: ObservableObject {
         }
 
         recordingSessionController.endActivity()
-
-        let appError = retryFailure.appError
-        errorPresenter.logAppError(appError, context: "retry_pending_transcription", operation: .retryTranscription)
-        setStatus(.error(retryFailure.statusMessage), error: appError)
-        showTranscriptWindow?()
-        showSettingsWindow?()
+        retryTranscriptionStatusPresenter.presentRetryableFailure(retryFailure)
         return true
     }
 

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -2,6 +2,53 @@ import Combine
 import Foundation
 
 @MainActor
+final class RetryTranscriptionStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showSettingsWindow: () -> Void
+    private let showTranscriptWindow: () -> Void
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showSettingsWindow: @escaping () -> Void,
+        showTranscriptWindow: @escaping () -> Void
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showSettingsWindow = showSettingsWindow
+        self.showTranscriptWindow = showTranscriptWindow
+    }
+
+    func presentRetryContextFailure(
+        appError: AppError,
+        opensSettings: Bool,
+        statusMessage: String?
+    ) {
+        if let statusMessage {
+            errorPresenter.setStatus(.error(statusMessage), error: appError)
+        } else {
+            let result = errorPresenter.presentError(appError, operation: .retryTranscription)
+            if result.shouldOpenSettingsWindow {
+                showSettingsWindow()
+            }
+        }
+
+        if opensSettings {
+            showSettingsWindow()
+        }
+    }
+
+    func presentRetryableFailure(_ failure: PendingTranscriptionRetryFailure) {
+        errorPresenter.logAppError(
+            failure.appError,
+            context: "retry_pending_transcription",
+            operation: .retryTranscription
+        )
+        errorPresenter.setStatus(.error(failure.statusMessage), error: failure.appError)
+        showTranscriptWindow()
+        showSettingsWindow()
+    }
+}
+
+@MainActor
 final class TranscriptionRecoveryController: ObservableObject {
     @Published private(set) var retryingSessionID: UUID?
 

--- a/Tests/BugNarratorTests/RetryTranscriptionStatusPresenterTests.swift
+++ b/Tests/BugNarratorTests/RetryTranscriptionStatusPresenterTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class RetryTranscriptionStatusPresenterTests: XCTestCase {
+    func testPresentRetryContextFailureUsesRecoveryStatusAndOpensSettings() {
+        let harness = RetryTranscriptionStatusPresenterHarness()
+
+        harness.presenter.presentRetryContextFailure(
+            appError: .missingAPIKey,
+            opensSettings: true,
+            statusMessage: "Recording saved locally. Add your OpenAI API key in Settings."
+        )
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Recording saved locally. Add your OpenAI API key in Settings.")
+        )
+        XCTAssertEqual(harness.presentationState.currentError, .missingAPIKey)
+        XCTAssertEqual(harness.showSettingsCallCount, 1)
+        XCTAssertEqual(harness.showTranscriptCallCount, 0)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testPresentRetryContextFailureWithoutStatusDelegatesToErrorPresenter() throws {
+        let harness = RetryTranscriptionStatusPresenterHarness()
+
+        harness.presenter.presentRetryContextFailure(
+            appError: .transcriptionFailure("The saved retry session is unavailable."),
+            opensSettings: false,
+            statusMessage: nil
+        )
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Transcription failed: The saved retry session is unavailable.")
+        )
+        XCTAssertEqual(
+            harness.presentationState.currentError,
+            .transcriptionFailure("The saved retry session is unavailable.")
+        )
+        XCTAssertEqual(harness.showSettingsCallCount, 0)
+        XCTAssertEqual(harness.showTranscriptCallCount, 0)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "retry_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "transcription_failure")
+    }
+
+    func testPresentRetryableFailureLogsStatusAndOpensRecoverySurfaces() throws {
+        let harness = RetryTranscriptionStatusPresenterHarness()
+        let failure = PendingTranscriptionRetryFailure(
+            session: TranscriptSession(
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                transcript: "",
+                duration: 4,
+                model: "whisper-1",
+                languageHint: nil,
+                prompt: nil
+            ),
+            appError: .invalidAPIKey,
+            statusMessage: "Recording saved locally. Replace the rejected OpenAI API key in Settings."
+        )
+
+        harness.presenter.presentRetryableFailure(failure)
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Recording saved locally. Replace the rejected OpenAI API key in Settings.")
+        )
+        XCTAssertEqual(harness.presentationState.currentError, .invalidAPIKey)
+        XCTAssertEqual(harness.showSettingsCallCount, 1)
+        XCTAssertEqual(harness.showTranscriptCallCount, 1)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "retry_pending_transcription")
+        XCTAssertEqual(telemetry.metadata["operation"], "retry_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
+    }
+}
+
+@MainActor
+private final class RetryTranscriptionStatusPresenterHarness {
+    let presentationState: AppPresentationState
+    let telemetryRecorder: MockOperationalTelemetryRecorder
+    let errorPresenter: AppErrorPresenter
+    let presenter: RetryTranscriptionStatusPresenter
+    private let windowCalls: WindowCallRecorder
+
+    var showSettingsCallCount: Int {
+        windowCalls.showSettingsCallCount
+    }
+
+    var showTranscriptCallCount: Int {
+        windowCalls.showTranscriptCallCount
+    }
+
+    init() {
+        let presentationState = AppPresentationState()
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let windowCalls = WindowCallRecorder()
+        self.presentationState = presentationState
+        self.telemetryRecorder = telemetryRecorder
+        self.windowCalls = windowCalls
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
+        self.errorPresenter = errorPresenter
+        self.presenter = RetryTranscriptionStatusPresenter(
+            errorPresenter: errorPresenter,
+            showSettingsWindow: {
+                windowCalls.showSettingsCallCount += 1
+            },
+            showTranscriptWindow: {
+                windowCalls.showTranscriptCallCount += 1
+            }
+        )
+    }
+
+    func lastAppErrorTelemetry(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> (name: String, metadata: [String: String]) {
+        try XCTUnwrap(
+            telemetryRecorder.recordedEvents.last { $0.name == TelemetryEvent.appError.rawValue },
+            file: file,
+            line: line
+        )
+    }
+}
+
+private final class WindowCallRecorder {
+    var showSettingsCallCount = 0
+    var showTranscriptCallCount = 0
+}


### PR DESCRIPTION
## Summary
- Add RetryTranscriptionStatusPresenter for retry preflight and retryable-failure status presentation
- Replace AppState inline retry status, telemetry, and recovery-window presentation with presenter calls
- Add focused presenter tests and include them in the Xcode test target

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests -only-testing:BugNarratorTests/RetryTranscriptionStatusPresenterTests\n- ./scripts/validate.sh origin/main\n\nCloses #189