### PR TITLE
BUG: Reject empty preserved retry audio at final path (#243)

### DIFF
--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -367,28 +367,31 @@ final class TranscriptionRecoveryController: ObservableObject {
             sourceFileURL: recordedAudio.fileURL
         )
 
-        if fileManager.fileExists(atPath: preservedAudioURL.path) {
-            try fileManager.removeItem(at: preservedAudioURL)
+        let sourceAlreadyPreserved = recordedAudio.fileURL.standardizedFileURL == preservedAudioURL.standardizedFileURL
+
+        if !sourceAlreadyPreserved {
+            if fileManager.fileExists(atPath: preservedAudioURL.path) {
+                try fileManager.removeItem(at: preservedAudioURL)
+            }
+
+            try fileManager.copyItem(at: recordedAudio.fileURL, to: preservedAudioURL)
         }
 
-        if recordedAudio.fileURL.standardizedFileURL == preservedAudioURL.standardizedFileURL {
-            return preservedAudioURL
-        }
-
-        try fileManager.copyItem(at: recordedAudio.fileURL, to: preservedAudioURL)
-
-        let attributes = try fileManager.attributesOfItem(atPath: preservedAudioURL.path)
-        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
-        guard fileSize > 0 else {
-            throw AppError.recordingFailure("The preserved audio file was empty.")
-        }
-
+        try validatePreservedAudio(at: preservedAudioURL)
         recordingLogger.info(
             "recorded_audio_preserved_for_retry",
             "Preserved the finished recording for a later transcription retry.",
             metadata: ["file_name": preservedAudioURL.lastPathComponent]
         )
         return preservedAudioURL
+    }
+
+    private func validatePreservedAudio(at preservedAudioURL: URL) throws {
+        let attributes = try fileManager.attributesOfItem(atPath: preservedAudioURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            throw AppError.recordingFailure("The preserved audio file was empty.")
+        }
     }
 
 }

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -148,6 +148,55 @@ final class TranscriptionRecoveryControllerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: try XCTUnwrap(session.pendingTranscriptionAudioURL).path))
     }
 
+    func testPreserveRetryableSessionKeepsSamePathAudioAndStoresPendingSession() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        let audioURL = recordingSession.artifactsDirectoryURL
+            .appendingPathComponent("recording")
+            .appendingPathExtension("m4a")
+        let recordedAudio = try harness.makeRecordedAudio(fileURL: audioURL, contents: "audio")
+
+        let result = harness.controller.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: harness.request,
+            failureReason: .invalidAPIKey
+        )
+
+        guard case .preserved(let session, _) = result else {
+            return XCTFail("Expected retryable session preservation.")
+        }
+        XCTAssertEqual(session.pendingTranscriptionAudioURL?.standardizedFileURL, audioURL.standardizedFileURL)
+        XCTAssertEqual(try String(contentsOf: audioURL, encoding: .utf8), "audio")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
+    func testPreserveRetryableSessionRejectsEmptySamePathAudio() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        let audioURL = recordingSession.artifactsDirectoryURL
+            .appendingPathComponent("recording")
+            .appendingPathExtension("m4a")
+        let recordedAudio = try harness.makeRecordedAudio(fileURL: audioURL, contents: "")
+
+        let result = harness.controller.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: harness.request,
+            failureReason: .invalidAPIKey
+        )
+
+        guard case .preservationFailure(let error as AppError) = result else {
+            return XCTFail("Expected empty preserved audio to fail preservation.")
+        }
+        XCTAssertEqual(error, .recordingFailure("The preserved audio file was empty."))
+        XCTAssertNil(harness.transcriptStore.session(with: recordingSession.sessionID))
+    }
+
     func testPreserveRetryableSessionPersistenceFailureStagesCurrentTranscript() throws {
         let harness = try TranscriptionRecoveryControllerHarness()
         defer { harness.cleanup() }
@@ -279,6 +328,10 @@ private struct TranscriptionRecoveryControllerHarness {
 
     func makeRecordedAudio(fileName: String, contents: String) throws -> RecordedAudio {
         let fileURL = rootDirectoryURL.appendingPathComponent(fileName).appendingPathExtension("m4a")
+        return try makeRecordedAudio(fileURL: fileURL, contents: contents)
+    }
+
+    func makeRecordedAudio(fileURL: URL, contents: String) throws -> RecordedAudio {
         try Data(contents.utf8).write(to: fileURL)
         return RecordedAudio(fileURL: fileURL, duration: 3)
     }


### PR DESCRIPTION
Closes #243

## Summary
- avoid deleting recorded audio when it is already at the final preserved retry URL
- validate preserved retry audio size in both copied and same-path cases
- add same-path non-empty and zero-byte coverage for retryable preservation

## Local validation
- git diff --check
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64