### PR TITLE
Move transcript persistence failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -13,6 +13,7 @@ final class AppState: ObservableObject {
     let recordingTimer: RecordingTimerViewModel
     let presentationState: AppPresentationState
     let errorPresenter: AppErrorPresenter
+    let transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter
     let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
@@ -291,6 +292,10 @@ final class AppState: ObservableObject {
             permissionRecoveryController: permissionRecoveryController
         )
         self.appUtilityActions = appUtilityActions
+        self.transcriptPersistenceFailurePresenter = TranscriptPersistenceFailurePresenter(
+            errorPresenter: self.errorPresenter,
+            showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
+        )
         self.recoveredRecordingLaunchImporter = RecoveredRecordingLaunchImportPresenter(
             importController: recoveredRecordingImportController,
             errorPresenter: self.errorPresenter,
@@ -1364,22 +1369,7 @@ final class AppState: ObservableObject {
         cleanupPendingRecordedAudioIfNeeded()
         recordingSessionController.endActivity()
 
-        let normalizedError = errorPresenter.normalizeError(
-            error,
-            operation: .sessionLibrary,
-            fallback: { .storageFailure($0) }
-        )
-        let appError = normalizedError.appError
-        errorPresenter.logAppError(normalizedError, context: "transcript_persist_failed")
-        var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "transcript_persist_failed")
-        metadata["session_id"] = session.id.uuidString
-        sessionLibraryLogger.error(
-            "transcript_persist_failed",
-            "Transcription succeeded, but saving the transcript locally failed.",
-            metadata: metadata
-        )
-        setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
-        showTranscriptWindow?()
+        transcriptPersistenceFailurePresenter.present(error, sessionID: session.id)
     }
 
     private func handleFinishedRecordingPostTranscriptionResult(

--- a/Sources/BugNarrator/Services/AppErrorPresenter.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresenter.swift
@@ -27,6 +27,42 @@ struct AppErrorPresentationResult: Equatable {
 }
 
 @MainActor
+final class TranscriptPersistenceFailurePresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showTranscriptWindow: () -> Void
+    private let sessionLibraryLogger: DiagnosticsLogger
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showTranscriptWindow: @escaping () -> Void,
+        sessionLibraryLogger: DiagnosticsLogger = DiagnosticsLogger(category: .sessionLibrary)
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showTranscriptWindow = showTranscriptWindow
+        self.sessionLibraryLogger = sessionLibraryLogger
+    }
+
+    func present(_ error: Error, sessionID: UUID) {
+        let normalizedError = errorPresenter.normalizeError(
+            error,
+            operation: .sessionLibrary,
+            fallback: { .storageFailure($0) }
+        )
+        let appError = normalizedError.appError
+        errorPresenter.logAppError(normalizedError, context: "transcript_persist_failed")
+        var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "transcript_persist_failed")
+        metadata["session_id"] = sessionID.uuidString
+        sessionLibraryLogger.error(
+            "transcript_persist_failed",
+            "Transcription succeeded, but saving the transcript locally failed.",
+            metadata: metadata
+        )
+        errorPresenter.setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+        showTranscriptWindow()
+    }
+}
+
+@MainActor
 final class AppErrorPresenter {
     private let presentationState: AppPresentationState
     private let telemetryRecorder: any OperationalTelemetryRecording

--- a/Tests/BugNarratorTests/AppErrorPresenterTests.swift
+++ b/Tests/BugNarratorTests/AppErrorPresenterTests.swift
@@ -71,6 +71,35 @@ final class AppErrorPresenterTests: XCTestCase {
         XCTAssertEqual(telemetry.metadata["operation"], "post_transcription")
         XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
     }
+
+    func testTranscriptPersistenceFailurePresenterPrefixesStatusAndOpensTranscript() throws {
+        let harness = AppErrorPresenterHarness()
+        let underlyingError = NSError(
+            domain: "AppErrorPresenterTests",
+            code: 11,
+            userInfo: [NSLocalizedDescriptionKey: "Disk locked"]
+        )
+        var showTranscriptCallCount = 0
+        let presenter = TranscriptPersistenceFailurePresenter(
+            errorPresenter: harness.presenter,
+            showTranscriptWindow: {
+                showTranscriptCallCount += 1
+            }
+        )
+
+        presenter.present(underlyingError, sessionID: UUID())
+
+        let appError = AppError.storageFailure("Disk locked")
+        XCTAssertEqual(harness.presentationState.status, .error("Transcript ready, but \(appError.userMessage)"))
+        XCTAssertEqual(harness.presentationState.currentError, appError)
+        XCTAssertEqual(showTranscriptCallCount, 1)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "transcript_persist_failed")
+        XCTAssertEqual(telemetry.metadata["operation"], "session_library")
+        XCTAssertEqual(telemetry.metadata["error_type"], "storage_failure")
+        XCTAssertEqual(telemetry.metadata["underlying_error"], "Disk locked")
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- Add TranscriptPersistenceFailurePresenter for post-transcription save failure presentation and logging
- Replace AppState inline normalization/status/logging/window presentation with a presenter call
- Keep AppState responsible for transcript staging, active-recording cleanup, and temporary audio cleanup

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppErrorPresenterTests\n- ./scripts/validate.sh origin/main\n\nCloses #193