### PR TITLE
BUG: Preserve retina screenshot pixel dimensions (#247)

### DIFF
--- a/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
+++ b/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
@@ -313,8 +313,9 @@ struct ScreenshotCaptureService: ScreenshotCapturing {
             throw AppError.screenshotCaptureFailure("No display content was available to capture.")
         }
 
-        let width = Int(compositeBounds.width.rounded(.up))
-        let height = Int(compositeBounds.height.rounded(.up))
+        let scale = compositeScale(for: capturedDisplays)
+        let width = Int((compositeBounds.width * scale).rounded(.up))
+        let height = Int((compositeBounds.height * scale).rounded(.up))
         let colorSpace = capturedDisplays.first?.image.colorSpace ?? CGColorSpaceCreateDeviceRGB()
 
         guard let context = CGContext(
@@ -330,6 +331,7 @@ struct ScreenshotCaptureService: ScreenshotCapturing {
         }
 
         context.interpolationQuality = .high
+        context.scaleBy(x: scale, y: scale)
 
         for capturedDisplay in capturedDisplays {
             let frame = capturedDisplay.capturedFrame
@@ -347,6 +349,19 @@ struct ScreenshotCaptureService: ScreenshotCapturing {
         }
 
         return image
+    }
+
+    private func compositeScale(for capturedDisplays: [CapturedDisplayImage]) -> CGFloat {
+        capturedDisplays.reduce(CGFloat(1)) { currentScale, capturedDisplay in
+            let frame = capturedDisplay.capturedFrame
+            guard frame.width > 0, frame.height > 0 else {
+                return currentScale
+            }
+
+            let scaleX = CGFloat(capturedDisplay.image.width) / frame.width
+            let scaleY = CGFloat(capturedDisplay.image.height) / frame.height
+            return max(currentScale, scaleX, scaleY)
+        }
     }
 
     private func validateCapturedScreenshotFile(at url: URL) throws {

--- a/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
@@ -94,6 +94,39 @@ final class ScreenshotCaptureServiceTests: XCTestCase {
         XCTAssertEqual(provider.requestedSourceRects, [CGRect(x: 10, y: 20, width: 30, height: 40)])
     }
 
+    func testCaptureScreenshotPreservesRetinaPixelDimensions() async throws {
+        let temporaryRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let display = ScreenCaptureDisplaySnapshot(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            pixelWidth: 200,
+            pixelHeight: 200
+        )
+
+        let provider = MockScreenCaptureImageProvider(
+            displays: [display],
+            imagesByDisplayID: [
+                1: try makeSolidImage(width: 60, height: 80, color: CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+            ]
+        )
+
+        let service = ScreenshotCaptureService(
+            imageProvider: provider,
+            imageWriter: PNGScreenshotImageWriter()
+        )
+
+        let outputURL = temporaryRoot.appendingPathComponent("capture.png")
+        try await service.captureScreenshot(in: CGRect(x: 10, y: 20, width: 30, height: 40), to: outputURL)
+
+        let imageSource = try XCTUnwrap(CGImageSourceCreateWithURL(outputURL as CFURL, nil))
+        let properties = try XCTUnwrap(CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any])
+        XCTAssertEqual(properties[kCGImagePropertyPixelWidth] as? Int, 60)
+        XCTAssertEqual(properties[kCGImagePropertyPixelHeight] as? Int, 80)
+        XCTAssertEqual(provider.requestedSourceRects, [CGRect(x: 10, y: 20, width: 30, height: 40)])
+    }
+
     func testCaptureScreenshotFailsWhenNoDisplaysAreAvailable() async {
         let service = ScreenshotCaptureService(
             imageProvider: MockScreenCaptureImageProvider(displays: []),


### PR DESCRIPTION
Closes #247

## Summary
- composite screenshots at the captured display pixel scale instead of point dimensions
- keep 1x display screenshot dimensions unchanged
- add 2x display coverage for saving a 60x80 PNG from a 30x40 point selection

## Local validation
- git diff --check
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/ScreenshotCaptureServiceTests
- ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64