### PR TITLE
Move support data export failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -812,11 +812,7 @@ final class AppState: ObservableObject {
 
             supportDataActionPresenter.presentDebugBundleExport(completion)
         } catch {
-            presentError(
-                error,
-                operation: .diagnosticsExport,
-                fallback: { _ in .diagnosticsFailure("BugNarrator could not create the debug bundle.") }
-            )
+            supportDataActionPresenter.presentDebugBundleExportFailure(error)
         }
     }
 
@@ -830,11 +826,7 @@ final class AppState: ObservableObject {
 
             supportDataActionPresenter.presentPrivacyDataExport(completion)
         } catch {
-            presentError(
-                error,
-                operation: .privacyExport,
-                fallback: { _ in .exportFailure("BugNarrator could not create the data export.") }
-            )
+            supportDataActionPresenter.presentPrivacyDataExportFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -15,23 +15,51 @@ struct PrivacyDataExportCompletion {
     let statusMessage: String
 }
 
+enum SupportDataActionFailure {
+    case debugBundleExport
+    case privacyDataExport
+    case localDataDeletion
+
+    var operation: AppErrorOperation {
+        switch self {
+        case .debugBundleExport:
+            return .diagnosticsExport
+        case .privacyDataExport:
+            return .privacyExport
+        case .localDataDeletion:
+            return .sessionLibrary
+        }
+    }
+
+    var fallback: (String) -> AppError {
+        switch self {
+        case .debugBundleExport:
+            return { _ in .diagnosticsFailure("BugNarrator could not create the debug bundle.") }
+        case .privacyDataExport:
+            return { _ in .exportFailure("BugNarrator could not create the data export.") }
+        case .localDataDeletion:
+            return { .storageFailure($0) }
+        }
+    }
+}
+
 @MainActor
 final class SupportDataActionPresenter {
     private let setStatus: (AppStatus) -> Void
     private let revealInFinder: (URL) -> AppUtilityActionResult
     private let presentUtilityActionResult: (AppUtilityActionResult) -> Void
-    private let presentDeletionFailure: (Error) -> Void
+    private let presentFailure: (Error, SupportDataActionFailure) -> Void
 
     init(
         setStatus: @escaping (AppStatus) -> Void,
         revealInFinder: @escaping (URL) -> AppUtilityActionResult,
         presentUtilityActionResult: @escaping (AppUtilityActionResult) -> Void,
-        presentDeletionFailure: @escaping (Error) -> Void = { _ in }
+        presentFailure: @escaping (Error, SupportDataActionFailure) -> Void = { _, _ in }
     ) {
         self.setStatus = setStatus
         self.revealInFinder = revealInFinder
         self.presentUtilityActionResult = presentUtilityActionResult
-        self.presentDeletionFailure = presentDeletionFailure
+        self.presentFailure = presentFailure
     }
 
     convenience init(
@@ -50,8 +78,8 @@ final class SupportDataActionPresenter {
             presentUtilityActionResult: { result in
                 utilityResultPresenter.present(result)
             },
-            presentDeletionFailure: { error in
-                _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            presentFailure: { error, failure in
+                _ = errorPresenter.presentError(error, operation: failure.operation, fallback: failure.fallback)
             }
         )
     }
@@ -68,6 +96,14 @@ final class SupportDataActionPresenter {
         presentExportedBundle(at: completion.bundleURL, statusMessage: completion.statusMessage)
     }
 
+    func presentDebugBundleExportFailure(_ error: Error) {
+        presentFailure(error, .debugBundleExport)
+    }
+
+    func presentPrivacyDataExportFailure(_ error: Error) {
+        presentFailure(error, .privacyDataExport)
+    }
+
     func presentLocalDataDeletion(_ outcome: LocalDataDeletionOutcome) {
         presentSuccess(outcome.statusMessage)
     }
@@ -82,7 +118,7 @@ final class SupportDataActionPresenter {
     }
 
     func presentLocalDataDeletionFailure(_ error: Error) {
-        presentDeletionFailure(error)
+        presentFailure(error, .localDataDeletion)
     }
 
     private func presentExportedBundle(at bundleURL: URL, statusMessage: String) {

--- a/Tests/BugNarratorTests/SupportDataControllerTests.swift
+++ b/Tests/BugNarratorTests/SupportDataControllerTests.swift
@@ -158,6 +158,61 @@ final class SupportDataControllerTests: XCTestCase {
     }
 
     func testActionPresenterNormalizesLocalDataDeletionFailure() {
+        let harness = makeSupportDataActionFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not clear local data"]
+        )
+        let expectedError = AppError.storageFailure("Could not clear local data")
+
+        harness.presenter.presentLocalDataDeletionFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
+    }
+
+    func testActionPresenterNormalizesDebugBundleExportFailure() {
+        let harness = makeSupportDataActionFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Archive failed"]
+        )
+        let expectedError = AppError.diagnosticsFailure("BugNarrator could not create the debug bundle.")
+
+        harness.presenter.presentDebugBundleExportFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "diagnostics_export")
+    }
+
+    func testActionPresenterNormalizesPrivacyDataExportFailure() {
+        let harness = makeSupportDataActionFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Archive failed"]
+        )
+        let expectedError = AppError.exportFailure("BugNarrator could not create the data export.")
+
+        harness.presenter.presentPrivacyDataExportFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "privacy_export")
+    }
+
+    private func makeSupportDataActionFailurePresenter() -> (
+        presenter: SupportDataActionPresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder
+    ) {
         let presentationState = AppPresentationState()
         let telemetryRecorder = MockOperationalTelemetryRecorder()
         let errorPresenter = AppErrorPresenter(
@@ -168,23 +223,16 @@ final class SupportDataControllerTests: XCTestCase {
             setStatus: { status in presentationState.setStatus(status, error: nil) },
             revealInFinder: { _ in .opened },
             presentUtilityActionResult: { _ in },
-            presentDeletionFailure: { error in
-                _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+            presentFailure: { error, failure in
+                _ = errorPresenter.presentError(error, operation: failure.operation, fallback: failure.fallback)
             }
         )
-        let error = NSError(
-            domain: "BugNarratorTests",
-            code: 1,
-            userInfo: [NSLocalizedDescriptionKey: "Could not clear local data"]
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
         )
-        let expectedError = AppError.storageFailure("Could not clear local data")
-
-        presenter.presentLocalDataDeletionFailure(error)
-
-        XCTAssertEqual(presentationState.status, .error(expectedError.userMessage))
-        XCTAssertEqual(presentationState.currentError, expectedError)
-        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.name, "app_error")
-        XCTAssertEqual(telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
     }
 }
 


### PR DESCRIPTION
## Summary
- add SupportDataActionFailure to centralize support-data failure operations and fallbacks
- route debug bundle and privacy data export failures through SupportDataActionPresenter
- keep local data deletion failure on the same presenter path and add focused tests for all three failures

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/SupportDataControllerTests
- ./scripts/validate.sh origin/main

Closes #213