### PR TITLE
BUG: Avoid crash when Application Support URL is unavailable

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
 		121A00000000000000000001 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000003 /* AppUtilityActionController.swift */; };
 		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
+		253A00000000000000000001 /* AppSupportLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253A00000000000000000002 /* AppSupportLocationTests.swift */; };
 		125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000003 /* ApplicationTerminationController.swift */; };
 		125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */; };
 		127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000003 /* ScreenshotCaptureController.swift */; };
@@ -244,6 +245,7 @@
 		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
 		121A00000000000000000003 /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
 		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
+		253A00000000000000000002 /* AppSupportLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocationTests.swift; sourceTree = "<group>"; };
 		125A00000000000000000003 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
 		125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
 		127A00000000000000000003 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				117A00000000000000000004 /* AppErrorPresenterTests.swift */,
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
 				121A00000000000000000004 /* AppUtilityActionControllerTests.swift */,
+				253A00000000000000000002 /* AppSupportLocationTests.swift */,
 				125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				131A00000000000000000004 /* DebugSessionContextProviderTests.swift */,
@@ -746,6 +749,7 @@
 				117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */,
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
 				121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */,
+				253A00000000000000000001 /* AppSupportLocationTests.swift in Sources */,
 				125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
 				131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */,

--- a/Sources/BugNarrator/Utilities/AppSupportLocation.swift
+++ b/Sources/BugNarrator/Utilities/AppSupportLocation.swift
@@ -5,7 +5,7 @@ enum AppSupportLocation {
     private static let legacyAppDirectoryNames = ["SessionMic"]
 
     static func appDirectory(fileManager: FileManager = .default) -> URL {
-        let baseURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let baseURL = applicationSupportBaseURL(fileManager: fileManager)
         let currentDirectoryURL = baseURL.appendingPathComponent(currentAppDirectoryName, isDirectory: true)
 
         migrateLegacyDirectoryIfNeeded(
@@ -19,6 +19,14 @@ enum AppSupportLocation {
         }
 
         return currentDirectoryURL
+    }
+
+    private static func applicationSupportBaseURL(fileManager: FileManager) -> URL {
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ??
+            fileManager.temporaryDirectory.appendingPathComponent(
+                "\(currentAppDirectoryName)-ApplicationSupportFallback",
+                isDirectory: true
+            )
     }
 
     private static func migrateLegacyDirectoryIfNeeded(

--- a/Tests/BugNarratorTests/AppSupportLocationTests.swift
+++ b/Tests/BugNarratorTests/AppSupportLocationTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import BugNarrator
+
+final class AppSupportLocationTests: XCTestCase {
+    func testAppDirectoryFallsBackWhenApplicationSupportURLIsUnavailable() {
+        let fileManager = StubApplicationSupportFileManager(applicationSupportURLs: [])
+
+        let appDirectoryURL = AppSupportLocation.appDirectory(fileManager: fileManager)
+        defer { try? FileManager.default.removeItem(at: appDirectoryURL.deletingLastPathComponent()) }
+
+        XCTAssertEqual(appDirectoryURL.lastPathComponent, "BugNarrator")
+        XCTAssertEqual(appDirectoryURL.deletingLastPathComponent().lastPathComponent, "BugNarrator-ApplicationSupportFallback")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appDirectoryURL.path))
+    }
+
+    func testAppDirectoryMigratesLegacyDirectoryWhenApplicationSupportURLIsAvailable() throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let legacyDirectoryURL = rootDirectoryURL.appendingPathComponent("SessionMic", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDirectoryURL, withIntermediateDirectories: true)
+        try Data("legacy".utf8).write(to: legacyDirectoryURL.appendingPathComponent("marker.txt"))
+
+        let fileManager = StubApplicationSupportFileManager(applicationSupportURLs: [rootDirectoryURL])
+        let appDirectoryURL = AppSupportLocation.appDirectory(fileManager: fileManager)
+
+        XCTAssertEqual(appDirectoryURL, rootDirectoryURL.appendingPathComponent("BugNarrator", isDirectory: true))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appDirectoryURL.appendingPathComponent("marker.txt").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyDirectoryURL.path))
+    }
+
+    private func temporaryDirectoryURL() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+private final class StubApplicationSupportFileManager: FileManager {
+    private let applicationSupportURLs: [URL]
+
+    init(applicationSupportURLs: [URL]) {
+        self.applicationSupportURLs = applicationSupportURLs
+        super.init()
+    }
+
+    override func urls(
+        for directory: FileManager.SearchPathDirectory,
+        in domainMask: FileManager.SearchPathDomainMask
+    ) -> [URL] {
+        if directory == .applicationSupportDirectory, domainMask == .userDomainMask {
+            return applicationSupportURLs
+        }
+
+        return super.urls(for: directory, in: domainMask)
+    }
+}


### PR DESCRIPTION
Closes #253

## Summary
- Replace AppSupportLocation's Application Support force unwrap with a temporary fallback base directory
- Preserve normal BugNarrator Application Support behavior and legacy SessionMic migration
- Add focused AppSupportLocation tests and Xcode project membership

## Local validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppSupportLocationTests
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e <generated PR event>