### PR TITLE
Move manual issue extraction presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -25,6 +25,7 @@ final class AppState: ObservableObject {
     let recoveredRecordingImportController: RecoveredRecordingImportController
     private let recoveredRecordingLaunchImporter: RecoveredRecordingLaunchImportPresenter
     let issueExtractionController: IssueExtractionController
+    let manualIssueExtractionStatusPresenter: ManualIssueExtractionStatusPresenter
     let issueExportController: IssueExportController
     let permissionRecoveryController: PermissionRecoveryController
     let appUtilityActions: AppUtilityActionController
@@ -308,6 +309,11 @@ final class AppState: ObservableObject {
             permissionRecoveryController: permissionRecoveryController
         )
         self.appUtilityActions = appUtilityActions
+        self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
+            errorPresenter: self.errorPresenter,
+            showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
         self.transcriptPersistenceFailurePresenter = TranscriptPersistenceFailurePresenter(
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
@@ -1001,13 +1007,8 @@ final class AppState: ObservableObject {
             aiProviderCompatibilityIssue: settingsStore.aiProviderCompatibilityIssue,
             statusPhase: status.phase
         ) else {
-            setStatus(IssueExtractionStatusPresenter.manualProgressStatus)
+            manualIssueExtractionStatusPresenter.presentRequestStarted(sessionID: transcriptSession.id)
             recordingSessionController.beginActivity(reason: "Extracting review issues")
-            transcriptionLogger.info(
-                "issue_extraction_requested",
-                "Issue extraction was requested for the selected transcript.",
-                metadata: ["session_id": transcriptSession.id.uuidString]
-            )
 
             do {
                 guard let apiKey = settingsStore.aiProviderCredentialForUserInitiatedAccess() else {
@@ -1023,21 +1024,15 @@ final class AppState: ObservableObject {
                 )
 
                 recordingSessionController.endActivity()
-                setStatus(IssueExtractionStatusPresenter.manualCompletionStatus(issueCount: extraction.issues.count))
-                showTranscriptWindow?()
+                manualIssueExtractionStatusPresenter.presentCompletion(issueCount: extraction.issues.count)
             } catch {
-                presentError(error, operation: .postTranscription, fallback: { .issueExtractionFailure($0) })
+                manualIssueExtractionStatusPresenter.presentFailure(error)
             }
 
             return
         }
 
-        transcriptionLogger.warning(
-            "issue_extraction_preflight_failed",
-            preflightError.userMessage,
-            metadata: ["session_id": transcriptSession.id.uuidString]
-        )
-        presentError(preflightError, operation: .postTranscription)
+        manualIssueExtractionStatusPresenter.presentPreflightFailure(preflightError, sessionID: transcriptSession.id)
     }
 
     func updateExtractedIssue(_ updatedIssue: ExtractedIssue, in sessionID: UUID) {

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -12,6 +12,63 @@ enum IssueExtractionStatusPresenter {
 }
 
 @MainActor
+final class ManualIssueExtractionStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showTranscriptWindow: () -> Void
+    private let showSettingsWindow: () -> Void
+    private let logger: DiagnosticsLogger
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showTranscriptWindow: @escaping () -> Void,
+        showSettingsWindow: @escaping () -> Void,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .transcription)
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showTranscriptWindow = showTranscriptWindow
+        self.showSettingsWindow = showSettingsWindow
+        self.logger = logger
+    }
+
+    func presentRequestStarted(sessionID: UUID) {
+        errorPresenter.setStatus(IssueExtractionStatusPresenter.manualProgressStatus)
+        logger.info(
+            "issue_extraction_requested",
+            "Issue extraction was requested for the selected transcript.",
+            metadata: ["session_id": sessionID.uuidString]
+        )
+    }
+
+    func presentCompletion(issueCount: Int) {
+        errorPresenter.setStatus(IssueExtractionStatusPresenter.manualCompletionStatus(issueCount: issueCount))
+        showTranscriptWindow()
+    }
+
+    func presentPreflightFailure(_ error: AppError, sessionID: UUID) {
+        logger.warning(
+            "issue_extraction_preflight_failed",
+            error.userMessage,
+            metadata: ["session_id": sessionID.uuidString]
+        )
+        presentError(error)
+    }
+
+    func presentFailure(_ error: Error) {
+        presentError(error, fallback: { .issueExtractionFailure($0) })
+    }
+
+    private func presentError(
+        _ error: Error,
+        fallback: (String) -> AppError = { .transcriptionFailure($0) }
+    ) {
+        let result = errorPresenter.presentError(error, operation: .postTranscription, fallback: fallback)
+        if result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
+    }
+}
+
+@MainActor
 final class IssueExtractionController: ObservableObject {
     @Published private(set) var issueExtractionSessionID: UUID?
 

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -14,6 +14,66 @@ final class IssueExtractionControllerTests: XCTestCase {
         )
     }
 
