### PR TITLE
Move post-transcription status presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -21,6 +21,7 @@ final class AppState: ObservableObject {
     let recordingSessionStopFailurePresenter: RecordingSessionStopFailurePresenter
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
+    let postTranscriptionStatusPresenter: PostTranscriptionStatusPresenter
     let sessionLibrary: SessionLibraryController
     let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
     let exportHistoryController: ExportHistoryController
@@ -323,6 +324,11 @@ final class AppState: ObservableObject {
         self.recordingSessionStopFailurePresenter = RecordingSessionStopFailurePresenter(
             errorPresenter: self.errorPresenter,
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
+        self.postTranscriptionStatusPresenter = PostTranscriptionStatusPresenter(
+            recordingStatusMessages: recordingStatusMessages,
+            setStatus: { status in presentationState.setStatus(status, error: nil) },
+            showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
         )
         self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
             errorPresenter: self.errorPresenter,
@@ -682,7 +688,7 @@ final class AppState: ObservableObject {
                 return
             }
 
-            setStatus(.transcribing(recordingStatusMessages.transcriptionUploadProgressMessage()))
+            postTranscriptionStatusPresenter.presentUploadProgress()
             recordingSessionController.swapActivity(reason: "Uploading audio for transcription")
 
             let transcriptionResult = try await transcriptionClient.transcribe(
@@ -1205,7 +1211,7 @@ final class AppState: ObservableObject {
     ) async -> PostTranscriptionPipelineResult {
         var session = session
         recordCompletedTranscriptionIfNeeded(session, mode: mode)
-        setStatus(.transcribing(recordingStatusMessages.transcriptionSavingProgressMessage(mode: mode)))
+        postTranscriptionStatusPresenter.presentSavingProgress(mode: mode)
 
         do {
             try persistInitialPostTranscriptionSession(session, mode: mode)
@@ -1282,7 +1288,7 @@ final class AppState: ObservableObject {
 
         sessionLibrary.setCurrentTranscript(session)
         recordingSessionController.clearActiveRecordingSession()
-        showTranscriptWindow?()
+        postTranscriptionStatusPresenter.presentTranscriptWindow()
     }
 
     private func extractIssuesAfterTranscription(
@@ -1290,7 +1296,7 @@ final class AppState: ObservableObject {
         apiKey: String
     ) async throws -> TranscriptSession {
         var session = session
-        setStatus(.transcribing(recordingStatusMessages.transcriptionIssueExtractionProgressMessage()))
+        postTranscriptionStatusPresenter.presentIssueExtractionProgress()
         recordingSessionController.swapActivity(reason: "Extracting review issues")
 
         let extraction = try await issueExtractionController.extractIssues(
@@ -1306,11 +1312,11 @@ final class AppState: ObservableObject {
 
     private func finishSuccessfulTranscription(showTranscriptWindow: Bool) {
         if showTranscriptWindow {
-            self.showTranscriptWindow?()
+            postTranscriptionStatusPresenter.presentTranscriptWindow()
         }
 
         recordingSessionController.endActivity()
-        setStatus(.success(recordingStatusMessages.transcriptionSuccessMessage()))
+        postTranscriptionStatusPresenter.presentSuccess()
     }
 
     private func handleCompletedTranscriptPersistenceFailure(

--- a/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
+++ b/Sources/BugNarrator/Utilities/RecordingStatusMessageBuilder.swift
@@ -123,3 +123,40 @@ final class RecordingStatusMessageProvider {
         )
     }
 }
+
+@MainActor
+final class PostTranscriptionStatusPresenter {
+    private let recordingStatusMessages: RecordingStatusMessageProvider
+    private let setStatus: (AppStatus) -> Void
+    private let showTranscriptWindow: () -> Void
+
+    init(
+        recordingStatusMessages: RecordingStatusMessageProvider,
+        setStatus: @escaping (AppStatus) -> Void,
+        showTranscriptWindow: @escaping () -> Void
+    ) {
+        self.recordingStatusMessages = recordingStatusMessages
+        self.setStatus = setStatus
+        self.showTranscriptWindow = showTranscriptWindow
+    }
+
+    func presentUploadProgress() {
+        setStatus(.transcribing(recordingStatusMessages.transcriptionUploadProgressMessage()))
+    }
+
+    func presentSavingProgress(mode: PostTranscriptionPipelineMode) {
+        setStatus(.transcribing(recordingStatusMessages.transcriptionSavingProgressMessage(mode: mode)))
+    }
+
+    func presentIssueExtractionProgress() {
+        setStatus(.transcribing(recordingStatusMessages.transcriptionIssueExtractionProgressMessage()))
+    }
+
+    func presentTranscriptWindow() {
+        showTranscriptWindow()
+    }
+
+    func presentSuccess() {
+        setStatus(.success(recordingStatusMessages.transcriptionSuccessMessage()))
+    }
+}

--- a/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
+++ b/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
@@ -192,4 +192,87 @@ final class RecordingStatusMessageBuilderTests: XCTestCase {
             "Step 3 of 3: Extracting reviewable issues..."
         )
     }
+
+    @MainActor
+    func testPostTranscriptionStatusPresenterPresentsProgressStatuses() {
+        let harness = makePostTranscriptionStatusPresenter(autoExtractIssues: true)
+
+        harness.presenter.presentUploadProgress()
+        XCTAssertEqual(
+            harness.status(),
+            .transcribing("Step 1 of 3: Uploading audio to OpenAI for transcription...")
+        )
+
+        harness.presenter.presentSavingProgress(mode: .finishedRecording)
+        XCTAssertEqual(
+            harness.status(),
+            .transcribing("Step 2 of 3: Saving the finished session locally...")
+        )
+
+        harness.presenter.presentSavingProgress(mode: .retry)
+        XCTAssertEqual(
+            harness.status(),
+            .transcribing("Step 2 of 3: Saving the recovered session locally...")
+        )
+
+        harness.presenter.presentIssueExtractionProgress()
+        XCTAssertEqual(
+            harness.status(),
+            .transcribing("Step 3 of 3: Extracting reviewable issues...")
+        )
+    }
+
+    @MainActor
+    func testPostTranscriptionStatusPresenterOpensTranscriptWindowAndPresentsSuccess() {
+        let harness = makePostTranscriptionStatusPresenter(
+            autoExtractIssues: false,
+            autoCopyTranscript: true
+        )
+
+        harness.presenter.presentTranscriptWindow()
+        harness.presenter.presentSuccess()
+
+        XCTAssertEqual(harness.showTranscriptWindowCallCount(), 1)
+        XCTAssertEqual(
+            harness.status(),
+            .success("Session saved. Transcript copied to the clipboard.")
+        )
+    }
+
+    @MainActor
+    private func makePostTranscriptionStatusPresenter(
+        autoExtractIssues: Bool,
+        autoCopyTranscript: Bool = false
+    ) -> (
+        presenter: PostTranscriptionStatusPresenter,
+        status: () -> AppStatus,
+        showTranscriptWindowCallCount: () -> Int
+    ) {
+        var status = AppStatus.idle()
+        var showTranscriptWindowCallCount = 0
+        let provider = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: autoExtractIssues,
+                autoCopyTranscript: autoCopyTranscript
+            )
+        }
+        let presenter = PostTranscriptionStatusPresenter(
+            recordingStatusMessages: provider,
+            setStatus: { newStatus in
+                status = newStatus
+            },
+            showTranscriptWindow: {
+                showTranscriptWindowCallCount += 1
+            }
+        )
+
+        return (
+            presenter: presenter,
+            status: { status },
+            showTranscriptWindowCallCount: { showTranscriptWindowCallCount }
+        )
+    }
 }


### PR DESCRIPTION
Summary
- Added PostTranscriptionStatusPresenter for transcription upload, saving, issue-extraction, transcript-window, and success presentation.
- Updated AppState to delegate those status/window presentation calls while keeping persistence, retry cleanup, and activity sequencing in AppState.
- Added focused presenter tests for progress, transcript-window, and success behavior.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/RecordingSessionControllerTests -only-testing:BugNarratorTests/RecordingStatusMessageBuilderTests\n- ./scripts/validate.sh origin/main\n\nCloses #221