### PR TITLE
Move recording start outcome presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -16,6 +16,7 @@ final class AppState: ObservableObject {
     let transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter
     let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
+    let recordingSessionStartStatusPresenter: RecordingSessionStartStatusPresenter
     let recordingSessionStopReadinessPresenter: RecordingSessionStopReadinessPresenter
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
@@ -65,7 +66,6 @@ final class AppState: ObservableObject {
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
-    private let permissionsLogger = DiagnosticsLogger(category: .permissions)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
     var status: AppStatus {
@@ -255,6 +255,18 @@ final class AppState: ObservableObject {
             )
         }
         self.recordingStatusMessages = recordingStatusMessages
+        self.recordingSessionStartStatusPresenter = RecordingSessionStartStatusPresenter(
+            errorPresenter: self.errorPresenter,
+            recordingStatusMessages: recordingStatusMessages,
+            startDiagnosticsMetadata: {
+                [
+                    "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
+                    "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
+                    "ai_provider": settingsStore.aiProvider.rawValue
+                ]
+            },
+            telemetryRecorder: telemetryRecorder
+        )
         let sessionLibrary = SessionLibraryController(
             transcriptStore: transcriptStore,
             artifactsService: artifactsService,
@@ -614,54 +626,7 @@ final class AppState: ObservableObject {
             statusPhase: status.phase,
             activityReason: recordingStatusMessages.recordingActivityReason()
         )
-
-        switch outcome {
-        case .transitionInProgress:
-            recordingLogger.debug(.sessionStartIgnored, "The start request was ignored because another recording transition is already in progress.")
-            return
-
-        case .busy:
-            recordingLogger.warning(.sessionStartRejected, "The start request was rejected because BugNarrator is already busy.")
-            return
-
-        case .restored(let recordingSession):
-            recordingLogger.warning(
-                "session_start_reconciled_active_session",
-                "A start request arrived while a recording session draft was still active; restoring recording state instead of starting a duplicate recorder.",
-                metadata: ["session_id": recordingSession.sessionID.uuidString]
-            )
-            setStatus(.recording(recordingStatusMessages.recordingDetailMessage()))
-            return
-
-        case .preflightFailure(let preflightError):
-            permissionsLogger.warning(.sessionStartPreflightFailed, preflightError.userMessage)
-            presentError(preflightError, operation: .recordingStart)
-            return
-
-        case .failure(let error):
-            presentError(error, operation: .recordingStart, fallback: { .recordingFailure($0) })
-
-        case .started(let recordingSession):
-            setStatus(.recording(recordingStatusMessages.recordingDetailMessage()))
-            recordingLogger.info(
-                .sessionStarted,
-                "A feedback session started successfully.",
-                metadata: [
-                    "session_id": recordingSession.sessionID.uuidString,
-                    "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
-                    "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
-                    "ai_provider": settingsStore.aiProvider.rawValue
-                ]
-            )
-            telemetryRecorder.record(
-                .recordingStarted,
-                metadata: [
-                    "audio_source": settingsStore.recordingAudioSource.diagnosticsValue,
-                    "has_ai_provider_credential": settingsStore.hasUsableAIProviderCredential ? "yes" : "no",
-                    "ai_provider": settingsStore.aiProvider.rawValue
-                ]
-            )
-        }
+        recordingSessionStartStatusPresenter.present(outcome)
     }
 
     func stopSession() async {

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -1,6 +1,69 @@
 import Foundation
 
 @MainActor
+final class RecordingSessionStartStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let recordingStatusMessages: RecordingStatusMessageProvider
+    private let startDiagnosticsMetadata: () -> [String: String]
+    private let telemetryRecorder: any OperationalTelemetryRecording
+    private let recordingLogger: DiagnosticsLogger
+    private let permissionsLogger: DiagnosticsLogger
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        recordingStatusMessages: RecordingStatusMessageProvider,
+        startDiagnosticsMetadata: @escaping () -> [String: String],
+        telemetryRecorder: any OperationalTelemetryRecording,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording),
+        permissionsLogger: DiagnosticsLogger = DiagnosticsLogger(category: .permissions)
+    ) {
+        self.errorPresenter = errorPresenter
+        self.recordingStatusMessages = recordingStatusMessages
+        self.startDiagnosticsMetadata = startDiagnosticsMetadata
+        self.telemetryRecorder = telemetryRecorder
+        self.recordingLogger = recordingLogger
+        self.permissionsLogger = permissionsLogger
+    }
+
+    func present(_ outcome: RecordingSessionStartOutcome) {
+        switch outcome {
+        case .transitionInProgress:
+            recordingLogger.debug(.sessionStartIgnored, "The start request was ignored because another recording transition is already in progress.")
+
+        case .busy:
+            recordingLogger.warning(.sessionStartRejected, "The start request was rejected because BugNarrator is already busy.")
+
+        case .restored(let recordingSession):
+            recordingLogger.warning(
+                "session_start_reconciled_active_session",
+                "A start request arrived while a recording session draft was still active; restoring recording state instead of starting a duplicate recorder.",
+                metadata: ["session_id": recordingSession.sessionID.uuidString]
+            )
+            errorPresenter.setStatus(.recording(recordingStatusMessages.recordingDetailMessage()))
+
+        case .preflightFailure(let preflightError):
+            permissionsLogger.warning(.sessionStartPreflightFailed, preflightError.userMessage)
+            _ = errorPresenter.presentError(preflightError, operation: .recordingStart)
+
+        case .failure(let error):
+            _ = errorPresenter.presentError(error, operation: .recordingStart, fallback: { .recordingFailure($0) })
+
+        case .started(let recordingSession):
+            errorPresenter.setStatus(.recording(recordingStatusMessages.recordingDetailMessage()))
+            let metadata = startDiagnosticsMetadata()
+            var logMetadata = metadata
+            logMetadata["session_id"] = recordingSession.sessionID.uuidString
+            recordingLogger.info(
+                .sessionStarted,
+                "A feedback session started successfully.",
+                metadata: logMetadata
+            )
+            telemetryRecorder.record(.recordingStarted, metadata: metadata)
+        }
+    }
+}
+
+@MainActor
 final class RecordingSessionCancelStatusPresenter {
     static let discardedStatus = AppStatus.idle("Session discarded.")
 

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -44,6 +44,85 @@ final class RecordingSessionControllerTests: XCTestCase {
         XCTAssertEqual(harness.audioRecorder.startCallCount, 1)
     }
 
+    func testStartStatusPresenterSetsRecordingStatusAndTelemetryForStartedSession() {
+        let harness = makeStartStatusPresenter()
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/bug-narrator-started-session", isDirectory: true)
+        )
+
+        harness.presenter.present(.started(recordingSession))
+
+        XCTAssertEqual(harness.presentationState.status, .recording(harness.recordingMessage))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.count, 1)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "recording_started")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata, harness.diagnosticsMetadata)
+    }
+
+    func testStartStatusPresenterSetsRecordingStatusForRestoredSession() {
+        let harness = makeStartStatusPresenter(status: .idle("Ready."))
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: URL(fileURLWithPath: "/tmp/bug-narrator-restored-session", isDirectory: true)
+        )
+
+        harness.presenter.present(.restored(recordingSession))
+
+        XCTAssertEqual(harness.presentationState.status, .recording(harness.recordingMessage))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testStartStatusPresenterPresentsPreflightFailure() {
+        let harness = makeStartStatusPresenter()
+        let expectedError = AppError.microphonePermissionDenied
+
+        harness.presenter.present(.preflightFailure(expectedError))
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_start")
+    }
+
+    func testStartStatusPresenterNormalizesGenericStartFailure() {
+        let harness = makeStartStatusPresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Recorder unavailable"]
+        )
+        let expectedError = AppError.recordingFailure("Recorder unavailable")
+
+        harness.presenter.present(.failure(error))
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_start")
+    }
+
+    func testStartStatusPresenterLeavesStatusForTransitionInProgress() {
+        let harness = makeStartStatusPresenter(status: .idle("Ready."))
+
+        harness.presenter.present(.transitionInProgress)
+
+        XCTAssertEqual(harness.presentationState.status, .idle("Ready."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testStartStatusPresenterLeavesStatusForBusyApp() {
+        let harness = makeStartStatusPresenter(status: .transcribing("Uploading..."))
+
+        harness.presenter.present(.busy)
+
+        XCTAssertEqual(harness.presentationState.status, .transcribing("Uploading..."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
     func testStopSessionReturnsRecordedAudioAndStoresHandoff() async throws {
         let harness = try RecordingSessionControllerHarness()
         defer { harness.cleanup() }
@@ -227,6 +306,50 @@ final class RecordingSessionControllerTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
         XCTAssertNil(harness.controller.pendingRecordedAudioSnapshot)
+    }
+
+    private func makeStartStatusPresenter(
+        status: AppStatus = .idle()
+    ) -> (
+        presenter: RecordingSessionStartStatusPresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder,
+        recordingMessage: String,
+        diagnosticsMetadata: [String: String]
+    ) {
+        let presentationState = AppPresentationState(status: status)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let statusMessages = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: false,
+                autoCopyTranscript: false
+            )
+        }
+        let diagnosticsMetadata = [
+            "audio_source": RecordingAudioSource.microphone.diagnosticsValue,
+            "has_ai_provider_credential": "yes",
+            "ai_provider": "openAI"
+        ]
+        let presenter = RecordingSessionStartStatusPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            ),
+            recordingStatusMessages: statusMessages,
+            startDiagnosticsMetadata: { diagnosticsMetadata },
+            telemetryRecorder: telemetryRecorder
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder,
+            recordingMessage: statusMessages.recordingDetailMessage(),
+            diagnosticsMetadata: diagnosticsMetadata
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `RecordingSessionStartStatusPresenter` for recording-start outcome status, error, logging, and telemetry presentation.
- Have `AppState.startSession()` delegate the `RecordingSessionStartOutcome` presentation after requesting the controller start.
- Cover started, restored, preflight failure, generic failure, ignored, and busy outcomes in recording-session tests.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests`
- `./scripts/validate.sh origin/main`

Closes #199