### PR TITLE
Move recording stop readiness presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -16,6 +16,7 @@ final class AppState: ObservableObject {
     let transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter
     let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
+    let recordingSessionStopReadinessPresenter: RecordingSessionStopReadinessPresenter
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
     let sessionLibrary: SessionLibraryController
@@ -238,6 +239,9 @@ final class AppState: ObservableObject {
             recordingTimer: recordingTimer
         )
         self.recordingSessionController = recordingSessionController
+        self.recordingSessionStopReadinessPresenter = RecordingSessionStopReadinessPresenter(
+            errorPresenter: self.errorPresenter
+        )
         self.recordingSessionCancelStatusPresenter = RecordingSessionCancelStatusPresenter(
             setStatus: { status in presentationState.setStatus(status, error: nil) }
         )
@@ -1225,25 +1229,9 @@ final class AppState: ObservableObject {
     }
 
     private func beginStoppingSession() -> RecordingSessionDraft? {
-        switch recordingSessionController.beginStoppingSession(statusPhase: status.phase) {
-        case .transitionInProgress:
-            recordingLogger.debug(.sessionStopIgnored, "The stop request was ignored because another recording transition is already in progress.")
-            return nil
-
-        case .noActiveRecording:
-            recordingLogger.warning(.sessionStopRejected, "The stop request was rejected because no recording session is active.")
-            return nil
-
-        case .missingSessionMetadata:
-            presentError(
-                AppError.recordingFailure("The recording session metadata was unavailable."),
-                operation: .recordingStop
-            )
-            return nil
-
-        case .ready(let recordingSession):
-            return recordingSession
-        }
+        recordingSessionStopReadinessPresenter.recordingSession(
+            for: recordingSessionController.beginStoppingSession(statusPhase: status.phase)
+        )
     }
 
     private func completePostTranscriptionPipeline(

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -34,6 +34,42 @@ final class RecordingSessionCancelStatusPresenter {
 }
 
 @MainActor
+final class RecordingSessionStopReadinessPresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let recordingLogger: DiagnosticsLogger
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording)
+    ) {
+        self.errorPresenter = errorPresenter
+        self.recordingLogger = recordingLogger
+    }
+
+    func recordingSession(for readiness: RecordingSessionStopReadiness) -> RecordingSessionDraft? {
+        switch readiness {
+        case .transitionInProgress:
+            recordingLogger.debug(.sessionStopIgnored, "The stop request was ignored because another recording transition is already in progress.")
+            return nil
+
+        case .noActiveRecording:
+            recordingLogger.warning(.sessionStopRejected, "The stop request was rejected because no recording session is active.")
+            return nil
+
+        case .missingSessionMetadata:
+            _ = errorPresenter.presentError(
+                AppError.recordingFailure("The recording session metadata was unavailable."),
+                operation: .recordingStop
+            )
+            return nil
+
+        case .ready(let recordingSession):
+            return recordingSession
+        }
+    }
+}
+
+@MainActor
 final class RecordingSessionController: ObservableObject {
     @Published private(set) var activeRecordingSession: RecordingSessionDraft?
 

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -81,6 +81,75 @@ final class RecordingSessionControllerTests: XCTestCase {
         XCTAssertEqual(harness.audioRecorder.stopCallCount, 0)
     }
 
+    func testStopReadinessPresenterReturnsReadySession() {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let presenter = RecordingSessionStopReadinessPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            )
+        )
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/bug-narrator-ready-session", isDirectory: true)
+        )
+
+        let readySession = presenter.recordingSession(for: .ready(recordingSession))
+
+        XCTAssertEqual(readySession?.sessionID, recordingSession.sessionID)
+        XCTAssertEqual(readySession?.artifactsDirectoryURL, recordingSession.artifactsDirectoryURL)
+        XCTAssertEqual(presentationState.status, .recording("Recording in progress."))
+        XCTAssertNil(presentationState.currentError)
+        XCTAssertTrue(telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testStopReadinessPresenterLeavesStatusForTransitionInProgress() {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let presenter = RecordingSessionStopReadinessPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: MockOperationalTelemetryRecorder()
+            )
+        )
+
+        XCTAssertNil(presenter.recordingSession(for: .transitionInProgress))
+        XCTAssertEqual(presentationState.status, .recording("Recording in progress."))
+        XCTAssertNil(presentationState.currentError)
+    }
+
+    func testStopReadinessPresenterLeavesStatusForNoActiveRecording() {
+        let presentationState = AppPresentationState(status: .idle("Ready."))
+        let presenter = RecordingSessionStopReadinessPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: MockOperationalTelemetryRecorder()
+            )
+        )
+
+        XCTAssertNil(presenter.recordingSession(for: .noActiveRecording))
+        XCTAssertEqual(presentationState.status, .idle("Ready."))
+        XCTAssertNil(presentationState.currentError)
+    }
+
+    func testStopReadinessPresenterPresentsMissingMetadataError() {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let presenter = RecordingSessionStopReadinessPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            )
+        )
+        let expectedError = AppError.recordingFailure("The recording session metadata was unavailable.")
+
+        XCTAssertNil(presenter.recordingSession(for: .missingSessionMetadata))
+        XCTAssertEqual(presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(presentationState.currentError, expectedError)
+        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_stop")
+    }
+
     func testCancelSessionCancelsRecorderAndRemovesArtifacts() async throws {
         let harness = try RecordingSessionControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Add `RecordingSessionStopReadinessPresenter` for stop-readiness logging and missing-metadata error presentation.
- Delegate `AppState.beginStoppingSession()` to the presenter so `AppState` only consumes the ready recording session.
- Cover ready, ignored, rejected, and missing-metadata readiness outcomes in `RecordingSessionControllerTests`.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests`
- `./scripts/validate.sh origin/main`

Closes #197