### PR TITLE
BUG: End retry activity on nonrecoverable transcription failure (#241)

### DIFF
--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -208,6 +208,10 @@ final class RecordingSessionController: ObservableObject {
         pendingRecordedAudio
     }
 
+    var hasActiveProcessActivity: Bool {
+        processActivity != nil
+    }
+
     func startSession(
         statusPhase: AppStatus.Phase,
         activityReason: String

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -76,13 +76,14 @@ final class PendingTranscriptionRetryFailureHandler {
     }
 
     func handle(_ error: Error, context: PendingTranscriptionRetryContext) {
+        recordingSessionController.endActivity()
+
         guard let retryFailure = transcriptionRecovery.recordRetryableFailure(error, context: context) else {
             transcriptionRecovery.finishRetry()
             retryStatusPresenter.presentFailure(error)
             return
         }
 
-        recordingSessionController.endActivity()
         retryStatusPresenter.presentRetryableFailure(retryFailure)
     }
 }

--- a/Tests/BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests.swift
+++ b/Tests/BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests.swift
@@ -46,11 +46,14 @@ final class PendingTranscriptionRetryFailureHandlerTests: XCTestCase {
         let context = try harness.makeRetryContext()
 
         XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+        harness.recordingSessionController.beginActivity(reason: "Retrying transcription from preserved audio")
+        XCTAssertTrue(harness.recordingSessionController.hasActiveProcessActivity)
 
         harness.handler.handle(AppError.transcriptionFailure("Network unavailable."), context: context)
 
         let storedSession = try XCTUnwrap(harness.transcriptStore.session(with: context.session.id))
         XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertFalse(harness.recordingSessionController.hasActiveProcessActivity)
         XCTAssertEqual(storedSession.pendingTranscription?.failureReason, .missingAPIKey)
         XCTAssertEqual(storedSession.pendingTranscription?.attemptCount, 0)
         XCTAssertEqual(harness.presentationState.status.phase, .error)


### PR DESCRIPTION
Closes #241

## Summary
- end retry process activity for both retryable and nonrecoverable retry failures
- expose active process activity state for internal test coverage
- add nonrecoverable retry failure coverage for activity cleanup

## Local validation
- git diff --check
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/PendingTranscriptionRetryFailureHandlerTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64