### PR TITLE
Move issue mutation failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -27,6 +27,7 @@ final class AppState: ObservableObject {
     private let recoveredRecordingLaunchImporter: RecoveredRecordingLaunchImportPresenter
     let issueExtractionController: IssueExtractionController
     let manualIssueExtractionStatusPresenter: ManualIssueExtractionStatusPresenter
+    let issueMutationFailurePresenter: IssueMutationFailurePresenter
     let issueExportController: IssueExportController
     let issueExportPresentationController: IssueExportPresentationController
     let permissionRecoveryController: PermissionRecoveryController
@@ -318,6 +319,9 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
+        self.issueMutationFailurePresenter = IssueMutationFailurePresenter(
+            errorPresenter: self.errorPresenter
         )
         self.issueExportPresentationController = IssueExportPresentationController(
             errorPresenter: self.errorPresenter,
@@ -1037,7 +1041,7 @@ final class AppState: ObservableObject {
         do {
             try issueExtractionController.updateExtractedIssue(updatedIssue, in: sessionID)
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            issueMutationFailurePresenter.presentFailure(error)
         }
     }
 
@@ -1045,7 +1049,7 @@ final class AppState: ObservableObject {
         do {
             try issueExtractionController.setIssueSelection(isSelected, issueID: issueID, in: sessionID)
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            issueMutationFailurePresenter.presentFailure(error)
         }
     }
 
@@ -1053,7 +1057,7 @@ final class AppState: ObservableObject {
         do {
             try issueExtractionController.setAllIssuesSelected(isSelected, in: sessionID)
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            issueMutationFailurePresenter.presentFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -69,6 +69,19 @@ final class ManualIssueExtractionStatusPresenter {
 }
 
 @MainActor
+final class IssueMutationFailurePresenter {
+    private let errorPresenter: AppErrorPresenter
+
+    init(errorPresenter: AppErrorPresenter) {
+        self.errorPresenter = errorPresenter
+    }
+
+    func presentFailure(_ error: Error) {
+        _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+    }
+}
+
+@MainActor
 final class IssueExtractionController: ObservableObject {
     @Published private(set) var issueExtractionSessionID: UUID?
 

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -74,6 +74,23 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "post_transcription")
     }
 
+    func testIssueMutationFailurePresenterNormalizesStorageFailure() {
+        let harness = makeIssueMutationFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not save issue"]
+        )
+        let expectedError = AppError.storageFailure("Could not save issue")
+
+        harness.presenter.presentFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
+    }
+
     func testPreflightMapsCredentialTranscriptAndRecordingFailures() throws {
         let harness = try IssueExtractionControllerHarness()
         defer { harness.cleanup() }
@@ -197,6 +214,29 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(
             harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.map(\.isSelectedForExport),
             [false, false]
+        )
+    }
+
+    private func makeIssueMutationFailurePresenter(
+        status: AppStatus = .idle()
+    ) -> (
+        presenter: IssueMutationFailurePresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder
+    ) {
+        let presentationState = AppPresentationState(status: status)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let presenter = IssueMutationFailurePresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            )
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
         )
     }
 


### PR DESCRIPTION
## Summary
- add IssueMutationFailurePresenter for issue edit/selection storage failure presentation
- delegate AppState issue mutation catch blocks through the presenter
- cover storage failure normalization and session_library telemetry in IssueExtractionControllerTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/IssueExtractionControllerTests
- ./scripts/validate.sh origin/main

Closes #209