### PR TITLE
BUG: Remove force-unwrapped diagnostics redaction regexes

### DIFF
--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -427,11 +427,11 @@ enum DiagnosticsRedactor {
     ]
 
     private static let tokenPatterns: [NSRegularExpression] = [
-        try! NSRegularExpression(pattern: #"sk-[A-Za-z0-9_-]+"#),
-        try! NSRegularExpression(pattern: #"github_pat_[A-Za-z0-9_]+"#),
-        try! NSRegularExpression(pattern: #"gh[pousr]_[A-Za-z0-9]+"#, options: [.caseInsensitive]),
-        try! NSRegularExpression(pattern: #"Bearer\s+[A-Za-z0-9._\-]+"#, options: [.caseInsensitive])
-    ]
+        makeTokenPattern(#"sk-[A-Za-z0-9_-]+"#),
+        makeTokenPattern(#"github_pat_[A-Za-z0-9_]+"#),
+        makeTokenPattern(#"gh[pousr]_[A-Za-z0-9]+"#, options: [.caseInsensitive]),
+        makeTokenPattern(#"Bearer\s+[A-Za-z0-9._\-]+"#, options: [.caseInsensitive])
+    ].compactMap { $0 }
 
     static func sensitiveValues(in metadata: [String: String]) -> [String] {
         var values = Set<String>()
@@ -505,5 +505,12 @@ enum DiagnosticsRedactor {
         }
 
         return sanitizeFreeformText(value) != value
+    }
+
+    private static func makeTokenPattern(
+        _ pattern: String,
+        options: NSRegularExpression.Options = []
+    ) -> NSRegularExpression? {
+        try? NSRegularExpression(pattern: pattern, options: options)
     }
 }

--- a/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
+++ b/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
@@ -2,6 +2,20 @@ import XCTest
 @testable import BugNarrator
 
 final class DiagnosticsLoggerTests: XCTestCase {
+    func testFreeformRedactionSanitizesKnownTokenPatterns() {
+        let sanitized = DiagnosticsRedactor.sanitizeFreeformText(
+            """
+            OpenAI sk-test_TOKEN-123 GitHub github_pat_testTOKEN123 cli ghp_TESTTOKEN123 header Bearer test.token-123
+            """
+        )
+
+        XCTAssertTrue(sanitized.contains("<redacted>"))
+        XCTAssertFalse(sanitized.contains("sk-test_TOKEN-123"))
+        XCTAssertFalse(sanitized.contains("github_pat_testTOKEN123"))
+        XCTAssertFalse(sanitized.contains("ghp_TESTTOKEN123"))
+        XCTAssertFalse(sanitized.contains("Bearer test.token-123"))
+    }
+
     func testLoggerRedactsCredentialsFromMetadataAndMessage() async {
         BugNarratorDiagnostics.setDebugModeEnabled(true)
         let storageURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
Closes #251

## Summary
- Compile diagnostics token-redaction regexes without force unwraps
- Keep redaction best-effort if a future pattern fails to compile
- Add direct coverage for OpenAI, GitHub PAT, gh-token, and Bearer-token freeform redaction

## Local validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/DiagnosticsLoggerTests
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e <generated PR event>