### PR TITLE
Move displayed transcript copy presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -882,10 +882,7 @@ final class AppState: ObservableObject {
     }
 
     func copyDisplayedTranscript() {
-        let result = sessionLibrary.copyDisplayedTranscript()
-        if let status = DisplayedTranscriptCopyStatusPresenter.status(for: result) {
-            setStatus(status)
-        }
+        sessionLibraryStatusPresenter.presentDisplayedTranscriptCopyResult(sessionLibrary.copyDisplayedTranscript())
     }
 
     func retryPendingTranscription(for sessionID: UUID) async {

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -48,6 +48,12 @@ final class SessionLibraryStatusPresenter {
         self.errorPresenter = errorPresenter
     }
 
+    func presentDisplayedTranscriptCopyResult(_ result: DisplayedTranscriptCopyResult) {
+        if let status = DisplayedTranscriptCopyStatusPresenter.status(for: result) {
+            errorPresenter.setStatus(status)
+        }
+    }
+
     func presentSavedSession(_ savedSession: TranscriptSession?) {
         if let status = TranscriptSaveStatusPresenter.status(savedSession: savedSession) {
             errorPresenter.setStatus(status)

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -139,6 +139,39 @@ final class SessionLibraryControllerTests: XCTestCase {
         )
     }
 
+    func testSessionLibraryStatusPresenterSetsCopiedTranscriptStatus() {
+        let harness = makeSessionLibraryStatusPresenter()
+
+        harness.presenter.presentDisplayedTranscriptCopyResult(.copied)
+
+        XCTAssertEqual(harness.presentationState.status, .success("Transcript copied to the clipboard."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterSetsUnavailableTranscriptStatus() {
+        let harness = makeSessionLibraryStatusPresenter()
+
+        harness.presenter.presentDisplayedTranscriptCopyResult(.transcriptUnavailable)
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Transcription is not available yet. Retry the preserved session first.")
+        )
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testSessionLibraryStatusPresenterLeavesStatusForMissingDisplayedTranscript() {
+        let harness = makeSessionLibraryStatusPresenter(status: .idle("Ready."))
+
+        harness.presenter.presentDisplayedTranscriptCopyResult(.noDisplayedTranscript)
+
+        XCTAssertEqual(harness.presentationState.status, .idle("Ready."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
     func testSessionLibraryStatusPresenterSetsSavedTranscriptStatus() {
         let harness = makeSessionLibraryStatusPresenter()
 


### PR DESCRIPTION
## Summary
- add SessionLibraryStatusPresenter coverage for displayed transcript copy results
- delegate AppState.copyDisplayedTranscript status updates through the session-library presenter
- cover copied, unavailable, and no-displayed-transcript presentation paths

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

Closes #207