### PR TITLE
Move session library save and delete presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -21,6 +21,7 @@ final class AppState: ObservableObject {
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
     let sessionLibrary: SessionLibraryController
+    let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
     let exportHistoryController: ExportHistoryController
     let recoveredRecordingImportController: RecoveredRecordingImportController
     private let recoveredRecordingLaunchImporter: RecoveredRecordingLaunchImportPresenter
@@ -275,6 +276,9 @@ final class AppState: ObservableObject {
             clipboardService: clipboardService
         )
         self.sessionLibrary = sessionLibrary
+        self.sessionLibraryStatusPresenter = SessionLibraryStatusPresenter(
+            errorPresenter: self.errorPresenter
+        )
         self.exportHistoryController = ExportHistoryController(exportService: exportService)
         let recoveredRecordingImportController = RecoveredRecordingImportController(
             transcriptStore: transcriptStore,
@@ -967,33 +971,25 @@ final class AppState: ObservableObject {
 
     func saveCurrentTranscriptToHistory() {
         do {
-            if let status = TranscriptSaveStatusPresenter.status(savedSession: try sessionLibrary.saveCurrentTranscriptToHistory()) {
-                setStatus(status)
-            }
+            sessionLibraryStatusPresenter.presentSavedSession(try sessionLibrary.saveCurrentTranscriptToHistory())
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            sessionLibraryStatusPresenter.presentFailure(error)
         }
     }
 
     func deleteDisplayedTranscript() {
         do {
-            let deletedCount = try sessionLibrary.deleteDisplayedTranscript()
-            if let status = SessionDeletionStatusPresenter.status(deletedCount: deletedCount) {
-                setStatus(status)
-            }
+            sessionLibraryStatusPresenter.presentDeletedCount(try sessionLibrary.deleteDisplayedTranscript())
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            sessionLibraryStatusPresenter.presentFailure(error)
         }
     }
 
     func deleteSessions(withIDs ids: Set<UUID>) {
         do {
-            let deletedCount = try sessionLibrary.deleteSessions(withIDs: ids)
-            if let status = SessionDeletionStatusPresenter.status(deletedCount: deletedCount) {
-                setStatus(status)
-            }
+            sessionLibraryStatusPresenter.presentDeletedCount(try sessionLibrary.deleteSessions(withIDs: ids))
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            sessionLibraryStatusPresenter.presentFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -41,6 +41,31 @@ enum SessionDeletionStatusPresenter {
 }
 
 @MainActor
+final class SessionLibraryStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+
+    init(errorPresenter: AppErrorPresenter) {
+        self.errorPresenter = errorPresenter
+    }
+
+    func presentSavedSession(_ savedSession: TranscriptSession?) {
+        if let status = TranscriptSaveStatusPresenter.status(savedSession: savedSession) {
+            errorPresenter.setStatus(status)
+        }
+    }
+
+    func presentDeletedCount(_ deletedCount: Int) {
+        if let status = SessionDeletionStatusPresenter.status(deletedCount: deletedCount) {
+            errorPresenter.setStatus(status)
+        }
+    }
+
+    func presentFailure(_ error: Error) {
+        _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+    }
+}
+
+@MainActor
 final class SessionLibraryController: ObservableObject {
     @Published var currentTranscript: TranscriptSession?
     @Published var selectedTranscriptID: UUID?

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -139,6 +139,63 @@ final class SessionLibraryControllerTests: XCTestCase {
         )
     }
 
+    func testSessionLibraryStatusPresenterSetsSavedTranscriptStatus() {
+        let harness = makeSessionLibraryStatusPresenter()
+
+        harness.presenter.presentSavedSession(makeSession(index: 1))
+
+        XCTAssertEqual(harness.presentationState.status, .success("Transcript saved to session history."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterLeavesStatusForNoSavedTranscript() {
+        let harness = makeSessionLibraryStatusPresenter(status: .idle("Ready."))
+
+        harness.presenter.presentSavedSession(nil)
+
+        XCTAssertEqual(harness.presentationState.status, .idle("Ready."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterSetsDeletionStatus() {
+        let harness = makeSessionLibraryStatusPresenter()
+
+        harness.presenter.presentDeletedCount(3)
+
+        XCTAssertEqual(harness.presentationState.status, .success("Deleted 3 sessions."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterLeavesStatusForNoDeletedSessions() {
+        let harness = makeSessionLibraryStatusPresenter(status: .idle("Ready."))
+
+        harness.presenter.presentDeletedCount(0)
+
+        XCTAssertEqual(harness.presentationState.status, .idle("Ready."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterNormalizesFailures() {
+        let harness = makeSessionLibraryStatusPresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Disk full"]
+        )
+        let expectedError = AppError.storageFailure("Disk full")
+
+        harness.presenter.presentFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
+    }
+
     func testPersistCompletedTranscriptCopiesWhenRequested() throws {
         let harness = try SessionLibraryControllerHarness()
         defer { harness.cleanup() }
@@ -225,6 +282,29 @@ final class SessionLibraryControllerTests: XCTestCase {
 
         XCTAssertEqual(result, .copied)
         XCTAssertEqual(harness.clipboardService.copiedStrings, ["Displayed transcript"])
+    }
+
+    private func makeSessionLibraryStatusPresenter(
+        status: AppStatus = .idle()
+    ) -> (
+        presenter: SessionLibraryStatusPresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder
+    ) {
+        let presentationState = AppPresentationState(status: status)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let presenter = SessionLibraryStatusPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            )
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
     }
 
     private func makeSession(


### PR DESCRIPTION
## Summary
- add SessionLibraryStatusPresenter for save/delete status and storage failure presentation
- route AppState session library save/delete methods through the presenter
- cover saved, no-op, deletion, and failure presentation behavior in SessionLibraryControllerTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #205