### PR TITLE
Move stop session failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -18,6 +18,7 @@ final class AppState: ObservableObject {
     let recordingSessionController: RecordingSessionController
     let recordingSessionStartStatusPresenter: RecordingSessionStartStatusPresenter
     let recordingSessionStopReadinessPresenter: RecordingSessionStopReadinessPresenter
+    let recordingSessionStopFailurePresenter: RecordingSessionStopFailurePresenter
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
     let sessionLibrary: SessionLibraryController
@@ -319,6 +320,10 @@ final class AppState: ObservableObject {
             permissionRecoveryController: permissionRecoveryController
         )
         self.appUtilityActions = appUtilityActions
+        self.recordingSessionStopFailurePresenter = RecordingSessionStopFailurePresenter(
+            errorPresenter: self.errorPresenter,
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
         self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
@@ -1147,17 +1152,21 @@ final class AppState: ObservableObject {
         operation: AppErrorOperation = .generic,
         fallback: (String) -> AppError = { .transcriptionFailure($0) }
     ) {
-        recordingSessionController.stopTimer(resetElapsed: status.phase == .recording)
-        recordingSessionController.endActivity()
-        cleanupPendingRecordedAudioIfNeeded()
-        issueExtractionController.clearProgress()
-        issueExportController.clearProgress()
+        prepareErrorPresentationSideEffects()
 
         let result = errorPresenter.presentError(error, operation: operation, fallback: fallback)
 
         if result.shouldOpenSettingsWindow {
             showSettingsWindow?()
         }
+    }
+
+    private func prepareErrorPresentationSideEffects() {
+        recordingSessionController.stopTimer(resetElapsed: status.phase == .recording)
+        recordingSessionController.endActivity()
+        cleanupPendingRecordedAudioIfNeeded()
+        issueExtractionController.clearProgress()
+        issueExportController.clearProgress()
     }
 
     private func presentPostTranscriptionError(
@@ -1356,10 +1365,12 @@ final class AppState: ObservableObject {
             artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
         }
         recordingSessionController.clearActiveRecordingSession()
-        if recordingSessionController.pendingRecordedAudioSnapshot == nil {
-            presentError(error, operation: .recordingStop, fallback: { .recordingFailure($0) })
+        let hasPendingRecordedAudio = recordingSessionController.pendingRecordedAudioSnapshot != nil
+        prepareErrorPresentationSideEffects()
+        if !hasPendingRecordedAudio {
+            recordingSessionStopFailurePresenter.presentRecordingStopFailure(error)
         } else {
-            presentError(error, operation: .transcription)
+            recordingSessionStopFailurePresenter.presentTranscriptionFailure(error)
         }
     }
 
@@ -1423,7 +1434,8 @@ final class AppState: ObservableObject {
                 artifactsService.removeArtifactsDirectory(at: recordingSession.artifactsDirectoryURL)
             }
             recordingSessionController.clearActiveRecordingSession()
-            presentError(error, operation: .recordingStop)
+            prepareErrorPresentationSideEffects()
+            recordingSessionStopFailurePresenter.presentPreservationFailure(error)
         }
     }
 

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -133,6 +133,43 @@ final class RecordingSessionStopReadinessPresenter {
 }
 
 @MainActor
+final class RecordingSessionStopFailurePresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showSettingsWindow: () -> Void
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showSettingsWindow: @escaping () -> Void
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showSettingsWindow = showSettingsWindow
+    }
+
+    func presentRecordingStopFailure(_ error: Error) {
+        present(error, operation: .recordingStop, fallback: { .recordingFailure($0) })
+    }
+
+    func presentTranscriptionFailure(_ error: Error) {
+        present(error, operation: .transcription)
+    }
+
+    func presentPreservationFailure(_ error: Error) {
+        present(error, operation: .recordingStop)
+    }
+
+    private func present(
+        _ error: Error,
+        operation: AppErrorOperation,
+        fallback: (String) -> AppError = { .transcriptionFailure($0) }
+    ) {
+        let result = errorPresenter.presentError(error, operation: operation, fallback: fallback)
+        if result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
+    }
+}
+
+@MainActor
 final class RecordingSessionController: ObservableObject {
     @Published private(set) var activeRecordingSession: RecordingSessionDraft?
 

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -229,6 +229,63 @@ final class RecordingSessionControllerTests: XCTestCase {
         XCTAssertEqual(telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_stop")
     }
 
+    func testStopFailurePresenterNormalizesRecordingStopFailure() {
+        let harness = makeStopFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Recorder stop failed"]
+        )
+        let expectedError = AppError.recordingFailure("Recorder stop failed")
+
+        harness.presenter.presentRecordingStopFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_stop")
+    }
+
+    func testStopFailurePresenterNormalizesTranscriptionFailure() {
+        let harness = makeStopFailurePresenter()
+        let error = NSError(
+            domain: "BugNarratorTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Upload failed"]
+        )
+        let expectedError = AppError.transcriptionFailure("Upload failed")
+
+        harness.presenter.presentTranscriptionFailure(error)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "transcription")
+    }
+
+    func testStopFailurePresenterPresentsPreservationFailure() {
+        let harness = makeStopFailurePresenter()
+        let expectedError = AppError.recordingFailure("Preserving the recording failed.")
+
+        harness.presenter.presentPreservationFailure(expectedError)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_stop")
+    }
+
+    func testStopFailurePresenterOpensSettingsForCredentialFailure() {
+        let harness = makeStopFailurePresenter()
+        let expectedError = AppError.missingAPIKey
+
+        harness.presenter.presentTranscriptionFailure(expectedError)
+
+        XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
+        XCTAssertEqual(harness.presentationState.currentError, expectedError)
+        XCTAssertEqual(harness.showSettingsCallCount(), 1)
+    }
+
     func testCancelSessionCancelsRecorderAndRemovesArtifacts() async throws {
         let harness = try RecordingSessionControllerHarness()
         defer { harness.cleanup() }
@@ -306,6 +363,33 @@ final class RecordingSessionControllerTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
         XCTAssertNil(harness.controller.pendingRecordedAudioSnapshot)
+    }
+
+    private func makeStopFailurePresenter() -> (
+        presenter: RecordingSessionStopFailurePresenter,
+        presentationState: AppPresentationState,
+        telemetryRecorder: MockOperationalTelemetryRecorder,
+        showSettingsCallCount: () -> Int
+    ) {
+        let presentationState = AppPresentationState(status: .recording("Recording in progress."))
+        let telemetryRecorder = MockOperationalTelemetryRecorder()
+        var showSettingsCallCount = 0
+        let presenter = RecordingSessionStopFailurePresenter(
+            errorPresenter: AppErrorPresenter(
+                presentationState: presentationState,
+                telemetryRecorder: telemetryRecorder
+            ),
+            showSettingsWindow: {
+                showSettingsCallCount += 1
+            }
+        )
+
+        return (
+            presenter: presenter,
+            presentationState: presentationState,
+            telemetryRecorder: telemetryRecorder,
+            showSettingsCallCount: { showSettingsCallCount }
+        )
     }
 
     private func makeStartStatusPresenter(


### PR DESCRIPTION
Summary
- Added RecordingSessionStopFailurePresenter for stop-recording, transcription, and preservation failure presentation.
- Kept AppState cleanup side effects before delegating failure UI presentation.
- Added presenter tests for recording stop, transcription, preservation, and settings-opening credential failures.

Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests\n- ./scripts/validate.sh origin/main\n\nCloses #219