### PR TITLE
Remove unused AppState presentation wrappers

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1154,24 +1154,6 @@ final class AppState: ObservableObject {
         appUtilityActionPresenter.present(appUtilityActions.openScreenshot(screenshot))
     }
 
-    private func setStatus(_ newStatus: AppStatus, error: AppError? = nil) {
-        errorPresenter.setStatus(newStatus, error: error)
-    }
-
-    private func presentError(
-        _ error: Error,
-        operation: AppErrorOperation = .generic,
-        fallback: (String) -> AppError = { .transcriptionFailure($0) }
-    ) {
-        prepareErrorPresentationSideEffects()
-
-        let result = errorPresenter.presentError(error, operation: operation, fallback: fallback)
-
-        if result.shouldOpenSettingsWindow {
-            showSettingsWindow?()
-        }
-    }
-
     private func prepareErrorPresentationSideEffects() {
         recordingSessionController.stopTimer(resetElapsed: status.phase == .recording)
         recordingSessionController.endActivity()


### PR DESCRIPTION
Summary
- Removed unused private AppState setStatus and presentError wrappers left after presenter extraction.
- Kept prepareErrorPresentationSideEffects in place for stop-session failure cleanup paths.
- No runtime behavior changed; this is dead-code removal.

Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests\n- ./scripts/validate.sh origin/main\n\nCloses #225