### PR TITLE
Move retryable session preservation presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -33,6 +33,7 @@ final class AppState: ObservableObject {
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let retryTranscriptionStatusPresenter: RetryTranscriptionStatusPresenter
+    let retryableSessionPreservationPresenter: RetryableSessionPreservationPresenter
     let screenshotCoordinator: ScreenshotCoordinator
     let screenshotCaptureController: ScreenshotCaptureController
 
@@ -63,7 +64,6 @@ final class AppState: ObservableObject {
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
-    private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
     private let permissionsLogger = DiagnosticsLogger(category: .permissions)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
@@ -342,6 +342,11 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() },
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
+        )
+        self.retryableSessionPreservationPresenter = RetryableSessionPreservationPresenter(
+            errorPresenter: self.errorPresenter,
+            showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
         let screenshotCoordinator = ScreenshotCoordinator(
             screenCapturePermissionService: screenCapturePermissionService,
@@ -1458,40 +1463,17 @@ final class AppState: ObservableObject {
             recordingSessionController.clearActiveRecordingSession()
             cleanupPendingRecordedAudioIfNeeded()
             recordingSessionController.endActivity()
-            errorPresenter.logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
-            setStatus(.error(retryableSession.transcriptionRecoveryMessage ?? appError.userMessage), error: appError)
-            showTranscriptWindow?()
-            if appError.suggestsOpenAISettings {
-                showSettingsWindow?()
-            }
+            retryableSessionPreservationPresenter.presentPreservedSession(retryableSession, appError: appError)
 
         case .persistenceFailure(let retryableSession, let error):
             recordingSessionController.clearActiveRecordingSession()
             cleanupPendingRecordedAudioIfNeeded()
             recordingSessionController.endActivity()
-
-            let normalizedError = errorPresenter.normalizeError(
+            retryableSessionPreservationPresenter.presentPersistenceFailure(
                 error,
-                operation: .sessionLibrary,
-                fallback: { .storageFailure($0) }
+                retryableSession: retryableSession,
+                recoveryAppError: failureReason.appError
             )
-            let persistenceError = normalizedError.appError
-            errorPresenter.logAppError(normalizedError, context: "retryable_session_persist_failed")
-            var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
-            metadata["session_id"] = retryableSession.id.uuidString
-            sessionLibraryLogger.error(
-                "retryable_session_persist_failed",
-                "The preserved recording could not be saved into local session history.",
-                metadata: metadata
-            )
-            setStatus(
-                .error("Recording preserved, but \(persistenceError.userMessage)"),
-                error: persistenceError
-            )
-            showTranscriptWindow?()
-            if failureReason.appError.suggestsOpenAISettings {
-                showSettingsWindow?()
-            }
 
         case .preservationFailure(let error):
             if !settingsStore.debugMode {

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -49,6 +49,67 @@ final class RetryTranscriptionStatusPresenter {
 }
 
 @MainActor
+final class RetryableSessionPreservationPresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showTranscriptWindow: () -> Void
+    private let showSettingsWindow: () -> Void
+    private let sessionLibraryLogger: DiagnosticsLogger
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showTranscriptWindow: @escaping () -> Void,
+        showSettingsWindow: @escaping () -> Void,
+        sessionLibraryLogger: DiagnosticsLogger = DiagnosticsLogger(category: .sessionLibrary)
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showTranscriptWindow = showTranscriptWindow
+        self.showSettingsWindow = showSettingsWindow
+        self.sessionLibraryLogger = sessionLibraryLogger
+    }
+
+    func presentPreservedSession(_ retryableSession: TranscriptSession, appError: AppError) {
+        errorPresenter.logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
+        errorPresenter.setStatus(
+            .error(retryableSession.transcriptionRecoveryMessage ?? appError.userMessage),
+            error: appError
+        )
+        showTranscriptWindow()
+        if appError.suggestsOpenAISettings {
+            showSettingsWindow()
+        }
+    }
+
+    func presentPersistenceFailure(
+        _ error: Error,
+        retryableSession: TranscriptSession,
+        recoveryAppError: AppError
+    ) {
+        let normalizedError = errorPresenter.normalizeError(
+            error,
+            operation: .sessionLibrary,
+            fallback: { .storageFailure($0) }
+        )
+        let persistenceError = normalizedError.appError
+        errorPresenter.logAppError(normalizedError, context: "retryable_session_persist_failed")
+        var metadata = errorPresenter.appErrorMetadata(for: normalizedError, context: "retryable_session_persist_failed")
+        metadata["session_id"] = retryableSession.id.uuidString
+        sessionLibraryLogger.error(
+            "retryable_session_persist_failed",
+            "The preserved recording could not be saved into local session history.",
+            metadata: metadata
+        )
+        errorPresenter.setStatus(
+            .error("Recording preserved, but \(persistenceError.userMessage)"),
+            error: persistenceError
+        )
+        showTranscriptWindow()
+        if recoveryAppError.suggestsOpenAISettings {
+            showSettingsWindow()
+        }
+    }
+}
+
+@MainActor
 final class TranscriptionRecoveryController: ObservableObject {
     @Published private(set) var retryingSessionID: UUID?
 

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -48,6 +48,83 @@ final class TranscriptionRecoveryControllerTests: XCTestCase {
         XCTAssertEqual(statusMessage, session.transcriptionRecoveryMessage)
     }
 
+    func testPreservationPresenterPresentsPreservedSessionRecoveryStatus() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+        let session = try harness.addPendingSession(failureReason: .missingAPIKey)
+        let presentationState = AppPresentationState()
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
+        var showTranscriptCallCount = 0
+        var showSettingsCallCount = 0
+        let presenter = RetryableSessionPreservationPresenter(
+            errorPresenter: errorPresenter,
+            showTranscriptWindow: { showTranscriptCallCount += 1 },
+            showSettingsWindow: { showSettingsCallCount += 1 }
+        )
+
+        presenter.presentPreservedSession(session, appError: .missingAPIKey)
+
+        XCTAssertEqual(presentationState.status, .error(try XCTUnwrap(session.transcriptionRecoveryMessage)))
+        XCTAssertEqual(presentationState.currentError, .missingAPIKey)
+        XCTAssertEqual(showTranscriptCallCount, 1)
+        XCTAssertEqual(showSettingsCallCount, 1)
+
+        let telemetry = try XCTUnwrap(
+            telemetryRecorder.recordedEvents.last { $0.name == TelemetryEvent.appError.rawValue }
+        )
+        XCTAssertEqual(telemetry.metadata["context"], "preserve_retryable_session")
+        XCTAssertEqual(telemetry.metadata["operation"], "transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "missing_api_key")
+    }
+
+    func testPreservationPresenterPresentsPersistenceFailureRecoveryStatus() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+        let session = try harness.addPendingSession(failureReason: .missingAPIKey)
+        let presentationState = AppPresentationState()
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
+        var showTranscriptCallCount = 0
+        var showSettingsCallCount = 0
+        let presenter = RetryableSessionPreservationPresenter(
+            errorPresenter: errorPresenter,
+            showTranscriptWindow: { showTranscriptCallCount += 1 },
+            showSettingsWindow: { showSettingsCallCount += 1 }
+        )
+        let underlyingError = NSError(
+            domain: "TranscriptionRecoveryControllerTests",
+            code: 17,
+            userInfo: [NSLocalizedDescriptionKey: "Index path is a directory"]
+        )
+
+        presenter.presentPersistenceFailure(
+            underlyingError,
+            retryableSession: session,
+            recoveryAppError: .missingAPIKey
+        )
+
+        let appError = AppError.storageFailure("Index path is a directory")
+        XCTAssertEqual(presentationState.status, .error("Recording preserved, but \(appError.userMessage)"))
+        XCTAssertEqual(presentationState.currentError, appError)
+        XCTAssertEqual(showTranscriptCallCount, 1)
+        XCTAssertEqual(showSettingsCallCount, 1)
+
+        let telemetry = try XCTUnwrap(
+            telemetryRecorder.recordedEvents.last { $0.name == TelemetryEvent.appError.rawValue }
+        )
+        XCTAssertEqual(telemetry.metadata["context"], "retryable_session_persist_failed")
+        XCTAssertEqual(telemetry.metadata["operation"], "session_library")
+        XCTAssertEqual(telemetry.metadata["error_type"], "storage_failure")
+        XCTAssertEqual(telemetry.metadata["underlying_error"], "Index path is a directory")
+    }
+
     func testPreserveRetryableSessionCopiesAudioAndStoresPendingSession() throws {
         let harness = try TranscriptionRecoveryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add RetryableSessionPreservationPresenter for preserved-recording retry status/logging/window presentation
- Replace AppState inline preserved-session and persistence-failure presentation blocks with presenter calls
- Keep AppState responsible for cleanup, active-recording lifecycle, and preservation-failure handling

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #195