### PR TITLE
Move retry transcription progress and failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -910,7 +910,9 @@ final class AppState: ObservableObject {
 
         let request = settingsStore.transcriptionRequest
         sessionLibrary.stageCurrentTranscript(retryContext.session)
-        setStatus(.transcribing(recordingStatusMessages.transcriptionRetryProgressMessage()))
+        retryTranscriptionStatusPresenter.presentRetryStarted(
+            progressMessage: recordingStatusMessages.transcriptionRetryProgressMessage()
+        )
         recordingSessionController.swapActivity(reason: "Retrying transcription from preserved audio")
         logPendingTranscriptionRetryRequested(retryContext)
 
@@ -944,7 +946,7 @@ final class AppState: ObservableObject {
                 finishSuccessfulTranscription(showTranscriptWindow: true)
             case .persistenceFailure(_, let error):
                 transcriptionRecovery.finishRetry()
-                presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+                sessionLibraryStatusPresenter.presentFailure(error)
             case .postTranscriptionFailure(let error):
                 transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
                     at: retryContext.audioFileURL,
@@ -960,7 +962,7 @@ final class AppState: ObservableObject {
             }
 
             transcriptionRecovery.finishRetry()
-            presentError(error, operation: .retryTranscription)
+            retryTranscriptionStatusPresenter.presentFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -17,6 +17,10 @@ final class RetryTranscriptionStatusPresenter {
         self.showTranscriptWindow = showTranscriptWindow
     }
 
+    func presentRetryStarted(progressMessage: String) {
+        errorPresenter.setStatus(.transcribing(progressMessage))
+    }
+
     func presentRetryContextFailure(
         appError: AppError,
         opensSettings: Bool,
@@ -45,6 +49,13 @@ final class RetryTranscriptionStatusPresenter {
         errorPresenter.setStatus(.error(failure.statusMessage), error: failure.appError)
         showTranscriptWindow()
         showSettingsWindow()
+    }
+
+    func presentFailure(_ error: Error) {
+        let result = errorPresenter.presentError(error, operation: .retryTranscription)
+        if result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
     }
 }
 

--- a/Tests/BugNarratorTests/RetryTranscriptionStatusPresenterTests.swift
+++ b/Tests/BugNarratorTests/RetryTranscriptionStatusPresenterTests.swift
@@ -3,6 +3,21 @@ import XCTest
 
 @MainActor
 final class RetryTranscriptionStatusPresenterTests: XCTestCase {
+    func testPresentRetryStartedSetsProgressStatus() {
+        let harness = RetryTranscriptionStatusPresenterHarness()
+
+        harness.presenter.presentRetryStarted(progressMessage: "Retrying transcription from preserved audio...")
+
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .transcribing("Retrying transcription from preserved audio...")
+        )
+        XCTAssertNil(harness.presentationState.currentError)
+        XCTAssertEqual(harness.showSettingsCallCount, 0)
+        XCTAssertEqual(harness.showTranscriptCallCount, 0)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
     func testPresentRetryContextFailureUsesRecoveryStatusAndOpensSettings() {
         let harness = RetryTranscriptionStatusPresenterHarness()
 
@@ -77,6 +92,22 @@ final class RetryTranscriptionStatusPresenterTests: XCTestCase {
         XCTAssertEqual(telemetry.metadata["context"], "retry_pending_transcription")
         XCTAssertEqual(telemetry.metadata["operation"], "retry_transcription")
         XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
+    }
+
+    func testPresentFailureDelegatesToErrorPresenterAndOpensSettingsWhenNeeded() throws {
+        let harness = RetryTranscriptionStatusPresenterHarness()
+
+        harness.presenter.presentFailure(AppError.missingAPIKey)
+
+        XCTAssertEqual(harness.presentationState.status, .error(AppError.missingAPIKey.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, .missingAPIKey)
+        XCTAssertEqual(harness.showSettingsCallCount, 1)
+        XCTAssertEqual(harness.showTranscriptCallCount, 0)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "retry_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "missing_api_key")
     }
 }
 


### PR DESCRIPTION
## Summary
- add retry progress and final failure presentation methods to RetryTranscriptionStatusPresenter
- delegate AppState retry progress, retry storage failure, and terminal retry failure presentation
- cover retry progress and settings-opening failure behavior in RetryTranscriptionStatusPresenterTests

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RetryTranscriptionStatusPresenterTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests
- ./scripts/validate.sh origin/main

Closes #217