### PR TITLE
ARCH: Move retry transcription failure handling out of AppState (#235)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */; };
 		229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
 		231A00000000000000000001 /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */; };
+		235A00000000000000000001 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */; };
 		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
 		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
 		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
@@ -258,6 +259,7 @@
 		227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
 		229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
+		235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailureHandlerTests.swift; sourceTree = "<group>"; };
 		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -399,6 +401,7 @@
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
+				235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */,
 				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
 				227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */,
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
@@ -762,6 +765,7 @@
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,
+				235A00000000000000000001 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */,
 				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,
 				227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */,
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -46,6 +46,7 @@ final class AppState: ObservableObject {
     let localDataDeletionController: LocalDataDeletionController
     let transcriptionRecovery: TranscriptionRecoveryController
     let retryTranscriptionStatusPresenter: RetryTranscriptionStatusPresenter
+    let pendingTranscriptionRetryFailureHandler: PendingTranscriptionRetryFailureHandler
     let retryableSessionPreservationPresenter: RetryableSessionPreservationPresenter
     let screenshotCoordinator: ScreenshotCoordinator
     let screenshotCaptureController: ScreenshotCaptureController
@@ -420,6 +421,11 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() },
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
+        )
+        self.pendingTranscriptionRetryFailureHandler = PendingTranscriptionRetryFailureHandler(
+            transcriptionRecovery: self.transcriptionRecovery,
+            recordingSessionController: recordingSessionController,
+            retryStatusPresenter: self.retryTranscriptionStatusPresenter
         )
         self.retryableSessionPreservationPresenter = RetryableSessionPreservationPresenter(
             errorPresenter: self.errorPresenter,
@@ -984,12 +990,7 @@ final class AppState: ObservableObject {
             )
             retryPostTranscriptionResultHandler.handle(pipelineResult, context: retryContext)
         } catch {
-            if handlePendingTranscriptionRetryFailure(error, context: retryContext) {
-                return
-            }
-
-            transcriptionRecovery.finishRetry()
-            retryTranscriptionStatusPresenter.presentFailure(error)
+            pendingTranscriptionRetryFailureHandler.handle(error, context: retryContext)
         }
     }
 
@@ -1232,19 +1233,6 @@ final class AppState: ObservableObject {
                 "attempt_count": "\(context.pendingTranscription.attemptCount + 1)"
             ]
         )
-    }
-
-    private func handlePendingTranscriptionRetryFailure(
-        _ error: Error,
-        context: PendingTranscriptionRetryContext
-    ) -> Bool {
-        guard let retryFailure = transcriptionRecovery.recordRetryableFailure(error, context: context) else {
-            return false
-        }
-
-        recordingSessionController.endActivity()
-        retryTranscriptionStatusPresenter.presentRetryableFailure(retryFailure)
-        return true
     }
 
     private func preserveRetryableSession(

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -60,6 +60,34 @@ final class RetryTranscriptionStatusPresenter {
 }
 
 @MainActor
+final class PendingTranscriptionRetryFailureHandler {
+    private let transcriptionRecovery: TranscriptionRecoveryController
+    private let recordingSessionController: RecordingSessionController
+    private let retryStatusPresenter: RetryTranscriptionStatusPresenter
+
+    init(
+        transcriptionRecovery: TranscriptionRecoveryController,
+        recordingSessionController: RecordingSessionController,
+        retryStatusPresenter: RetryTranscriptionStatusPresenter
+    ) {
+        self.transcriptionRecovery = transcriptionRecovery
+        self.recordingSessionController = recordingSessionController
+        self.retryStatusPresenter = retryStatusPresenter
+    }
+
+    func handle(_ error: Error, context: PendingTranscriptionRetryContext) {
+        guard let retryFailure = transcriptionRecovery.recordRetryableFailure(error, context: context) else {
+            transcriptionRecovery.finishRetry()
+            retryStatusPresenter.presentFailure(error)
+            return
+        }
+
+        recordingSessionController.endActivity()
+        retryStatusPresenter.presentRetryableFailure(retryFailure)
+    }
+}
+
+@MainActor
 final class RetryableSessionPreservationPresenter {
     private let errorPresenter: AppErrorPresenter
     private let showTranscriptWindow: () -> Void

--- a/Tests/BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests.swift
+++ b/Tests/BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class PendingTranscriptionRetryFailureHandlerTests: XCTestCase {
+    func testRecoverableFailureUpdatesPendingSessionFinishesRetryAndPresentsRecovery() throws {
+        let harness = try PendingTranscriptionRetryFailureHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(attemptCount: 1)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(AppError.invalidAPIKey, context: context)
+
+        let updatedSession = try XCTUnwrap(harness.transcriptStore.session(with: context.session.id))
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertEqual(updatedSession.pendingTranscription?.failureReason, .invalidAPIKey)
+        XCTAssertEqual(updatedSession.pendingTranscription?.attemptCount, 2)
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .invalidAPIKey)
+        XCTAssertTrue(harness.transcriptWindowSpy.didShow)
+        XCTAssertTrue(harness.settingsWindowSpy.didShow)
+    }
+
+    func testNonrecoverableFailureFinishesRetryAndPresentsFailure() throws {
+        let harness = try PendingTranscriptionRetryFailureHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext()
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        harness.handler.handle(AppError.transcriptionFailure("Network unavailable."), context: context)
+
+        let storedSession = try XCTUnwrap(harness.transcriptStore.session(with: context.session.id))
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertEqual(storedSession.pendingTranscription?.failureReason, .missingAPIKey)
+        XCTAssertEqual(storedSession.pendingTranscription?.attemptCount, 0)
+        XCTAssertEqual(harness.presentationState.status.phase, .error)
+        XCTAssertEqual(harness.presentationState.currentError, .transcriptionFailure("Network unavailable."))
+        XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+        XCTAssertFalse(harness.settingsWindowSpy.didShow)
+    }
+}
+
+@MainActor
+private final class PendingTranscriptionRetryFailureHandlerHarness {
+    let rootDirectoryURL: URL
+    let transcriptStore: TranscriptStore
+    let sessionLibrary: SessionLibraryController
+    let recordingSessionController: RecordingSessionController
+    let transcriptionRecovery: TranscriptionRecoveryController
+    let presentationState: AppPresentationState
+    let transcriptWindowSpy = PendingRetryTranscriptWindowSpy()
+    let settingsWindowSpy = PendingRetrySettingsWindowSpy()
+    let handler: PendingTranscriptionRetryFailureHandler
+
+    init() throws {
+        let fileManager = FileManager.default
+        rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("PendingTranscriptionRetryFailureHandlerTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        transcriptStore = TranscriptStore(
+            fileManager: fileManager,
+            storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"),
+            sessionDataProtector: PlaintextSessionDataProtector()
+        )
+        let artifactsService = MockArtifactsService(
+            rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts", isDirectory: true)
+        )
+        sessionLibrary = SessionLibraryController(
+            transcriptStore: transcriptStore,
+            artifactsService: artifactsService,
+            clipboardService: MockClipboardService()
+        )
+        let audioRecorder = MockAudioRecorder()
+        recordingSessionController = RecordingSessionController(
+            audioRecorder: audioRecorder,
+            microphonePermissionService: MicrophonePermissionService(permissionAccess: audioRecorder),
+            artifactsService: artifactsService,
+            recordingTimer: RecordingTimerViewModel()
+        )
+        transcriptionRecovery = TranscriptionRecoveryController(
+            sessionLibrary: sessionLibrary,
+            artifactsService: artifactsService
+        )
+        presentationState = AppPresentationState()
+        let errorPresenter = AppErrorPresenter(
+            presentationState: presentationState,
+            telemetryRecorder: MockOperationalTelemetryRecorder()
+        )
+        let retryStatusPresenter = RetryTranscriptionStatusPresenter(
+            errorPresenter: errorPresenter,
+            showSettingsWindow: { [settingsWindowSpy] in
+                settingsWindowSpy.didShow = true
+            },
+            showTranscriptWindow: { [transcriptWindowSpy] in
+                transcriptWindowSpy.didShow = true
+            }
+        )
+        handler = PendingTranscriptionRetryFailureHandler(
+            transcriptionRecovery: transcriptionRecovery,
+            recordingSessionController: recordingSessionController,
+            retryStatusPresenter: retryStatusPresenter
+        )
+    }
+
+    func makeRetryContext(attemptCount: Int = 0) throws -> PendingTranscriptionRetryContext {
+        let sessionID = UUID()
+        let artifactsDirectoryURL = rootDirectoryURL
+            .appendingPathComponent("retry-session-\(sessionID.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: artifactsDirectoryURL, withIntermediateDirectories: true)
+        let audioFileURL = artifactsDirectoryURL.appendingPathComponent("recording.m4a")
+        try Data("audio".utf8).write(to: audioFileURL)
+        let pendingTranscription = PendingTranscription(
+            audioFileName: audioFileURL.lastPathComponent,
+            failureReason: .missingAPIKey,
+            preservedAt: Date(timeIntervalSince1970: 1),
+            attemptCount: attemptCount
+        )
+        let session = TranscriptSession(
+            id: sessionID,
+            createdAt: Date(timeIntervalSince1970: 1),
+            transcript: "",
+            duration: 8,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            pendingTranscription: pendingTranscription,
+            artifactsDirectoryPath: artifactsDirectoryURL.path
+        )
+        try transcriptStore.add(session)
+        return PendingTranscriptionRetryContext(
+            session: session,
+            pendingTranscription: pendingTranscription,
+            audioFileURL: audioFileURL
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class PendingRetryTranscriptWindowSpy {
+    var didShow = false
+}
+
+@MainActor
+private final class PendingRetrySettingsWindowSpy {
+    var didShow = false
+}


### PR DESCRIPTION
Closes #235

## Summary
- add PendingTranscriptionRetryFailureHandler for retry catch-branch side effects
- delegate retry API failure handling from AppState
- cover recoverable provider failures and nonrecoverable retry failures

## Local validation
- git diff --check
- git diff --cached --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests -only-testing:BugNarratorTests/AppStateTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e /tmp event with origin/main base SHA