### PR TITLE
ARCH: Move retry post-transcription result handling out of AppState (#231)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000003 /* PostTranscriptionPipelineController.swift */; };
 		227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */; };
 		229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
+		231A00000000000000000001 /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -256,6 +257,7 @@
 		227A00000000000000000003 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
 		227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
 		229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
+		231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
 				229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
+				231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
 				107A00000000000000000004 /* IssueExportControllerTests.swift */,
 				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
@@ -746,6 +749,7 @@
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
 				229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
+				231A00000000000000000001 /* RetryPostTranscriptionResultHandlerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
 				107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */,
 				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -25,6 +25,7 @@ final class AppState: ObservableObject {
     let postTranscriptionStatusPresenter: PostTranscriptionStatusPresenter
     let postTranscriptionPipeline: PostTranscriptionPipelineController
     let finishedRecordingPostTranscriptionResultHandler: FinishedRecordingPostTranscriptionResultHandler
+    let retryPostTranscriptionResultHandler: RetryPostTranscriptionResultHandler
     let sessionLibrary: SessionLibraryController
     let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
     let exportHistoryController: ExportHistoryController
@@ -424,6 +425,14 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
+        )
+        self.retryPostTranscriptionResultHandler = RetryPostTranscriptionResultHandler(
+            transcriptionRecovery: self.transcriptionRecovery,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: self.postTranscriptionStatusPresenter,
+            sessionLibraryStatusPresenter: self.sessionLibraryStatusPresenter,
+            postTranscriptionFailurePresenter: self.postTranscriptionFailurePresenter,
+            debugMode: { settingsStore.debugMode }
         )
         let screenshotCoordinator = ScreenshotCoordinator(
             screenCapturePermissionService: screenCapturePermissionService,
@@ -968,30 +977,12 @@ final class AppState: ObservableObject {
                 result: result
             )
 
-            switch await postTranscriptionPipeline.complete(
+            let pipelineResult = await postTranscriptionPipeline.complete(
                 session: updatedSession,
                 apiKey: apiKey,
                 mode: .retry
-            ) {
-            case .success:
-                transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
-                    at: retryContext.audioFileURL,
-                    debugMode: settingsStore.debugMode
-                )
-                transcriptionRecovery.finishRetry()
-                finishSuccessfulTranscription(showTranscriptWindow: true)
-            case .persistenceFailure(_, let error):
-                transcriptionRecovery.finishRetry()
-                sessionLibraryStatusPresenter.presentFailure(error)
-            case .postTranscriptionFailure(let error):
-                transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
-                    at: retryContext.audioFileURL,
-                    debugMode: settingsStore.debugMode
-                )
-                transcriptionRecovery.finishRetry()
-                recordingSessionController.endActivity()
-                postTranscriptionFailurePresenter.present(error, operation: .retryTranscription)
-            }
+            )
+            retryPostTranscriptionResultHandler.handle(pipelineResult, context: retryContext)
         } catch {
             if handlePendingTranscriptionRetryFailure(error, context: retryContext) {
                 return
@@ -1198,15 +1189,6 @@ final class AppState: ObservableObject {
         recordingSessionStopReadinessPresenter.recordingSession(
             for: recordingSessionController.beginStoppingSession(statusPhase: status.phase)
         )
-    }
-
-    private func finishSuccessfulTranscription(showTranscriptWindow: Bool) {
-        if showTranscriptWindow {
-            postTranscriptionStatusPresenter.presentTranscriptWindow()
-        }
-
-        recordingSessionController.endActivity()
-        postTranscriptionStatusPresenter.presentSuccess()
     }
 
     private func handleStopSessionFailure(

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -196,3 +196,60 @@ final class FinishedRecordingPostTranscriptionResultHandler {
         transcriptPersistenceFailurePresenter.present(error, sessionID: session.id)
     }
 }
+
+@MainActor
+final class RetryPostTranscriptionResultHandler {
+    private let transcriptionRecovery: TranscriptionRecoveryController
+    private let recordingSessionController: RecordingSessionController
+    private let statusPresenter: PostTranscriptionStatusPresenter
+    private let sessionLibraryStatusPresenter: SessionLibraryStatusPresenter
+    private let postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter
+    private let debugMode: () -> Bool
+
+    init(
+        transcriptionRecovery: TranscriptionRecoveryController,
+        recordingSessionController: RecordingSessionController,
+        statusPresenter: PostTranscriptionStatusPresenter,
+        sessionLibraryStatusPresenter: SessionLibraryStatusPresenter,
+        postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter,
+        debugMode: @escaping () -> Bool
+    ) {
+        self.transcriptionRecovery = transcriptionRecovery
+        self.recordingSessionController = recordingSessionController
+        self.statusPresenter = statusPresenter
+        self.sessionLibraryStatusPresenter = sessionLibraryStatusPresenter
+        self.postTranscriptionFailurePresenter = postTranscriptionFailurePresenter
+        self.debugMode = debugMode
+    }
+
+    func handle(
+        _ result: PostTranscriptionPipelineResult,
+        context: PendingTranscriptionRetryContext
+    ) {
+        switch result {
+        case .success:
+            cleanupPreservedRetryAudio(for: context)
+            transcriptionRecovery.finishRetry()
+            statusPresenter.presentTranscriptWindow()
+            recordingSessionController.endActivity()
+            statusPresenter.presentSuccess()
+
+        case .persistenceFailure(_, let error):
+            transcriptionRecovery.finishRetry()
+            sessionLibraryStatusPresenter.presentFailure(error)
+
+        case .postTranscriptionFailure(let error):
+            cleanupPreservedRetryAudio(for: context)
+            transcriptionRecovery.finishRetry()
+            recordingSessionController.endActivity()
+            postTranscriptionFailurePresenter.present(error, operation: .retryTranscription)
+        }
+    }
+
+    private func cleanupPreservedRetryAudio(for context: PendingTranscriptionRetryContext) {
+        transcriptionRecovery.cleanupPreservedRetryAudioIfNeeded(
+            at: context.audioFileURL,
+            debugMode: debugMode()
+        )
+    }
+}

--- a/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class RetryPostTranscriptionResultHandlerTests: XCTestCase {
+    func testSuccessCleansPreservedAudioFinishesRetryAndPresentsSuccess() throws {
+        let harness = try RetryPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(index: 1)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(.success(makeSampleTranscriptSession(index: 1)), context: context)
+
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: context.audioFileURL.path))
+        XCTAssertTrue(harness.transcriptWindowSpy.didShow)
+        XCTAssertEqual(harness.presentationState.status.phase, .success)
+        XCTAssertEqual(harness.presentationState.status.detail, "Session saved. Transcript copied to the clipboard.")
+    }
+
+    func testSuccessKeepsPreservedAudioWhenDebugModeIsEnabled() throws {
+        let harness = try RetryPostTranscriptionResultHandlerHarness(debugMode: true)
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(index: 2)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(.success(makeSampleTranscriptSession(index: 2)), context: context)
+
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: context.audioFileURL.path))
+        XCTAssertTrue(harness.transcriptWindowSpy.didShow)
+        XCTAssertEqual(harness.presentationState.status.phase, .success)
+    }
+
+    func testPersistenceFailureFinishesRetryAndKeepsPreservedAudio() throws {
+        let harness = try RetryPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(index: 3)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(
+            .persistenceFailure(session: context.session, error: AppError.storageFailure("Disk full.")),
+            context: context
+        )
+
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: context.audioFileURL.path))
+        XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .storageFailure("Disk full."))
+    }
+
+    func testPostTranscriptionFailureCleansPreservedAudioFinishesRetryAndPresentsFailure() throws {
+        let harness = try RetryPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(index: 4)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(.postTranscriptionFailure(AppError.invalidAPIKey), context: context)
+
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: context.audioFileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .invalidAPIKey)
+        XCTAssertTrue(harness.settingsWindowSpy.didShow)
+    }
+}
+
+@MainActor
+private final class RetryPostTranscriptionResultHandlerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let sessionLibrary: SessionLibraryController
+    let recordingSessionController: RecordingSessionController
+    let transcriptionRecovery: TranscriptionRecoveryController
+    let presentationState: AppPresentationState
+    let transcriptWindowSpy = RetryTranscriptWindowSpy()
+    let settingsWindowSpy = RetrySettingsWindowSpy()
+    let handler: RetryPostTranscriptionResultHandler
+
+    init(debugMode: Bool = false) throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("RetryPostTranscriptionResultHandlerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"),
+            sessionDataProtector: PlaintextSessionDataProtector()
+        )
+        let sessionArtifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("session-artifacts", isDirectory: true)
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: sessionArtifactsService,
+            clipboardService: MockClipboardService()
+        )
+        recordingSessionController = RecordingSessionController(
+            audioRecorder: MockAudioRecorder(),
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: MockAudioRecorder()),
+            artifactsService: MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("recording-artifacts")),
+            recordingTimer: RecordingTimerViewModel()
+        )
+        transcriptionRecovery = TranscriptionRecoveryController(
+            sessionLibrary: sessionLibrary,
+            artifactsService: sessionArtifactsService
+        )
+        presentationState = AppPresentationState()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: MockOperationalTelemetryRecorder()
+        )
+        let recordingStatusMessages = RecordingStatusMessageProvider {
+            RecordingStatusMessageSnapshot(
+                audioSource: .microphone,
+                hasUsableAIProviderCredential: true,
+                aiProviderCompatibilityIssue: nil,
+                autoExtractIssues: false,
+                autoCopyTranscript: true
+            )
+        }
+        let statusPresenter = PostTranscriptionStatusPresenter(
+            recordingStatusMessages: recordingStatusMessages,
+            setStatus: { [presentationState] status in
+                presentationState.setStatus(status, error: nil)
+            },
+            showTranscriptWindow: { [transcriptWindowSpy] in
+                transcriptWindowSpy.didShow = true
+            }
+        )
+        let sessionLibraryStatusPresenter = SessionLibraryStatusPresenter(errorPresenter: errorPresenter)
+        let postTranscriptionFailurePresenter = PostTranscriptionFailurePresenter(
+            errorPresenter: errorPresenter,
+            showSettingsWindow: { [settingsWindowSpy] in
+                settingsWindowSpy.didShow = true
+            }
+        )
+        handler = RetryPostTranscriptionResultHandler(
+            transcriptionRecovery: transcriptionRecovery,
+            recordingSessionController: recordingSessionController,
+            statusPresenter: statusPresenter,
+            sessionLibraryStatusPresenter: sessionLibraryStatusPresenter,
+            postTranscriptionFailurePresenter: postTranscriptionFailurePresenter,
+            debugMode: { debugMode }
+        )
+    }
+
+    func makeRetryContext(index: Int) throws -> PendingTranscriptionRetryContext {
+        let sessionID = UUID()
+        let artifactsDirectoryURL = rootDirectoryURL
+            .appendingPathComponent("retry-session-\(index)", isDirectory: true)
+        try FileManager.default.createDirectory(at: artifactsDirectoryURL, withIntermediateDirectories: true)
+        let audioFileURL = artifactsDirectoryURL.appendingPathComponent("recording.m4a")
+        try Data("audio".utf8).write(to: audioFileURL)
+        let pendingTranscription = PendingTranscription(
+            audioFileName: audioFileURL.lastPathComponent,
+            failureReason: .missingAPIKey,
+            preservedAt: Date(timeIntervalSince1970: TimeInterval(index))
+        )
+        let session = TranscriptSession(
+            id: sessionID,
+            createdAt: Date(timeIntervalSince1970: TimeInterval(index)),
+            transcript: "",
+            duration: 4,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            pendingTranscription: pendingTranscription,
+            artifactsDirectoryPath: artifactsDirectoryURL.path
+        )
+        return PendingTranscriptionRetryContext(
+            session: session,
+            pendingTranscription: pendingTranscription,
+            audioFileURL: audioFileURL
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class RetryTranscriptWindowSpy {
+    var didShow = false
+}
+
+@MainActor
+private final class RetrySettingsWindowSpy {
+    var didShow = false
+}


### PR DESCRIPTION
Closes #231

## Summary
- add RetryPostTranscriptionResultHandler for retry pipeline result side effects
- delegate retry post-transcription completion handling from AppState
- cover retry success, debug-mode retention, persistence failure, and post-transcription failure handling

## Local validation
- git diff --check
- git diff --cached --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RetryPostTranscriptionResultHandlerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e /tmp event with origin/main base SHA