### PR TITLE
BUG: Fix recovered recording import for system-audio crash files (#232)

### DIFF
--- a/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
+++ b/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 struct RecoveredRecordingImporter: RecoveredRecordingImporting {
+    private static let supportedAudioExtensions: Set<String> = ["m4a", "wav"]
+
     private let fileManager: FileManager
     private let recoveryDirectoryURL: URL
     private let qualityInspector: TranscriptQualityInspector
@@ -35,7 +37,7 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
                 includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
                 options: [.skipsHiddenFiles]
             )
-            .filter { $0.pathExtension.lowercased() == "m4a" }
+            .filter(Self.isRecoverableAudioFile)
             .filter { !alreadyImported.contains($0.lastPathComponent) }
             .sorted {
                 modificationDate(for: $0) > modificationDate(for: $1)
@@ -126,6 +128,10 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
         }
 
         return nil
+    }
+
+    private static func isRecoverableAudioFile(_ url: URL) -> Bool {
+        supportedAudioExtensions.contains(url.pathExtension.lowercased())
     }
 
     private func modificationDate(for url: URL) -> Date {

--- a/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
+++ b/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
@@ -56,6 +56,50 @@ final class RecoveredRecordingImporterTests: XCTestCase {
         XCTAssertTrue(session.preview.contains("Recovered recording found"))
     }
 
+    func testImporterCreatesRetryablePendingSessionForRecoveredSystemAudioWAV() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+        let audioURL = recoveryDirectoryURL.appendingPathComponent("crash-recovery-system-audio.wav")
+        try Data("system audio".utf8).write(to: audioURL)
+
+        let store = TranscriptStore(storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"))
+        let artifactsService = MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts"))
+        let importer = RecoveredRecordingImporter(recoveryDirectoryURL: recoveryDirectoryURL)
+
+        XCTAssertEqual(try importer.importRecoverableRecordings(into: store, artifactsService: artifactsService), 1)
+
+        let session = try XCTUnwrap(store.sessions.first)
+        XCTAssertEqual(session.pendingTranscription?.failureReason, .crashRecovery)
+        XCTAssertEqual(session.pendingTranscription?.audioFileName, "recording.wav")
+        XCTAssertEqual(session.pendingTranscription?.recoveredSourceFileName, audioURL.lastPathComponent)
+        XCTAssertEqual(session.recoveredSourceFileName, audioURL.lastPathComponent)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: try XCTUnwrap(session.pendingTranscriptionAudioURL).path
+            )
+        )
+    }
+
+    func testImporterIgnoresUnsupportedRecoveredFiles() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+        try Data("not audio".utf8).write(to: recoveryDirectoryURL.appendingPathComponent("notes.txt"))
+        try Data("not supported".utf8).write(to: recoveryDirectoryURL.appendingPathComponent("recording.mp3"))
+
+        let store = TranscriptStore(storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"))
+        let artifactsService = MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts"))
+        let importer = RecoveredRecordingImporter(recoveryDirectoryURL: recoveryDirectoryURL)
+
+        XCTAssertEqual(try importer.importRecoverableRecordings(into: store, artifactsService: artifactsService), 0)
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
     private func makeTempDirectory() -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-RecoveredRecordingImporterTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #232

## Summary
- allow recovered recording import to discover supported audio extensions instead of only .m4a
- add coverage for recovered system-audio .wav files becoming retryable pending transcription sessions
- add coverage that unsupported files in the recovery directory are ignored

## Local validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RecoveredRecordingImporterTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e /tmp event with origin/main base SHA

Note: initial local act attempt failed because the synthetic event lacked a base SHA and Docker inherited an SSH origin; reran with HTTPS origin and explicit base SHA, and runtime-guardrails succeeded locally.