### PR TITLE
BUG: Ignore non-file recovered recording artifacts (#245)

### DIFF
--- a/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
+++ b/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
@@ -34,7 +34,7 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
         let audioFiles = try fileManager
             .contentsOfDirectory(
                 at: recoveryDirectoryURL,
-                includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+                includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey, .isRegularFileKey],
                 options: [.skipsHiddenFiles]
             )
             .filter(Self.isImportableAudioFile)
@@ -135,7 +135,12 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
     }
 
     private static func isImportableAudioFile(_ url: URL) -> Bool {
-        isRecoverableAudioFile(url) && fileSize(for: url) > 0
+        isRecoverableAudioFile(url) && isRegularFile(url) && fileSize(for: url) > 0
+    }
+
+    private static func isRegularFile(_ url: URL) -> Bool {
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+        return values?.isRegularFile == true
     }
 
     private static func fileSize(for url: URL) -> Int {

--- a/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
+++ b/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
@@ -117,6 +117,29 @@ final class RecoveredRecordingImporterTests: XCTestCase {
         XCTAssertTrue(store.sessions.isEmpty)
     }
 
+    func testImporterIgnoresRecoveredAudioDirectories() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: recoveryDirectoryURL.appendingPathComponent("directory-microphone.m4a", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: recoveryDirectoryURL.appendingPathComponent("directory-system-audio.wav", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let store = TranscriptStore(storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"))
+        let artifactsService = MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts"))
+        let importer = RecoveredRecordingImporter(recoveryDirectoryURL: recoveryDirectoryURL)
+
+        XCTAssertEqual(try importer.importRecoverableRecordings(into: store, artifactsService: artifactsService), 0)
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
     private func makeTempDirectory() -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-RecoveredRecordingImporterTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #245

## Summary
- require recovered recording candidates to be regular files
- keep non-empty .m4a and .wav regular-file recovery imports working
- add regression coverage for .m4a/.wav directories being ignored

## Local validation
- git diff --check
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RecoveredRecordingImporterTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64