### PR TITLE
Move local data deletion failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -350,6 +350,7 @@ final class AppState: ObservableObject {
         self.appUtilityActionPresenter = appUtilityActionPresenter
         self.supportDataActionPresenter = SupportDataActionPresenter(
             presentationState: presentationState,
+            errorPresenter: self.errorPresenter,
             utilityActions: appUtilityActions,
             utilityResultPresenter: appUtilityActionPresenter
         )
@@ -845,7 +846,7 @@ final class AppState: ObservableObject {
             )
             supportDataActionPresenter.presentLocalDataDeletion(result)
         } catch {
-            presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            supportDataActionPresenter.presentLocalDataDeletionFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -20,19 +20,23 @@ final class SupportDataActionPresenter {
     private let setStatus: (AppStatus) -> Void
     private let revealInFinder: (URL) -> AppUtilityActionResult
     private let presentUtilityActionResult: (AppUtilityActionResult) -> Void
+    private let presentDeletionFailure: (Error) -> Void
 
     init(
         setStatus: @escaping (AppStatus) -> Void,
         revealInFinder: @escaping (URL) -> AppUtilityActionResult,
-        presentUtilityActionResult: @escaping (AppUtilityActionResult) -> Void
+        presentUtilityActionResult: @escaping (AppUtilityActionResult) -> Void,
+        presentDeletionFailure: @escaping (Error) -> Void = { _ in }
     ) {
         self.setStatus = setStatus
         self.revealInFinder = revealInFinder
         self.presentUtilityActionResult = presentUtilityActionResult
+        self.presentDeletionFailure = presentDeletionFailure
     }
 
     convenience init(
         presentationState: AppPresentationState,
+        errorPresenter: AppErrorPresenter,
         utilityActions: AppUtilityActionController,
         utilityResultPresenter: AppUtilityActionResultPresenter
     ) {
@@ -45,6 +49,9 @@ final class SupportDataActionPresenter {
             },
             presentUtilityActionResult: { result in
                 utilityResultPresenter.present(result)
+            },
+            presentDeletionFailure: { error in
+                _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
             }
         )
     }
@@ -72,6 +79,10 @@ final class SupportDataActionPresenter {
         case .deleted(let outcome):
             presentLocalDataDeletion(outcome)
         }
+    }
+
+    func presentLocalDataDeletionFailure(_ error: Error) {
+        presentDeletionFailure(error)
     }
 
     private func presentExportedBundle(at bundleURL: URL, statusMessage: String) {

--- a/Tests/BugNarratorTests/SupportDataControllerTests.swift
+++ b/Tests/BugNarratorTests/SupportDataControllerTests.swift
@@ -156,6 +156,36 @@ final class SupportDataControllerTests: XCTestCase {
         XCTAssertEqual(revealedURLs, [debugBundleURL, privacyBundleURL])
         XCTAssertEqual(presentedUtilityResults, [.opened, .opened])
     }
+
+    func testActionPresenterNormalizesLocalDataDeletionFailure() {
+        let presentationState = AppPresentationState()
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
+        )
+        let presenter = SupportDataActionPresenter(
+            setStatus: { status in presentationState.setStatus(status, error: nil) },
+            revealInFinder: { _ in .opened },
+            presentUtilityActionResult: { _ in },
+            presentDeletionFailure: { error in
+                _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            }
+        )
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not clear local data"]
+        )
+        let expectedError = AppError.storageFailure("Could not clear local data")
+
+        presenter.presentLocalDataDeletionFailure(error)
+
+        XCTAssertEqual(presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(presentationState.currentError, expectedError)
+        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- extend SupportDataActionPresenter with local data deletion failure presentation
- route AppState.deleteAllLocalData failures through the support-data presenter
- cover storage failure normalization and session_library telemetry in SupportDataControllerTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SupportDataControllerTests -only-testing:BugNarratorTests/LocalDataDeletionControllerTests
- ./scripts/validate.sh origin/main

Closes #211