### PR TITLE
Move post-transcription failure presentation out of AppState

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -14,6 +14,7 @@ final class AppState: ObservableObject {
     let presentationState: AppPresentationState
     let errorPresenter: AppErrorPresenter
     let transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter
+    let postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter
     let transientToastController: TransientToastController
     let recordingSessionController: RecordingSessionController
     let recordingSessionStartStatusPresenter: RecordingSessionStartStatusPresenter
@@ -329,6 +330,10 @@ final class AppState: ObservableObject {
             recordingStatusMessages: recordingStatusMessages,
             setStatus: { status in presentationState.setStatus(status, error: nil) },
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
+        )
+        self.postTranscriptionFailurePresenter = PostTranscriptionFailurePresenter(
+            errorPresenter: self.errorPresenter,
+            showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
         self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
             errorPresenter: self.errorPresenter,
@@ -965,7 +970,7 @@ final class AppState: ObservableObject {
                 )
                 transcriptionRecovery.finishRetry()
                 recordingSessionController.endActivity()
-                presentPostTranscriptionError(error, operation: .retryTranscription)
+                postTranscriptionFailurePresenter.present(error, operation: .retryTranscription)
             }
         } catch {
             if handlePendingTranscriptionRetryFailure(error, context: retryContext) {
@@ -1175,17 +1180,6 @@ final class AppState: ObservableObject {
         issueExportController.clearProgress()
     }
 
-    private func presentPostTranscriptionError(
-        _ error: Error,
-        operation: AppErrorOperation = .postTranscription
-    ) {
-        let result = errorPresenter.presentPostTranscriptionError(error, operation: operation)
-
-        if result.shouldOpenSettingsWindow {
-            showSettingsWindow?()
-        }
-    }
-
     private func cleanupPendingRecordedAudioIfNeeded() {
         recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
     }
@@ -1347,7 +1341,7 @@ final class AppState: ObservableObject {
         case .postTranscriptionFailure(let error):
             cleanupPendingRecordedAudioIfNeeded()
             recordingSessionController.endActivity()
-            presentPostTranscriptionError(error, operation: .postTranscription)
+            postTranscriptionFailurePresenter.present(error, operation: .postTranscription)
         }
     }
 

--- a/Sources/BugNarrator/Services/AppErrorPresenter.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresenter.swift
@@ -63,6 +63,30 @@ final class TranscriptPersistenceFailurePresenter {
 }
 
 @MainActor
+final class PostTranscriptionFailurePresenter {
+    private let errorPresenter: AppErrorPresenter
+    private let showSettingsWindow: () -> Void
+
+    init(
+        errorPresenter: AppErrorPresenter,
+        showSettingsWindow: @escaping () -> Void
+    ) {
+        self.errorPresenter = errorPresenter
+        self.showSettingsWindow = showSettingsWindow
+    }
+
+    func present(
+        _ error: Error,
+        operation: AppErrorOperation = .postTranscription
+    ) {
+        let result = errorPresenter.presentPostTranscriptionError(error, operation: operation)
+        if result.shouldOpenSettingsWindow {
+            showSettingsWindow()
+        }
+    }
+}
+
+@MainActor
 final class AppErrorPresenter {
     private let presentationState: AppPresentationState
     private let telemetryRecorder: any OperationalTelemetryRecording

--- a/Tests/BugNarratorTests/AppErrorPresenterTests.swift
+++ b/Tests/BugNarratorTests/AppErrorPresenterTests.swift
@@ -72,6 +72,55 @@ final class AppErrorPresenterTests: XCTestCase {
         XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
     }
 
+    func testPostTranscriptionFailurePresenterNormalizesFailureWithOperationMetadata() throws {
+        let harness = AppErrorPresenterHarness()
+        let error = NSError(
+            domain: "AppErrorPresenterTests",
+            code: 12,
+            userInfo: [NSLocalizedDescriptionKey: "Issue extraction service unavailable"]
+        )
+        let presenter = PostTranscriptionFailurePresenter(
+            errorPresenter: harness.presenter,
+            showSettingsWindow: {}
+        )
+
+        presenter.present(error, operation: .postTranscription)
+
+        let appError = AppError.issueExtractionFailure("Issue extraction service unavailable")
+        XCTAssertEqual(harness.presentationState.status, .error("Transcript ready, but \(appError.userMessage)"))
+        XCTAssertEqual(harness.presentationState.currentError, appError)
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_post_transcription_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "post_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "issue_extraction_failure")
+        XCTAssertEqual(telemetry.metadata["underlying_error"], "Issue extraction service unavailable")
+    }
+
+    func testPostTranscriptionFailurePresenterOpensSettingsForCredentialFailure() throws {
+        let harness = AppErrorPresenterHarness()
+        var showSettingsCallCount = 0
+        let presenter = PostTranscriptionFailurePresenter(
+            errorPresenter: harness.presenter,
+            showSettingsWindow: {
+                showSettingsCallCount += 1
+            }
+        )
+
+        presenter.present(AppError.invalidAPIKey, operation: .retryTranscription)
+
+        XCTAssertEqual(showSettingsCallCount, 1)
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error("Transcript ready, but \(AppError.invalidAPIKey.userMessage)")
+        )
+
+        let telemetry = try harness.lastAppErrorTelemetry()
+        XCTAssertEqual(telemetry.metadata["context"], "present_post_transcription_error")
+        XCTAssertEqual(telemetry.metadata["operation"], "retry_transcription")
+        XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
+    }
+
     func testTranscriptPersistenceFailurePresenterPrefixesStatusAndOpensTranscript() throws {
         let harness = AppErrorPresenterHarness()
         let underlyingError = NSError(


### PR DESCRIPTION
Summary
- Added PostTranscriptionFailurePresenter for post-transcription error UI and settings-window handling.
- Updated AppState retry and finished-recording failure paths to delegate failure presentation while preserving cleanup/activity order.
- Added focused presenter tests for normalized issue-extraction failures, operation telemetry, and credential settings behavior.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests -only-testing:BugNarratorTests/AppErrorPresenterTests\n- ./scripts/validate.sh origin/main\n\nCloses #223