### PR TITLE
Move issue export presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -27,6 +27,7 @@ final class AppState: ObservableObject {
     let issueExtractionController: IssueExtractionController
     let manualIssueExtractionStatusPresenter: ManualIssueExtractionStatusPresenter
     let issueExportController: IssueExportController
+    let issueExportPresentationController: IssueExportPresentationController
     let permissionRecoveryController: PermissionRecoveryController
     let appUtilityActions: AppUtilityActionController
     let appUtilityActionPresenter: AppUtilityActionResultPresenter
@@ -312,6 +313,10 @@ final class AppState: ObservableObject {
         self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
+        self.issueExportPresentationController = IssueExportPresentationController(
+            errorPresenter: self.errorPresenter,
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
         self.transcriptPersistenceFailurePresenter = TranscriptPersistenceFailurePresenter(
@@ -1069,14 +1074,11 @@ final class AppState: ObservableObject {
         case .success(let readyContext):
             context = readyContext
         case .failure(let failure):
-            presentError(failure.error, operation: .export, fallback: { .exportFailure($0) })
-            if failure.opensSettings {
-                showSettingsWindow?()
-            }
+            issueExportPresentationController.presentPreflightFailure(failure)
             return
         }
 
-        setStatus(IssueExportStatusPresenter.reviewPreparationStatus(destination: destination))
+        issueExportPresentationController.presentReviewPreparation(destination: destination)
         recordingSessionController.beginActivity(reason: "Reviewing similar issues before export")
 
         do {
@@ -1088,13 +1090,13 @@ final class AppState: ObservableObject {
             recordingSessionController.endActivity()
 
             if review.hasMatches {
-                setStatus(IssueExportStatusPresenter.reviewReadyStatus(destination: destination))
+                issueExportPresentationController.presentReviewReady(destination: destination)
             } else {
                 await finalizeIssueExport(using: review)
             }
         } catch {
             recordingSessionController.endActivity()
-            presentError(error, operation: .export, fallback: { .exportFailure($0) })
+            issueExportPresentationController.presentFailure(error)
         }
     }
 
@@ -1122,7 +1124,7 @@ final class AppState: ObservableObject {
         do {
             let requiresRemoteExport = try issueExportController.pendingReviewRequiresRemoteExport(review)
             if requiresRemoteExport {
-                setStatus(IssueExportStatusPresenter.remoteExportStatus(destination: review.destination))
+                issueExportPresentationController.presentRemoteExportStarted(destination: review.destination)
                 recordingSessionController.beginActivity(reason: "Exporting extracted issues")
             }
 
@@ -1131,11 +1133,11 @@ final class AppState: ObservableObject {
                 recordingSessionController.endActivity()
             }
 
-            setStatus(IssueExportStatusPresenter.completionStatus(completion))
+            issueExportPresentationController.presentCompletion(completion)
             await refreshExportHistory()
         } catch {
             recordingSessionController.endActivity()
-            presentError(error, operation: .export, fallback: { .exportFailure($0) })
+            issueExportPresentationController.presentFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/IssueExportController.swift
+++ b/Sources/BugNarrator/Services/IssueExportController.swift
@@ -20,6 +20,56 @@ enum IssueExportStatusPresenter {
 }
 
 @MainActor
+final class IssueExportPresentationController {
+    private let errorPresenter: AppErrorPresenter
+    private let showSettingsWindow: () -> Void
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showSettingsWindow: @escaping () -> Void
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showSettingsWindow = showSettingsWindow
+    }
+
+    func presentPreflightFailure(_ failure: IssueExportPreflightFailure) {
+        let result = presentExportError(failure.error)
+        if failure.opensSettings || result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
+    }
+
+    func presentReviewPreparation(destination: ExportDestination) {
+        errorPresenter.setStatus(IssueExportStatusPresenter.reviewPreparationStatus(destination: destination))
+    }
+
+    func presentReviewReady(destination: ExportDestination) {
+        errorPresenter.setStatus(IssueExportStatusPresenter.reviewReadyStatus(destination: destination))
+    }
+
+    func presentRemoteExportStarted(destination: ExportDestination) {
+        errorPresenter.setStatus(IssueExportStatusPresenter.remoteExportStatus(destination: destination))
+    }
+
+    func presentCompletion(_ completion: IssueExportCompletion) {
+        errorPresenter.setStatus(IssueExportStatusPresenter.completionStatus(completion))
+    }
+
+    @discardableResult
+    func presentFailure(_ error: Error) -> AppErrorPresentationResult {
+        let result = presentExportError(error)
+        if result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
+        return result
+    }
+
+    private func presentExportError(_ error: Error) -> AppErrorPresentationResult {
+        errorPresenter.presentError(error, operation: .export, fallback: { .exportFailure($0) })
+    }
+}
+
+@MainActor
 final class IssueExportController: ObservableObject {
     @Published private(set) var exportDestinationInProgress: ExportDestination?
     @Published private(set) var pendingExportReview: IssueExportReview?

--- a/Tests/BugNarratorTests/IssueExportControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExportControllerTests.swift
@@ -30,6 +30,84 @@ final class IssueExportControllerTests: XCTestCase {
         )
     }
 
+    func testIssueExportPresentationControllerSetsExportStatuses() {
+        let harness = makeIssueExportPresentationController()
+        let completion = IssueExportCompletion(
+            destination: .github,
+            sessionID: UUID(),
+            results: [],
+            duplicateCount: 1,
+            performedRemoteExport: false
+        )
+
+        harness.presenter.presentReviewPreparation(destination: .github)
+        XCTAssertEqual(
+            harness.presentationState.status,
+            IssueExportStatusPresenter.reviewPreparationStatus(destination: .github)
+        )
+
+        harness.presenter.presentReviewReady(destination: .jira)
+        XCTAssertEqual(
+            harness.presentationState.status,
+            IssueExportStatusPresenter.reviewReadyStatus(destination: .jira)
+        )
+
+        harness.presenter.presentRemoteExportStarted(destination: .github)
+        XCTAssertEqual(
+            harness.presentationState.status,
+            IssueExportStatusPresenter.remoteExportStatus(destination: .github)
+        )
+
+        harness.presenter.presentCompletion(completion)
+        XCTAssertEqual(harness.presentationState.status, IssueExportStatusPresenter.completionStatus(completion))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 0)
+    }
+
+    func testIssueExportPresentationControllerOpensSettingsForConfigurationFailure() {
+        let harness = makeIssueExportPresentationController()
+        let expectedError = AppError.exportConfigurationMissing("GitHub token is missing.")
+        let failure = IssueExportPreflightFailure(error: expectedError, opensSettings: true)
+
+        harness.presenter.presentPreflightFailure(failure)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 1)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "export")
+    }
+
+    func testIssueExportPresentationControllerOpensSettingsForMissingAPIKeyFailure() {
+        let harness = makeIssueExportPresentationController()
+        let expectedError = AppError.missingAPIKey
+        let failure = IssueExportPreflightFailure(error: expectedError, opensSettings: false)
+
+        harness.presenter.presentPreflightFailure(failure)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 1)
+    }
+
+    func testIssueExportPresentationControllerNormalizesGenericExportFailure() {
+        let harness = makeIssueExportPresentationController()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Remote export failed"]
+        )
+        let expectedError = AppError.exportFailure("Remote export failed")
+
+        harness.presenter.presentFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.settingsWindowOpenCount(), 0)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "export")
+    }
+
     func testReadinessAndDefaultGitHubRouting() throws {
         let harness = try IssueExportControllerHarness()
         defer { harness.cleanup() }
@@ -232,6 +310,35 @@ final class IssueExportControllerTests: XCTestCase {
         XCTAssertTrue(completion.performedRemoteExport)
         XCTAssertEqual(exportedIssues.count, 1)
         XCTAssertTrue(exportedIssues.first?.note?.contains("Related to #142") == true)
+    }
+
+    private func makeIssueExportPresentationController(
+        status: AppStatus = .idle()
+    ) -> (
+        presenter: IssueExportPresentationController,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder,
+        settingsWindowOpenCount: () -> Int
+    ) {
+        let presentationState = AppPresentationState(status: status)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        var settingsWindowOpenCount = 0
+        let presenter = IssueExportPresentationController(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            ),
+            showSettingsWindow: {
+                settingsWindowOpenCount += 1
+            }
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder,
+            settingsWindowOpenCount: { settingsWindowOpenCount }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `IssueExportPresentationController` for export status, error, and Settings-window presentation.
- Have `AppState` delegate issue export presentation while retaining export orchestration and activity lifecycle.
- Preserve Settings opening for export configuration and missing API key failures, with focused test coverage.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExportControllerTests`
- `./scripts/validate.sh origin/main`

Closes #203