### PR TITLE
Move session cancellation status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -15,6 +15,7 @@ final class AppState: ObservableObject {
     let errorPresenter: AppErrorPresenter
     let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
+    let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
     let sessionLibrary: SessionLibraryController
     let exportHistoryController: ExportHistoryController
@@ -236,6 +237,9 @@ final class AppState: ObservableObject {
             recordingTimer: recordingTimer
         )
         self.recordingSessionController = recordingSessionController
+        self.recordingSessionCancelStatusPresenter = RecordingSessionCancelStatusPresenter(
+            setStatus: { status in presentationState.setStatus(status, error: nil) }
+        )
         let recordingStatusMessages = RecordingStatusMessageProvider {
             RecordingStatusMessageSnapshot(
                 audioSource: settingsStore.recordingAudioSource,
@@ -717,21 +721,7 @@ final class AppState: ObservableObject {
             }
         )
 
-        switch outcome {
-        case .transitionInProgress:
-            recordingLogger.debug("session_cancel_ignored", "The cancel request was ignored because another recording transition is already in progress.")
-            return
-
-        case .cancelled(let activeRecordingSession):
-            if let activeRecordingSession {
-                recordingLogger.info(
-                    "session_cancelled",
-                    "The active feedback session was discarded.",
-                    metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
-                )
-            }
-            setStatus(.idle("Session discarded."))
-        }
+        recordingSessionCancelStatusPresenter.present(outcome)
     }
 
     func openTranscriptHistory() {

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -1,6 +1,39 @@
 import Foundation
 
 @MainActor
+final class RecordingSessionCancelStatusPresenter {
+    static let discardedStatus = AppStatus.idle("Session discarded.")
+
+    private let setStatus: (AppStatus) -> Void
+    private let recordingLogger: DiagnosticsLogger
+
+    init(
+        setStatus: @escaping (AppStatus) -> Void,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording)
+    ) {
+        self.setStatus = setStatus
+        self.recordingLogger = recordingLogger
+    }
+
+    func present(_ outcome: RecordingSessionCancelOutcome) {
+        switch outcome {
+        case .transitionInProgress:
+            recordingLogger.debug("session_cancel_ignored", "The cancel request was ignored because another recording transition is already in progress.")
+
+        case .cancelled(let activeRecordingSession):
+            if let activeRecordingSession {
+                recordingLogger.info(
+                    "session_cancelled",
+                    "The active feedback session was discarded.",
+                    metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
+                )
+            }
+            setStatus(Self.discardedStatus)
+        }
+    }
+}
+
+@MainActor
 final class RecordingSessionController: ObservableObject {
     @Published private(set) var activeRecordingSession: RecordingSessionDraft?
 

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -104,6 +104,37 @@ final class RecordingSessionControllerTests: XCTestCase {
         XCTAssertEqual(harness.artifactsService.removedDirectories, [recordingSession.artifactsDirectoryURL])
     }
 
+    func testCancelStatusPresenterSetsDiscardedStatusForCancelledSession() {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let presenter = RecordingSessionCancelStatusPresenter { status in
+            presentationState.setStatus(status, error: nil)
+        }
+
+        presenter.present(
+            .cancelled(
+                RecordingSessionDraft(
+                    sessionID: UUID(),
+                    artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/bug-narrator-session", isDirectory: true)
+                )
+            )
+        )
+
+        XCTAssertEqual(presentationState.status, .idle("Session discarded."))
+        XCTAssertNil(presentationState.currentError)
+    }
+
+    func testCancelStatusPresenterLeavesStatusForTransitionInProgress() {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let presenter = RecordingSessionCancelStatusPresenter { status in
+            presentationState.setStatus(status, error: nil)
+        }
+
+        presenter.present(.transitionInProgress)
+
+        XCTAssertEqual(presentationState.status, .recording("Recording in progress."))
+        XCTAssertNil(presentationState.currentError)
+    }
+
     func testCleanupPendingRecordedAudioPreservesDebugFilesUntilExplicitCleanup() async throws {
         let harness = try RecordingSessionControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add RecordingSessionCancelStatusPresenter for cancel outcome logging and discarded-session status presentation
- Replace AppState inline cancel-outcome switch with a presenter call
- Cover cancelled and transition-in-progress presentation behavior in RecordingSessionControllerTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #191