### PR TITLE
BUG: Ignore empty recovered recording files (#237)

### DIFF
--- a/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
+++ b/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
@@ -37,7 +37,7 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
                 includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
                 options: [.skipsHiddenFiles]
             )
-            .filter(Self.isRecoverableAudioFile)
+            .filter(Self.isImportableAudioFile)
             .filter { !alreadyImported.contains($0.lastPathComponent) }
             .sorted {
                 modificationDate(for: $0) > modificationDate(for: $1)
@@ -132,6 +132,15 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
 
     private static func isRecoverableAudioFile(_ url: URL) -> Bool {
         supportedAudioExtensions.contains(url.pathExtension.lowercased())
+    }
+
+    private static func isImportableAudioFile(_ url: URL) -> Bool {
+        isRecoverableAudioFile(url) && fileSize(for: url) > 0
+    }
+
+    private static func fileSize(for url: URL) -> Int {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+        return values?.fileSize ?? 0
     }
 
     private func modificationDate(for url: URL) -> Date {

--- a/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
+++ b/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
@@ -100,6 +100,23 @@ final class RecoveredRecordingImporterTests: XCTestCase {
         XCTAssertTrue(store.sessions.isEmpty)
     }
 
+    func testImporterIgnoresEmptyRecoveredAudioFiles() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+        try Data().write(to: recoveryDirectoryURL.appendingPathComponent("empty-microphone.m4a"))
+        try Data().write(to: recoveryDirectoryURL.appendingPathComponent("empty-system-audio.wav"))
+
+        let store = TranscriptStore(storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"))
+        let artifactsService = MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts"))
+        let importer = RecoveredRecordingImporter(recoveryDirectoryURL: recoveryDirectoryURL)
+
+        XCTAssertEqual(try importer.importRecoverableRecordings(into: store, artifactsService: artifactsService), 0)
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
     private func makeTempDirectory() -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-RecoveredRecordingImporterTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #237

## Summary
- skip zero-byte recovered audio files before creating recovered sessions
- keep non-empty recovered .m4a and .wav files eligible for import
- add importer coverage for empty microphone and system-audio crash artifacts

## Local validation
- git diff --check
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RecoveredRecordingImporterTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64