### PR TITLE
ARCH: Move post-transcription pipeline execution out of AppState (#227)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000004 /* DebugSessionContextProviderTests.swift */; };
 		137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000003 /* TranscriptionSessionBuilder.swift */; };
 		137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */; };
+		227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000003 /* PostTranscriptionPipelineController.swift */; };
+		227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -250,6 +252,8 @@
 		131A00000000000000000004 /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
 		137A00000000000000000003 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
 		137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
+		227A00000000000000000003 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
+		227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -390,6 +394,7 @@
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
 				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
+				227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */,
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
 				129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */,
@@ -523,6 +528,7 @@
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
 				109A00000000000000000003 /* PermissionRecoveryController.swift */,
+				227A00000000000000000003 /* PostTranscriptionPipelineController.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
 				115A00000000000000000003 /* RecoveredRecordingImportController.swift */,
@@ -749,6 +755,7 @@
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,
 				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,
+				227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */,
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
 				129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */,
@@ -850,6 +857,7 @@
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */,
 				109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */,
+				227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -23,6 +23,7 @@ final class AppState: ObservableObject {
     let recordingSessionCancelStatusPresenter: RecordingSessionCancelStatusPresenter
     let recordingStatusMessages: RecordingStatusMessageProvider
     let postTranscriptionStatusPresenter: PostTranscriptionStatusPresenter
+    let postTranscriptionPipeline: PostTranscriptionPipelineController
     let sessionLibrary: SessionLibraryController
     let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
     let exportHistoryController: ExportHistoryController
@@ -70,7 +71,6 @@ final class AppState: ObservableObject {
     private let lifecycleNotificationBinder: AppLifecycleNotificationBinder
     private let launchDiagnosticsReporter: AppLaunchDiagnosticsReporter
     private let artifactsService: any SessionArtifactsManaging
-    private let telemetryRecorder: any OperationalTelemetryRecording
 
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
@@ -335,6 +335,15 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
+        self.postTranscriptionPipeline = PostTranscriptionPipelineController(
+            settingsStore: settingsStore,
+            sessionLibrary: sessionLibrary,
+            issueExtractionController: issueExtractionController,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: self.postTranscriptionStatusPresenter,
+            telemetryRecorder: telemetryRecorder,
+            transcriptionLogger: transcriptionLogger
+        )
         self.manualIssueExtractionStatusPresenter = ManualIssueExtractionStatusPresenter(
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
@@ -433,7 +442,6 @@ final class AppState: ObservableObject {
         self.objectChangeForwarder = ObservableObjectChangeForwarder()
         self.lifecycleNotificationBinder = AppLifecycleNotificationBinder()
         self.artifactsService = artifactsService
-        self.telemetryRecorder = telemetryRecorder
         self.trackerIntegration = TrackerIntegrationController(
             settingsStore: settingsStore,
             exportService: exportService
@@ -707,7 +715,7 @@ final class AppState: ObservableObject {
                 request: request,
                 result: transcriptionResult
             )
-            let result = await completePostTranscriptionPipeline(
+            let result = await postTranscriptionPipeline.complete(
                 session: session,
                 apiKey: apiKey,
                 mode: .finishedRecording
@@ -948,7 +956,7 @@ final class AppState: ObservableObject {
                 result: result
             )
 
-            switch await completePostTranscriptionPipeline(
+            switch await postTranscriptionPipeline.complete(
                 session: updatedSession,
                 apiKey: apiKey,
                 mode: .retry
@@ -1178,112 +1186,6 @@ final class AppState: ObservableObject {
         recordingSessionStopReadinessPresenter.recordingSession(
             for: recordingSessionController.beginStoppingSession(statusPhase: status.phase)
         )
-    }
-
-    private func completePostTranscriptionPipeline(
-        session: TranscriptSession,
-        apiKey: String,
-        mode: PostTranscriptionPipelineMode
-    ) async -> PostTranscriptionPipelineResult {
-        var session = session
-        recordCompletedTranscriptionIfNeeded(session, mode: mode)
-        postTranscriptionStatusPresenter.presentSavingProgress(mode: mode)
-
-        do {
-            try persistInitialPostTranscriptionSession(session, mode: mode)
-        } catch {
-            return .persistenceFailure(session: session, error: error)
-        }
-
-        finalizeInitialPostTranscriptionPersistence(session, mode: mode)
-
-        guard settingsStore.autoExtractIssues else {
-            return .success(session)
-        }
-
-        do {
-            session = try await extractIssuesAfterTranscription(for: session, apiKey: apiKey)
-            return .success(session)
-        } catch {
-            return .postTranscriptionFailure(error)
-        }
-    }
-
-    private func recordCompletedTranscriptionIfNeeded(
-        _ session: TranscriptSession,
-        mode: PostTranscriptionPipelineMode
-    ) {
-        guard mode.recordsCompletionTelemetry else {
-            return
-        }
-
-        transcriptionLogger.info(
-            .transcriptionCompleted,
-            "BugNarrator finished transcription and created a transcript session.",
-            metadata: [
-                "session_id": session.id.uuidString,
-                "marker_count": "\(session.markerCount)",
-                "screenshot_count": "\(session.screenshotCount)"
-            ]
-        )
-        telemetryRecorder.record(
-            .transcriptionCompleted,
-            metadata: [
-                "marker_count": "\(session.markerCount)",
-                "screenshot_count": "\(session.screenshotCount)",
-                "model": session.model
-            ]
-        )
-    }
-
-    private func persistInitialPostTranscriptionSession(
-        _ session: TranscriptSession,
-        mode: PostTranscriptionPipelineMode
-    ) throws {
-        switch mode {
-        case .finishedRecording:
-            try sessionLibrary.persistCompletedTranscript(
-                session,
-                autoCopyTranscript: settingsStore.autoCopyTranscript
-            )
-        case .retry:
-            try sessionLibrary.persistUpdatedSession(
-                session,
-                autoCopyTranscript: settingsStore.autoCopyTranscript
-            )
-        }
-    }
-
-    private func finalizeInitialPostTranscriptionPersistence(
-        _ session: TranscriptSession,
-        mode: PostTranscriptionPipelineMode
-    ) {
-        guard mode == .finishedRecording else {
-            return
-        }
-
-        sessionLibrary.setCurrentTranscript(session)
-        recordingSessionController.clearActiveRecordingSession()
-        postTranscriptionStatusPresenter.presentTranscriptWindow()
-    }
-
-    private func extractIssuesAfterTranscription(
-        for session: TranscriptSession,
-        apiKey: String
-    ) async throws -> TranscriptSession {
-        var session = session
-        postTranscriptionStatusPresenter.presentIssueExtractionProgress()
-        recordingSessionController.swapActivity(reason: "Extracting review issues")
-
-        let extraction = try await issueExtractionController.extractIssues(
-            for: session,
-            apiKey: apiKey,
-            model: settingsStore.issueExtractionModelValue,
-            apiBaseURL: settingsStore.openAIBaseURLValue,
-            completionLog: .postTranscription
-        )
-        session.issueExtraction = extraction
-        return session
     }
 
     private func finishSuccessfulTranscription(showTranscriptWindow: Bool) {

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+@MainActor
+final class PostTranscriptionPipelineController {
+    private let settingsStore: SettingsStore
+    private let sessionLibrary: SessionLibraryController
+    private let issueExtractionController: IssueExtractionController
+    private let recordingSessionController: RecordingSessionController
+    private let statusPresenter: PostTranscriptionStatusPresenter
+    private let telemetryRecorder: any OperationalTelemetryRecording
+    private let transcriptionLogger: DiagnosticsLogger
+
+    init(
+        settingsStore: SettingsStore,
+        sessionLibrary: SessionLibraryController,
+        issueExtractionController: IssueExtractionController,
+        recordingSessionController: RecordingSessionController,
+        statusPresenter: PostTranscriptionStatusPresenter,
+        telemetryRecorder: any OperationalTelemetryRecording,
+        transcriptionLogger: DiagnosticsLogger = DiagnosticsLogger(category: .transcription)
+    ) {
+        self.settingsStore = settingsStore
+        self.sessionLibrary = sessionLibrary
+        self.issueExtractionController = issueExtractionController
+        self.recordingSessionController = recordingSessionController
+        self.statusPresenter = statusPresenter
+        self.telemetryRecorder = telemetryRecorder
+        self.transcriptionLogger = transcriptionLogger
+    }
+
+    func complete(
+        session: TranscriptSession,
+        apiKey: String,
+        mode: PostTranscriptionPipelineMode
+    ) async -> PostTranscriptionPipelineResult {
+        var session = session
+        recordCompletedTranscriptionIfNeeded(session, mode: mode)
+        statusPresenter.presentSavingProgress(mode: mode)
+
+        do {
+            try persistInitialPostTranscriptionSession(session, mode: mode)
+        } catch {
+            return .persistenceFailure(session: session, error: error)
+        }
+
+        finalizeInitialPostTranscriptionPersistence(session, mode: mode)
+
+        guard settingsStore.autoExtractIssues else {
+            return .success(session)
+        }
+
+        do {
+            session = try await extractIssuesAfterTranscription(for: session, apiKey: apiKey)
+            return .success(session)
+        } catch {
+            return .postTranscriptionFailure(error)
+        }
+    }
+
+    private func recordCompletedTranscriptionIfNeeded(
+        _ session: TranscriptSession,
+        mode: PostTranscriptionPipelineMode
+    ) {
+        guard mode.recordsCompletionTelemetry else {
+            return
+        }
+
+        transcriptionLogger.info(
+            .transcriptionCompleted,
+            "BugNarrator finished transcription and created a transcript session.",
+            metadata: [
+                "session_id": session.id.uuidString,
+                "marker_count": "\(session.markerCount)",
+                "screenshot_count": "\(session.screenshotCount)"
+            ]
+        )
+        telemetryRecorder.record(
+            .transcriptionCompleted,
+            metadata: [
+                "marker_count": "\(session.markerCount)",
+                "screenshot_count": "\(session.screenshotCount)",
+                "model": session.model
+            ]
+        )
+    }
+
+    private func persistInitialPostTranscriptionSession(
+        _ session: TranscriptSession,
+        mode: PostTranscriptionPipelineMode
+    ) throws {
+        switch mode {
+        case .finishedRecording:
+            try sessionLibrary.persistCompletedTranscript(
+                session,
+                autoCopyTranscript: settingsStore.autoCopyTranscript
+            )
+        case .retry:
+            try sessionLibrary.persistUpdatedSession(
+                session,
+                autoCopyTranscript: settingsStore.autoCopyTranscript
+            )
+        }
+    }
+
+    private func finalizeInitialPostTranscriptionPersistence(
+        _ session: TranscriptSession,
+        mode: PostTranscriptionPipelineMode
+    ) {
+        guard mode == .finishedRecording else {
+            return
+        }
+
+        sessionLibrary.setCurrentTranscript(session)
+        recordingSessionController.clearActiveRecordingSession()
+        statusPresenter.presentTranscriptWindow()
+    }
+
+    private func extractIssuesAfterTranscription(
+        for session: TranscriptSession,
+        apiKey: String
+    ) async throws -> TranscriptSession {
+        var session = session
+        statusPresenter.presentIssueExtractionProgress()
+        recordingSessionController.swapActivity(reason: "Extracting review issues")
+
+        let extraction = try await issueExtractionController.extractIssues(
+            for: session,
+            apiKey: apiKey,
+            model: settingsStore.issueExtractionModelValue,
+            apiBaseURL: settingsStore.openAIBaseURLValue,
+            completionLog: .postTranscription
+        )
+        session.issueExtraction = extraction
+        return session
+    }
+}

--- a/Tests/BugNarratorTests/PostTranscriptionPipelineControllerTests.swift
+++ b/Tests/BugNarratorTests/PostTranscriptionPipelineControllerTests.swift
@@ -1,0 +1,315 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class PostTranscriptionPipelineControllerTests: XCTestCase {
+    func testFinishedRecordingSuccessPersistsSessionRecordsTelemetryAndClearsActiveRecording() async throws {
+        let harness = try PostTranscriptionPipelineControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = makePipelineSession(
+            index: 1,
+            markers: [
+                SessionMarker(
+                    index: 1,
+                    elapsedTime: 1,
+                    title: "Marker 1",
+                    screenshotID: nil
+                )
+            ]
+        )
+        let recordingSession = RecordingSessionDraft(
+            sessionID: session.id,
+            artifactsDirectoryURL: harness.rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        harness.recordingSessionController.updateActiveRecordingSession(recordingSession)
+
+        let result = await harness.controller.complete(
+            session: session,
+            apiKey: "api-key",
+            mode: .finishedRecording
+        )
+
+        guard case .success(let completedSession) = result else {
+            return XCTFail("Expected success result.")
+        }
+        XCTAssertEqual(completedSession.id, session.id)
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id)?.transcript, session.transcript)
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+        XCTAssertNil(harness.recordingSessionController.activeRecordingSession)
+        XCTAssertTrue(harness.transcriptWindowSpy.didShow)
+        XCTAssertEqual(harness.presentationState.status.phase, .transcribing)
+        XCTAssertEqual(harness.presentationState.status.detail, "Step 2 of 2: Saving the finished session locally...")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.map(\.name), ["transcription_completed"])
+    }
+
+    func testRetrySuccessPersistsUpdatedSessionWithoutFinishedRecordingSideEffects() async throws {
+        let harness = try PostTranscriptionPipelineControllerHarness()
+        defer { harness.cleanup() }
+
+        let originalSession = makeSampleTranscriptSession(index: 2)
+        try harness.transcriptStore.add(originalSession)
+        let recoveredSession = makePipelineSession(
+            id: originalSession.id,
+            index: 2,
+            transcript: "Recovered transcript"
+        )
+        let recordingSession = RecordingSessionDraft(
+            sessionID: UUID(),
+            artifactsDirectoryURL: harness.rootDirectoryURL.appendingPathComponent("active", isDirectory: true)
+        )
+        harness.recordingSessionController.updateActiveRecordingSession(recordingSession)
+
+        let result = await harness.controller.complete(
+            session: recoveredSession,
+            apiKey: "api-key",
+            mode: .retry
+        )
+
+        guard case .success(let completedSession) = result else {
+            return XCTFail("Expected success result.")
+        }
+        XCTAssertEqual(completedSession.transcript, "Recovered transcript")
+        XCTAssertEqual(harness.transcriptStore.session(with: originalSession.id)?.transcript, "Recovered transcript")
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.sessionID, recordingSession.sessionID)
+        XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+        XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
+    }
+
+    func testPersistenceFailureReturnsSessionAndDoesNotFinalizeFinishedRecording() async throws {
+        let harness = try PostTranscriptionPipelineControllerHarness(failSessionPersistence: true)
+        defer { harness.cleanup() }
+
+        let session = makeSampleTranscriptSession(index: 3)
+        let recordingSession = RecordingSessionDraft(
+            sessionID: session.id,
+            artifactsDirectoryURL: harness.rootDirectoryURL.appendingPathComponent("active", isDirectory: true)
+        )
+        harness.recordingSessionController.updateActiveRecordingSession(recordingSession)
+
+        let result = await harness.controller.complete(
+            session: session,
+            apiKey: "api-key",
+            mode: .finishedRecording
+        )
+
+        guard case .persistenceFailure(let failedSession, let error) = result else {
+            return XCTFail("Expected persistence failure result.")
+        }
+        XCTAssertEqual(failedSession.id, session.id)
+        XCTAssertTrue(error is AppError)
+        XCTAssertNil(harness.sessionLibrary.currentTranscript)
+        XCTAssertEqual(harness.recordingSessionController.activeRecordingSession?.sessionID, session.id)
+        XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+    }
+
+    func testAutomaticIssueExtractionSuccessReturnsSessionWithExtractedIssues() async throws {
+        let issueExtractionService = MockIssueExtractionService()
+        let harness = try PostTranscriptionPipelineControllerHarness(
+            autoExtractIssues: true,
+            issueExtractionService: issueExtractionService
+        )
+        defer { harness.cleanup() }
+        let issue = ExtractedIssue(
+            title: "Save button fails",
+            category: .bug,
+            summary: "The save button fails.",
+            evidenceExcerpt: "Save fails",
+            timestamp: 1,
+            requiresReview: true
+        )
+        await issueExtractionService.setResult(
+            IssueExtractionResult(summary: "One issue.", issues: [issue])
+        )
+
+        let session = makeSampleTranscriptSession(index: 4)
+
+        let result = await harness.controller.complete(
+            session: session,
+            apiKey: "api-key",
+            mode: .finishedRecording
+        )
+
+        guard case .success(let completedSession) = result else {
+            return XCTFail("Expected success result.")
+        }
+        XCTAssertEqual(completedSession.issueExtraction?.summary, "One issue.")
+        XCTAssertEqual(harness.transcriptStore.session(with: session.id)?.issueExtraction?.issues.first?.title, "Save button fails")
+        XCTAssertEqual(harness.presentationState.status.detail, "Step 3 of 3: Extracting reviewable issues...")
+    }
+
+    func testAutomaticIssueExtractionFailureReturnsPostTranscriptionFailure() async throws {
+        let issueExtractionService = FailingIssueExtractionService(error: AppError.issueExtractionFailure("Extraction failed."))
+        let harness = try PostTranscriptionPipelineControllerHarness(
+            autoExtractIssues: true,
+            issueExtractionService: issueExtractionService
+        )
+        defer { harness.cleanup() }
+
+        let session = makeSampleTranscriptSession(index: 5)
+
+        let result = await harness.controller.complete(
+            session: session,
+            apiKey: "api-key",
+            mode: .finishedRecording
+        )
+
+        guard case .postTranscriptionFailure(let error) = result else {
+            return XCTFail("Expected post-transcription failure result.")
+        }
+        XCTAssertEqual(error as? AppError, .issueExtractionFailure("Extraction failed."))
+        XCTAssertNil(harness.transcriptStore.session(with: session.id)?.issueExtraction)
+        XCTAssertEqual(harness.presentationState.status.detail, "Step 3 of 3: Extracting reviewable issues...")
+    }
+}
+
+@MainActor
+private final class PostTranscriptionPipelineControllerHarness {
+    let rootDirectoryURL: URL
+    let defaultsSuiteName: String
+    let defaults: UserDefaults
+    let settingsStore: SettingsStore
+    let transcriptStore: TranscriptStore
+    let sessionLibrary: SessionLibraryController
+    let recordingSessionController: RecordingSessionController
+    let presentationState: AppPresentationState
+    let telemetryRecorder: MockOperationalTelemetryRecorder
+    let transcriptWindowSpy: TranscriptWindowSpy
+    let controller: PostTranscriptionPipelineController
+
+    init(
+        autoExtractIssues: Bool = false,
+        failSessionPersistence: Bool = false,
+        issueExtractionService: (any IssueExtracting)? = nil
+    ) throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("PostTranscriptionPipelineControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        defaultsSuiteName = "PostTranscriptionPipelineControllerTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+
+        settingsStore = SettingsStore(
+            defaults: defaults,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: MockLaunchAtLoginService()
+        )
+        settingsStore.apiKey = "api-key"
+        settingsStore.autoCopyTranscript = true
+        settingsStore.autoExtractIssues = autoExtractIssues
+
+        let sessionDataProtector: any SessionDataProtecting = failSessionPersistence
+            ? FailingSessionDataProtector()
+            : PlaintextSessionDataProtector()
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"),
+            sessionDataProtector: sessionDataProtector
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts")),
+            clipboardService: MockClipboardService()
+        )
+        let audioRecorder = MockAudioRecorder()
+        recordingSessionController = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("recording-artifacts")),
+            recordingTimer: RecordingTimerViewModel()
+        )
+        presentationState = AppPresentationState()
+        telemetryRecorder = MockOperationalTelemetryRecorder()
+        transcriptWindowSpy = TranscriptWindowSpy()
+
+        let recordingStatusMessages = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: autoExtractIssues,
+                autoCopyTranscript: true
+            )
+        }
+        let statusPresenter = PostTranscriptionStatusPresenter(
+            recordingStatusMessages: recordingStatusMessages,
+            setStatus: { [presentationState] status in
+                presentationState.setStatus(status, error: nil)
+            },
+            showTranscriptWindow: { [transcriptWindowSpy] in
+                transcriptWindowSpy.didShow = true
+            }
+        )
+        let issueExtractionController = IssueExtractionController(
+            sessionLibrary: sessionLibrary,
+            issueExtractionService: issueExtractionService ?? MockIssueExtractionService()
+        )
+        controller = PostTranscriptionPipelineController(
+            settingsStore: settingsStore,
+            sessionLibrary: sessionLibrary,
+            issueExtractionController: issueExtractionController,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: statusPresenter,
+            telemetryRecorder: telemetryRecorder
+        )
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class TranscriptWindowSpy {
+    var didShow = false
+}
+
+private struct FailingSessionDataProtector: SessionDataProtecting {
+    let writesEncryptedPayloads = false
+
+    func protect(_ data: Data) throws -> Data {
+        throw AppError.storageFailure("Injected persistence failure.")
+    }
+
+    func unprotect(_ data: Data) throws -> Data {
+        data
+    }
+}
+
+private actor FailingIssueExtractionService: IssueExtracting {
+    let error: Error
+
+    init(error: Error) {
+        self.error = error
+    }
+
+    func extractIssues(
+        from reviewSession: TranscriptSession,
+        apiKey: String,
+        model: String,
+        apiBaseURL: URL
+    ) async throws -> IssueExtractionResult {
+        throw error
+    }
+}
+
+private func makePipelineSession(
+    id: UUID = UUID(),
+    index: Int,
+    transcript: String? = nil,
+    markers: [SessionMarker] = []
+) -> TranscriptSession {
+    TranscriptSession(
+        id: id,
+        createdAt: Date(timeIntervalSince1970: TimeInterval(index * 60)),
+        transcript: transcript ?? "Transcript \(index)",
+        duration: TimeInterval(index),
+        model: "whisper-1",
+        languageHint: nil,
+        prompt: nil,
+        markers: markers
+    )
+}


### PR DESCRIPTION
Closes #227

## Summary
- Added PostTranscriptionPipelineController for completed transcript persistence, completion telemetry, and optional automatic issue extraction.
- Wired AppState finished-recording and retry flows to delegate pipeline execution while keeping result handling in AppState.
- Added focused pipeline tests for success, retry, persistence failure, issue extraction success, and issue extraction failure.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/PostTranscriptionPipelineControllerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main