### PR TITLE
ARCH: Move finished-recording post-transcription result handling out of AppState (#229)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */; };
 		227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000003 /* PostTranscriptionPipelineController.swift */; };
 		227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */; };
+		229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -254,6 +255,7 @@
 		137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
 		227A00000000000000000003 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
 		227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
+		229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 				131A00000000000000000004 /* DebugSessionContextProviderTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
+				229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
 				107A00000000000000000004 /* IssueExportControllerTests.swift */,
 				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
@@ -742,6 +745,7 @@
 				131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
+				229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
 				107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */,
 				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -24,6 +24,7 @@ final class AppState: ObservableObject {
     let recordingStatusMessages: RecordingStatusMessageProvider
     let postTranscriptionStatusPresenter: PostTranscriptionStatusPresenter
     let postTranscriptionPipeline: PostTranscriptionPipelineController
+    let finishedRecordingPostTranscriptionResultHandler: FinishedRecordingPostTranscriptionResultHandler
     let sessionLibrary: SessionLibraryController
     let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
     let exportHistoryController: ExportHistoryController
@@ -359,6 +360,17 @@ final class AppState: ObservableObject {
         self.transcriptPersistenceFailurePresenter = TranscriptPersistenceFailurePresenter(
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
+        )
+        self.finishedRecordingPostTranscriptionResultHandler = FinishedRecordingPostTranscriptionResultHandler(
+            sessionLibrary: sessionLibrary,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: self.postTranscriptionStatusPresenter,
+            transcriptPersistenceFailurePresenter: self.transcriptPersistenceFailurePresenter,
+            postTranscriptionFailurePresenter: self.postTranscriptionFailurePresenter,
+            autoCopyTranscript: { settingsStore.autoCopyTranscript },
+            cleanupPendingRecordedAudio: {
+                recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
+            }
         )
         self.recoveredRecordingLaunchImporter = RecoveredRecordingLaunchImportPresenter(
             importController: recoveredRecordingImportController,
@@ -720,7 +732,7 @@ final class AppState: ObservableObject {
                 apiKey: apiKey,
                 mode: .finishedRecording
             )
-            handleFinishedRecordingPostTranscriptionResult(result)
+            finishedRecordingPostTranscriptionResultHandler.handle(result)
         } catch {
             handleStopSessionFailure(error, recordingSession: recordingSession, request: request)
         }
@@ -1195,38 +1207,6 @@ final class AppState: ObservableObject {
 
         recordingSessionController.endActivity()
         postTranscriptionStatusPresenter.presentSuccess()
-    }
-
-    private func handleCompletedTranscriptPersistenceFailure(
-        _ error: Error,
-        session: TranscriptSession
-    ) {
-        sessionLibrary.stageCurrentTranscript(
-            session,
-            autoCopyTranscript: settingsStore.autoCopyTranscript
-        )
-        recordingSessionController.clearActiveRecordingSession()
-
-        cleanupPendingRecordedAudioIfNeeded()
-        recordingSessionController.endActivity()
-
-        transcriptPersistenceFailurePresenter.present(error, sessionID: session.id)
-    }
-
-    private func handleFinishedRecordingPostTranscriptionResult(
-        _ result: PostTranscriptionPipelineResult
-    ) {
-        switch result {
-        case .success:
-            cleanupPendingRecordedAudioIfNeeded()
-            finishSuccessfulTranscription(showTranscriptWindow: false)
-        case .persistenceFailure(let session, let error):
-            handleCompletedTranscriptPersistenceFailure(error, session: session)
-        case .postTranscriptionFailure(let error):
-            cleanupPendingRecordedAudioIfNeeded()
-            recordingSessionController.endActivity()
-            postTranscriptionFailurePresenter.present(error, operation: .postTranscription)
-        }
     }
 
     private func handleStopSessionFailure(

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -134,3 +134,65 @@ final class PostTranscriptionPipelineController {
         return session
     }
 }
+
+@MainActor
+final class FinishedRecordingPostTranscriptionResultHandler {
+    private let sessionLibrary: SessionLibraryController
+    private let recordingSessionController: RecordingSessionController
+    private let statusPresenter: PostTranscriptionStatusPresenter
+    private let transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter
+    private let postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter
+    private let autoCopyTranscript: () -> Bool
+    private let cleanupPendingRecordedAudio: () -> Void
+
+    init(
+        sessionLibrary: SessionLibraryController,
+        recordingSessionController: RecordingSessionController,
+        statusPresenter: PostTranscriptionStatusPresenter,
+        transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter,
+        postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter,
+        autoCopyTranscript: @escaping () -> Bool,
+        cleanupPendingRecordedAudio: @escaping () -> Void
+    ) {
+        self.sessionLibrary = sessionLibrary
+        self.recordingSessionController = recordingSessionController
+        self.statusPresenter = statusPresenter
+        self.transcriptPersistenceFailurePresenter = transcriptPersistenceFailurePresenter
+        self.postTranscriptionFailurePresenter = postTranscriptionFailurePresenter
+        self.autoCopyTranscript = autoCopyTranscript
+        self.cleanupPendingRecordedAudio = cleanupPendingRecordedAudio
+    }
+
+    func handle(_ result: PostTranscriptionPipelineResult) {
+        switch result {
+        case .success:
+            cleanupPendingRecordedAudio()
+            recordingSessionController.endActivity()
+            statusPresenter.presentSuccess()
+
+        case .persistenceFailure(let session, let error):
+            handleCompletedTranscriptPersistenceFailure(error, session: session)
+
+        case .postTranscriptionFailure(let error):
+            cleanupPendingRecordedAudio()
+            recordingSessionController.endActivity()
+            postTranscriptionFailurePresenter.present(error, operation: .postTranscription)
+        }
+    }
+
+    private func handleCompletedTranscriptPersistenceFailure(
+        _ error: Error,
+        session: TranscriptSession
+    ) {
+        sessionLibrary.stageCurrentTranscript(
+            session,
+            autoCopyTranscript: autoCopyTranscript()
+        )
+        recordingSessionController.clearActiveRecordingSession()
+
+        cleanupPendingRecordedAudio()
+        recordingSessionController.endActivity()
+
+        transcriptPersistenceFailurePresenter.present(error, sessionID: session.id)
+    }
+}

--- a/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class FinishedRecordingPostTranscriptionResultHandlerTests: XCTestCase {
+    func testSuccessCleansPendingAudioAndPresentsSuccessWithoutShowingTranscriptWindow() async throws {
+        let harness = try FinishedRecordingPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let recordedAudio = try harness.makeRecordedAudio()
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        _ = try await harness.recordingSessionController.stopRecording()
+
+        harness.handler.handle(.success(makeSampleTranscriptSession(index: 1)))
+
+        XCTAssertNil(harness.recordingSessionController.pendingRecordedAudioSnapshot)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .success)
+        XCTAssertEqual(harness.presentationState.status.detail, "Session saved. Transcript copied to the clipboard.")
+        XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+    }
+
+    func testPersistenceFailureStagesTranscriptClearsActiveRecordingAndPresentsFailure() async throws {
+        let harness = try FinishedRecordingPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let session = makeSampleTranscriptSession(index: 2)
+        let recordedAudio = try harness.makeRecordedAudio()
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        _ = try await harness.recordingSessionController.stopRecording()
+        harness.recordingSessionController.updateActiveRecordingSession(
+            RecordingSessionDraft(
+                sessionID: session.id,
+                artifactsDirectoryURL: harness.rootDirectoryURL.appendingPathComponent("active", isDirectory: true)
+            )
+        )
+
+        harness.handler.handle(.persistenceFailure(session: session, error: AppError.storageFailure("Disk full.")))
+
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+        XCTAssertEqual(harness.sessionLibrary.selectedTranscriptID, session.id)
+        XCTAssertNil(harness.recordingSessionController.activeRecordingSession)
+        XCTAssertNil(harness.recordingSessionController.pendingRecordedAudioSnapshot)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .storageFailure("Disk full."))
+        XCTAssertTrue(harness.transcriptWindowSpy.didShow)
+    }
+
+    func testPostTranscriptionFailureCleansPendingAudioAndPresentsFailure() async throws {
+        let harness = try FinishedRecordingPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let recordedAudio = try harness.makeRecordedAudio()
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        _ = try await harness.recordingSessionController.stopRecording()
+
+        harness.handler.handle(.postTranscriptionFailure(AppError.invalidAPIKey))
+
+        XCTAssertNil(harness.recordingSessionController.pendingRecordedAudioSnapshot)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .invalidAPIKey)
+        XCTAssertTrue(harness.settingsWindowSpy.didShow)
+    }
+}
+
+@MainActor
+private final class FinishedRecordingPostTranscriptionResultHandlerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let sessionLibrary: SessionLibraryController
+    let recordingSessionController: RecordingSessionController
+    let audioRecorder: MockAudioRecorder
+    let presentationState: AppPresentationState
+    let transcriptWindowSpy = TranscriptWindowSpy()
+    let settingsWindowSpy = SettingsWindowSpy()
+    let handler: FinishedRecordingPostTranscriptionResultHandler
+
+    init(debugMode: Bool = false) throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("FinishedRecordingPostTranscriptionResultHandlerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"),
+            sessionDataProtector: PlaintextSessionDataProtector()
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts")),
+            clipboardService: MockClipboardService()
+        )
+        audioRecorder = MockAudioRecorder()
+        recordingSessionController = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("recording-artifacts")),
+            recordingTimer: RecordingTimerViewModel()
+        )
+        presentationState = AppPresentationState()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: MockOperationalTelemetryRecorder()
+        )
+        let recordingStatusMessages = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: false,
+                autoCopyTranscript: true
+            )
+        }
+        let statusPresenter = PostTranscriptionStatusPresenter(
+            recordingStatusMessages: recordingStatusMessages,
+            setStatus: { [presentationState] status in
+                presentationState.setStatus(status, error: nil)
+            },
+            showTranscriptWindow: { [transcriptWindowSpy] in
+                transcriptWindowSpy.didShow = true
+            }
+        )
+        let transcriptPersistenceFailurePresenter = TranscriptPersistenceFailurePresenter(
+            errorPresenter: errorPresenter,
+            showTranscriptWindow: { [transcriptWindowSpy] in
+                transcriptWindowSpy.didShow = true
+            }
+        )
+        let postTranscriptionFailurePresenter = PostTranscriptionFailurePresenter(
+            errorPresenter: errorPresenter,
+            showSettingsWindow: { [settingsWindowSpy] in
+                settingsWindowSpy.didShow = true
+            }
+        )
+        handler = FinishedRecordingPostTranscriptionResultHandler(
+            sessionLibrary: sessionLibrary,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: statusPresenter,
+            transcriptPersistenceFailurePresenter: transcriptPersistenceFailurePresenter,
+            postTranscriptionFailurePresenter: postTranscriptionFailurePresenter,
+            autoCopyTranscript: { true },
+            cleanupPendingRecordedAudio: { [recordingSessionController] in
+                recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: debugMode)
+            }
+        )
+    }
+
+    func makeRecordedAudio() throws -> RecordedAudio {
+        let fileURL = rootDirectoryURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("m4a")
+        try Data("audio".utf8).write(to: fileURL)
+        return RecordedAudio(fileURL: fileURL, duration: 4)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class TranscriptWindowSpy {
+    var didShow = false
+}
+
+@MainActor
+private final class SettingsWindowSpy {
+    var didShow = false
+}


### PR DESCRIPTION
Closes #229

## Summary
- Added a finished-recording post-transcription result handler for success, persistence failure, and post-transcription failure cleanup/presentation.
- Wired AppState.stopSession() to delegate finished-recording result handling while leaving retry handling in AppState.
- Added focused handler tests for success cleanup, persistence failure staging/presentation, and post-transcription failure cleanup.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main