+    func testManualIssueExtractionPresenterSetsProgressStatus() {
+        let harness = makeManualIssueExtractionPresenter()
+
+        harness.presenter.presentRequestStarted(sessionID: UUID())
+
+        XCTAssertEqual(harness.presentationState.status, IssueExtractionStatusPresenter.manualProgressStatus)
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.transcriptWindowOpenCount(), 0)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 0)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testManualIssueExtractionPresenterSetsCompletionStatusAndShowsTranscriptWindow() {
+        let harness = makeManualIssueExtractionPresenter(status: .transcribing("Running extraction."))
+
+        harness.presenter.presentCompletion(issueCount: 2)
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            IssueExtractionStatusPresenter.manualCompletionStatus(issueCount: 2)
+        )
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.transcriptWindowOpenCount(), 1)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 0)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testManualIssueExtractionPresenterPresentsPreflightFailure() {
+        let harness = makeManualIssueExtractionPresenter()
+        let expectedError = AppError.missingAPIKey
+
+        harness.presenter.presentPreflightFailure(expectedError, sessionID: UUID())
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.transcriptWindowOpenCount(), 0)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 1)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "post_transcription")
+    }
+
+    func testManualIssueExtractionPresenterNormalizesExtractionFailure() {
+        let harness = makeManualIssueExtractionPresenter(status: .transcribing("Running extraction."))
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Extraction timed out"]
+        )
+        let expectedError = AppError.issueExtractionFailure("Extraction timed out")
+
+        harness.presenter.presentFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.transcriptWindowOpenCount(), 0)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 0)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "post_transcription")
+    }
+
     func testPreflightMapsCredentialTranscriptAndRecordingFailures() throws {
         let harness = try IssueExtractionControllerHarness()
         defer { harness.cleanup() }
@@ -137,6 +197,41 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(
             harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.map(\.isSelectedForExport),
             [false, false]
+        )
+    }
+
+    private func makeManualIssueExtractionPresenter(
+        status: AppStatus = .idle()
+    ) -> (
+        presenter: ManualIssueExtractionStatusPresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder,
+        transcriptWindowOpenCount: () -> Int,
+        settingsWindowOpenCount: () -> Int
+    ) {
+        let presentationState = AppPresentationState(status: status)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        var transcriptWindowOpenCount = 0
+        var settingsWindowOpenCount = 0
+        let presenter = ManualIssueExtractionStatusPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            ),
+            showTranscriptWindow: {
+                transcriptWindowOpenCount += 1
+            },
+            showSettingsWindow: {
+                settingsWindowOpenCount += 1
+            }
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder,
+            transcriptWindowOpenCount: { transcriptWindowOpenCount },
+            settingsWindowOpenCount: { settingsWindowOpenCount }
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add `ManualIssueExtractionStatusPresenter` for manual extraction progress, completion, preflight failure, and extraction failure presentation.
- Have `AppState.extractIssuesForDisplayedTranscript()` delegate status/error/window presentation while keeping extraction orchestration in place.
- Preserve Settings opening for missing API key failures and add focused presenter coverage.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExtractionControllerTests`
- `./scripts/validate.sh origin/main`

Closes #201