### PR TITLE
Move permission recovery status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -31,6 +31,7 @@ final class AppState: ObservableObject {
     let issueExportController: IssueExportController
     let issueExportPresentationController: IssueExportPresentationController
     let permissionRecoveryController: PermissionRecoveryController
+    let permissionRecoveryStatusPresenter: PermissionRecoveryStatusPresenter
     let appUtilityActions: AppUtilityActionController
     let appUtilityActionPresenter: AppUtilityActionResultPresenter
     let applicationTerminationController: ApplicationTerminationController
@@ -306,6 +307,9 @@ final class AppState: ObservableObject {
             runtimeEnvironment: runtimeEnvironment
         )
         self.permissionRecoveryController = permissionRecoveryController
+        self.permissionRecoveryStatusPresenter = PermissionRecoveryStatusPresenter(
+            errorPresenter: self.errorPresenter
+        )
         self.launchDiagnosticsReporter = AppLaunchDiagnosticsReporter(
             permissionRecoveryController: permissionRecoveryController,
             transcriptStore: transcriptStore
@@ -604,15 +608,12 @@ final class AppState: ObservableObject {
     }
 
     func refreshPermissionRecoveryState() {
-        switch permissionRecoveryController.refreshRecoveryState(
-            currentError: currentError,
-            statusPhase: status.phase
-        ) {
-        case .unchanged:
-            break
-        case .recovered(let recoveredStatus):
-            setStatus(recoveredStatus)
-        }
+        permissionRecoveryStatusPresenter.present(
+            permissionRecoveryController.refreshRecoveryState(
+                currentError: currentError,
+                statusPhase: status.phase
+            )
+        )
     }
 
     func canExportIssues(from session: TranscriptSession, to destination: ExportDestination) -> Bool {

--- a/Sources/BugNarrator/Services/PermissionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/PermissionRecoveryController.swift
@@ -11,6 +11,23 @@ enum PermissionSettingsOpenResult: Equatable {
 }
 
 @MainActor
+final class PermissionRecoveryStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+
+    init(errorPresenter: AppErrorPresenter) {
+        self.errorPresenter = errorPresenter
+    }
+
+    func present(_ outcome: PermissionRecoveryRefreshOutcome) {
+        guard case .recovered(let status) = outcome else {
+            return
+        }
+
+        errorPresenter.setStatus(status)
+    }
+}
+
+@MainActor
 final class PermissionRecoveryController {
     private let microphonePermissionService: any MicrophonePermissionServicing
     private let screenCapturePermissionService: any ScreenCapturePermissionServicing

--- a/Tests/BugNarratorTests/PermissionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/PermissionRecoveryControllerTests.swift
@@ -3,6 +3,29 @@ import XCTest
 
 @MainActor
 final class PermissionRecoveryControllerTests: XCTestCase {
+    func testStatusPresenterAppliesRecoveredStatus() {
+        let harness = makeStatusPresenter(currentError: .microphonePermissionDenied)
+
+        harness.presenter.present(.recovered(.idle("Microphone access enabled. You can start recording again.")))
+
+        XCTAssertEqual(harness.presentationState.status, .idle("Microphone access enabled. You can start recording again."))
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testStatusPresenterLeavesUnchangedOutcomeUntouched() {
+        let harness = makeStatusPresenter(
+            status: .error("Microphone access is still blocked."),
+            currentError: .microphonePermissionDenied
+        )
+
+        harness.presenter.present(.unchanged)
+
+        XCTAssertEqual(harness.presentationState.status, .error("Microphone access is still blocked."))
+        XCTAssertEqual(harness.presentationState.currentError, .microphonePermissionDenied)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
     func testRefreshRecoversMicrophoneDeniedStateWhenAccessIsGranted() {
         let harness = PermissionRecoveryControllerHarness(microphonePermissionState: .authorized)
 
@@ -105,6 +128,30 @@ final class PermissionRecoveryControllerTests: XCTestCase {
                 BugNarratorLinks.securityPrivacySettings,
                 BugNarratorLinks.systemSettingsApp
             ]
+        )
+    }
+
+    private func makeStatusPresenter(
+        status: AppStatus = .idle(),
+        currentError: AppError? = nil
+    ) -> (
+        presenter: PermissionRecoveryStatusPresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder
+    ) {
+        let presentationState = AppPresentationState(status: status, currentError: currentError)
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        let presenter = PermissionRecoveryStatusPresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            )
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder
         )
     }
 }


### PR DESCRIPTION
## Summary
- add PermissionRecoveryStatusPresenter for recovered permission statuses
- delegate AppState.refreshPermissionRecoveryState outcome presentation
- cover recovered and unchanged presenter behavior in PermissionRecoveryControllerTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/PermissionRecoveryControllerTests
- ./scripts/validate.sh origin/main

Closes #215