### PR TITLE
BUG: Delete mixed recording source files after successful mix

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
+		255A00000000000000000001 /* MixedAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A00000000000000000002 /* MixedAudioRecorderTests.swift */; };
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		280973289AE78D9919ECD80C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5346EDB503C6B05C81C368 /* KeychainService.swift */; };
@@ -269,6 +270,7 @@
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
+		255A00000000000000000002 /* MixedAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorderTests.swift; sourceTree = "<group>"; };
 		52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
 		54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureService.swift; sourceTree = "<group>"; };
 		553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
@@ -403,6 +405,7 @@
 				EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */,
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
+				255A00000000000000000002 /* MixedAudioRecorderTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
 				235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */,
 				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
@@ -768,6 +771,7 @@
 				0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */,
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
+				255A00000000000000000001 /* MixedAudioRecorderTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,
 				235A00000000000000000001 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */,
 				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -110,6 +110,10 @@ final class MixedAudioRecorder: AudioRecording {
             systemAudio: systemAudio,
             outputURL: outputURL
         )
+        removeSourceAudioFiles(
+            [microphoneAudio.fileURL, systemAudio.fileURL],
+            preserving: mixedAudio.fileURL
+        )
 
         recordingLogger.info(
             "mixed_recording_stopped",
@@ -121,6 +125,13 @@ final class MixedAudioRecorder: AudioRecording {
         )
 
         return mixedAudio
+    }
+
+    private func removeSourceAudioFiles(_ sourceURLs: [URL], preserving outputURL: URL) {
+        let preservedURL = outputURL.standardizedFileURL
+        for sourceURL in sourceURLs where sourceURL.standardizedFileURL != preservedURL {
+            try? FileManager.default.removeItem(at: sourceURL)
+        }
     }
 
     func cancelRecording(preserveFile: Bool) async {

--- a/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
@@ -1,0 +1,52 @@
+import AVFoundation
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class MixedAudioRecorderTests: XCTestCase {
+    func testStopRecordingRemovesSourceFilesAfterSuccessfulMix() async throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let microphoneURL = rootDirectoryURL.appendingPathComponent("microphone.wav")
+        let systemAudioURL = rootDirectoryURL.appendingPathComponent("system.wav")
+        try writeSilentAudioFile(to: microphoneURL)
+        try writeSilentAudioFile(to: systemAudioURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: microphoneURL, duration: 0.1))
+        ]
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: systemAudioURL, duration: 0.1))
+        ]
+        let recorder = MixedAudioRecorder(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            outputDirectoryURL: rootDirectoryURL
+        )
+
+        try await recorder.startRecording()
+        let mixedAudio = try await recorder.stopRecording()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedAudio.fileURL.path))
+        XCTAssertEqual(mixedAudio.fileURL.pathExtension, "m4a")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
+    }
+
+    private func temporaryDirectoryURL() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func writeSilentAudioFile(to url: URL) throws {
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_410))
+        buffer.frameLength = 4_410
+        try file.write(from: buffer)
+    }
+}


### PR DESCRIPTION
Closes #255

## Summary
- Remove mic/system source audio files only after a mixed recording export succeeds and validates
- Preserve source files on failed mixing so recovery still has inputs
- Add MixedAudioRecorder coverage using real short audio files

## Local validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/MixedAudioRecorderTests
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/validate.sh origin/main
- act pull_request -j runtime-guardrails --container-architecture linux/amd64 -e <generated PR event>