### PR TITLE
Add signed Windows tester release path

### DIFF
--- a/.github/workflows/windows-tester-release.yml
+++ b/.github/workflows/windows-tester-release.yml
@@ -54,12 +54,13 @@ jobs:
         shell: pwsh
         env:
           BUGNARRATOR_CERT_PASSWORD: ${{ secrets.BUGNARRATOR_WINDOWS_CERT_PASSWORD }}
+          RELEASE_RUNTIME: ${{ inputs.runtime }}
         run: |
           if (-not $env:BUGNARRATOR_CERT_PASSWORD) {
             throw "Repository secret BUGNARRATOR_WINDOWS_CERT_PASSWORD is required for a real signed Windows tester release."
           }
           powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 `
-            -Runtime "${{ inputs.runtime }}"
+            -Runtime "$env:RELEASE_RUNTIME"
 
       - name: Upload signed package evidence
         uses: actions/upload-artifact@v4
@@ -75,19 +76,23 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_DRAFT: ${{ inputs.draft }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_RUNTIME: ${{ inputs.runtime }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           $args = @(
-            "release", "create", "${{ inputs.tag }}",
-            "windows/artifacts/packages/BugNarrator-windows-${{ inputs.runtime }}.zip",
-            "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-signature.json",
-            "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-validation.json",
-            "--title", "BugNarrator Windows tester ${{ inputs.tag }}",
-            "--notes-file", "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-release-notes.md"
+            "release", "create", "$env:RELEASE_TAG",
+            "windows/artifacts/packages/BugNarrator-windows-$env:RELEASE_RUNTIME.zip",
+            "windows/artifacts/validation/BugNarrator-windows-$env:RELEASE_RUNTIME-signature.json",
+            "windows/artifacts/validation/BugNarrator-windows-$env:RELEASE_RUNTIME-validation.json",
+            "--title", "BugNarrator Windows tester $env:RELEASE_TAG",
+            "--notes-file", "windows/artifacts/validation/BugNarrator-windows-$env:RELEASE_RUNTIME-release-notes.md"
           )
-          if ("${{ inputs.draft }}" -eq "true") {
+          if ("$env:RELEASE_DRAFT" -eq "true") {
             $args += "--draft"
           }
-          if ("${{ inputs.prerelease }}" -eq "true") {
+          if ("$env:RELEASE_PRERELEASE" -eq "true") {
             $args += "--prerelease"
           }
           gh @args

--- a/.github/workflows/windows-tester-release.yml
+++ b/.github/workflows/windows-tester-release.yml
@@ -1,0 +1,101 @@
+name: Windows Tester Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create or update, for example windows-tester-v0.1.0"
+        required: true
+        type: string
+      runtime:
+        description: "Windows runtime identifier"
+        required: true
+        default: "win-x64"
+        type: string
+      draft:
+        description: "Create the GitHub Release as a draft"
+        required: true
+        default: true
+        type: boolean
+      prerelease:
+        description: "Mark the GitHub Release as a prerelease"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  signed-windows-tester-release:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Decode signing certificate
+        shell: pwsh
+        env:
+          CERT_BASE64: ${{ secrets.BUGNARRATOR_WINDOWS_CERT_BASE64 }}
+        run: |
+          if (-not $env:CERT_BASE64) {
+            throw "Repository secret BUGNARRATOR_WINDOWS_CERT_BASE64 is required for a real signed Windows tester release."
+          }
+          $certPath = Join-Path $env:RUNNER_TEMP "bugnarrator-windows-signing.pfx"
+          [System.IO.File]::WriteAllBytes($certPath, [System.Convert]::FromBase64String($env:CERT_BASE64))
+          "BUGNARRATOR_CERT_PATH=$certPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build signed tester package
+        shell: pwsh
+        env:
+          BUGNARRATOR_CERT_PASSWORD: ${{ secrets.BUGNARRATOR_WINDOWS_CERT_PASSWORD }}
+        run: |
+          if (-not $env:BUGNARRATOR_CERT_PASSWORD) {
+            throw "Repository secret BUGNARRATOR_WINDOWS_CERT_PASSWORD is required for a real signed Windows tester release."
+          }
+          powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 `
+            -Runtime "${{ inputs.runtime }}"
+
+      - name: Upload signed package evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: bugnarrator-windows-signed-tester-release
+          path: |
+            windows/artifacts/packages/BugNarrator-windows-${{ inputs.runtime }}.zip
+            windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-signature.json
+            windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-validation.json
+            windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-release-notes.md
+
+      - name: Publish GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $args = @(
+            "release", "create", "${{ inputs.tag }}",
+            "windows/artifacts/packages/BugNarrator-windows-${{ inputs.runtime }}.zip",
+            "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-signature.json",
+            "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-validation.json",
+            "--title", "BugNarrator Windows tester ${{ inputs.tag }}",
+            "--notes-file", "windows/artifacts/validation/BugNarrator-windows-${{ inputs.runtime }}-release-notes.md"
+          )
+          if ("${{ inputs.draft }}" -eq "true") {
+            $args += "--draft"
+          }
+          if ("${{ inputs.prerelease }}" -eq "true") {
+            $args += "--prerelease"
+          }
+          gh @args
+
+      - name: Remove decoded signing certificate
+        if: always()
+        shell: pwsh
+        run: |
+          if ($env:BUGNARRATOR_CERT_PATH -and (Test-Path $env:BUGNARRATOR_CERT_PATH)) {
+            Remove-Item $env:BUGNARRATOR_CERT_PATH -Force
+          }

--- a/docs/architecture/parity-matrix.md
+++ b/docs/architecture/parity-matrix.md
@@ -28,14 +28,14 @@ Use [product-spec.md](product-spec.md) as the source of truth for the contracts 
 | Recording audio source selection | Shipped | In Progress | Platform-native capture allowed | Windows supports microphone and WASAPI loopback system audio. Mixed mic plus system audio is surfaced as an explicit tracked limitation until muxing is implemented. |
 | Experimental GitHub and Jira export | Shipped as experimental | In Progress | Experimental on both platforms | Windows implementation exists; real credential validation remains in #44. |
 | Keyboard-first accessibility | Shipped baseline, validated in RR-005 | In Progress | Native implementation allowed | The contract is clear keyboard and assistive-tech support, not identical widgets. |
-| Public release packaging | Shipped as signed, notarized DMG | Planned in `WIN-009` | Platform-native packaging allowed | Windows zip packaging exists; signed tester release work is tracked in #75. |
+| Public release packaging | Shipped as signed, notarized DMG | Repo-side signed tester zip path ready; certificate provisioning required | Platform-native packaging allowed | Windows first tester format is a zip containing signed `BugNarrator.Windows.exe` plus signature and package validation evidence. Installer/MSIX can follow if tester distribution requires it. |
 
 ## Current Deliberate Differences
 
 - macOS is the only production platform today.
 - Windows implements the core `record -> review -> refine -> export` path, including session library, review workspace, extraction, export, hotkeys, and hardening coverage, but it still needs real Windows runtime validation in `RR-002` / #44.
 - macOS currently has mixed microphone plus system audio capture beyond Windows; Windows surfaces the limitation explicitly while system-audio loopback support is available.
-- Windows public tester distribution is still blocked on signing/release packaging decisions tracked in #75.
+- Windows public tester distribution is blocked on external code-signing certificate provisioning, not missing repo scripts. The release entrypoint and manual GitHub Actions workflow are in place for the signed tester zip path.
 
 ## Update Rules
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -47,6 +47,7 @@ Scripted equivalents:
 powershell -ExecutionPolicy Bypass -File windows/scripts/build-windows.ps1 -Configuration Debug
 powershell -ExecutionPolicy Bypass -File windows/scripts/test-windows.ps1 -Configuration Debug
 powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release
+powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 -Runtime win-x64
 powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-package.ps1 -Runtime win-x64
 powershell -ExecutionPolicy Bypass -File windows/scripts/validate-windows-single-instance.ps1 -Runtime win-x64
 ```
@@ -64,6 +65,7 @@ Current Windows milestone status:
 - Windows audio-source parity now includes microphone recording and WASAPI loopback system-audio recording; microphone plus system audio is visible as an explicit tracked limitation until mixed-source muxing is implemented
 - automated coverage currently includes `9` core tests and `47` Windows tests
 - `windows/scripts/package-windows.ps1` currently produces a zipped self-contained `dotnet publish` artifact at `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`
+- `windows/scripts/release-windows-tester.ps1` produces the first tester release format: a zip containing a signed `BugNarrator.Windows.exe`, plus signature, package-validation, and release-note evidence under `windows/artifacts/validation/`
 - `windows/scripts/validate-windows-package.ps1` validates that the published Windows zip contains the expected executable, DLL, and runtime metadata, checks packaged-file hash parity against the publish output, then writes a structured package smoke report for CI/release evidence
 - CI now uploads `bugnarrator-windows-package` and `bugnarrator-windows-validation` artifacts from the Windows runner
 - manual validation is still required for live AI provider transcription, live issue extraction, system-audio capture on representative output devices, overlay/display behavior, DPI scaling, multi-monitor screenshot preview behavior, hotkey behavior under reserved shortcuts and alternate keyboard layouts, session deletion on a real desktop, corrupted-local-state recovery, and real GitHub/Jira credentials on a Windows desktop
@@ -71,4 +73,4 @@ Current Windows milestone status:
 Current follow-up parity tickets:
 
 - `RR-002` / #44 remains the real Windows desktop validation gate.
-- `WIN-009` / #75 tracks the signed Windows tester release path.
+- `WIN-009` / #75 now has the repository-side signed tester release path; the remaining external dependency is a real Windows code-signing certificate configured outside the repo.

--- a/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
+++ b/windows/docs/WINDOWS_IMPLEMENTATION_ROADMAP.md
@@ -586,6 +586,13 @@ Deliverables:
 - validate the signed artifact on a clean Windows machine
 - publish release notes and validation evidence
 
+Current status:
+
+- the first tester artifact is a signed zip containing `BugNarrator.Windows.exe`
+- `windows/scripts/release-windows-tester.ps1` packages, signs, verifies Authenticode status, repacks, validates, and writes release evidence
+- `.github/workflows/windows-tester-release.yml` can publish the signed package and evidence to GitHub Releases when real signing secrets are configured
+- the remaining blocker is external certificate provisioning, not repository wiring
+
 Tracking:
 
 - GitHub issue #75

--- a/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
+++ b/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
@@ -15,7 +15,7 @@ That script publishes `BugNarrator.Windows.csproj` for `win-x64` by default and 
 - `windows/artifacts/publish/<runtime>/`
 - `windows/artifacts/packages/BugNarrator-windows-<runtime>.zip`
 
-This is sufficient for internal validation and external handoff while installer work remains deferred. The package includes the .NET runtime for the target runtime identifier so tester machines do not need a matching desktop runtime installed first. The signed tester release work is tracked in GitHub issue #75.
+This is sufficient for internal validation and external handoff while installer work remains deferred. The first tester release format is a zip that contains a signed `BugNarrator.Windows.exe`, package validation evidence, and release notes. Installer or MSIX authoring remains a follow-up if tester distribution needs a more guided install path.
 
 CI now validates the packaged zip contents and writes a structured package smoke report before uploading the Windows artifact from `windows-latest`. This improves release-candidate confidence, but it does not replace a real desktop validation pass for tray, microphone, screenshot, or hotkey behavior.
 
@@ -32,11 +32,18 @@ For release packaging, run:
 
 - `powershell -ExecutionPolicy Bypass -File windows/scripts/package-windows.ps1 -Configuration Release`
 
+For a signed tester release package, run on Windows:
+
+- `powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 -Runtime win-x64`
+
 ## Signing
 
 The repo now includes:
 
 - `windows/scripts/sign-windows.ps1`
+- `windows/scripts/verify-windows-signature.ps1`
+- `windows/scripts/release-windows-tester.ps1`
+- `.github/workflows/windows-tester-release.yml`
 
 Required environment variables:
 
@@ -52,6 +59,17 @@ powershell -ExecutionPolicy Bypass -File windows/scripts/sign-windows.ps1 `
   -FilePath windows/artifacts/publish/win-x64/BugNarrator.Windows.exe
 ```
 
+The release script packages the app, signs `BugNarrator.Windows.exe`, verifies the Authenticode signature with `Get-AuthenticodeSignature`, repacks the signed publish output into `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`, reruns package validation, and writes:
+
+- `windows/artifacts/validation/BugNarrator-windows-win-x64-signature.json`
+- `windows/artifacts/validation/BugNarrator-windows-win-x64-validation.json`
+- `windows/artifacts/validation/BugNarrator-windows-win-x64-release-notes.md`
+
+The GitHub Actions workflow is manual (`workflow_dispatch`) and requires these repository secrets:
+
+- `BUGNARRATOR_WINDOWS_CERT_BASE64`: base64-encoded PFX certificate
+- `BUGNARRATOR_WINDOWS_CERT_PASSWORD`: PFX password
+
 ## Current Release Blocker
 
 The current blocker for public signed distribution is certificate availability, not the script entrypoints.
@@ -62,14 +80,14 @@ This branch does not include:
 - a CI signing secret
 - an installer authoring pipeline
 
-Until a real code-signing certificate is provisioned, release candidates should be treated as internal or trusted-tester artifacts.
+Until a real code-signing certificate is provisioned and configured in the release environment, the signed tester release workflow will fail intentionally rather than producing an unsigned artifact that looks signed.
 
 ## Recommended Next Release Steps
 
 1. Provision a Windows code-signing certificate and store it outside the repo.
-2. Produce a `Release` package with `windows/scripts/package-windows.ps1`.
-3. Sign `BugNarrator.Windows.exe` and any additional distributables with `windows/scripts/sign-windows.ps1`.
+2. Add `BUGNARRATOR_WINDOWS_CERT_BASE64` and `BUGNARRATOR_WINDOWS_CERT_PASSWORD` as GitHub repository secrets, or set `BUGNARRATOR_CERT_PATH` and `BUGNARRATOR_CERT_PASSWORD` locally.
+3. Produce a signed `Release` package with `windows/scripts/release-windows-tester.ps1`.
 4. Validate the signed build on a clean Windows machine.
-5. Upload the zip package and validation notes to GitHub Releases.
+5. Upload the zip package, signature report, package validation report, and validation notes to GitHub Releases, or use the manual `Windows Tester Release` workflow.
 
-For `WIN-009`, decide whether the first tester artifact remains a signed zip or moves to installer packaging. A signed zip is the shortest path to parity evidence; installer or MSIX work can follow if tester distribution needs it.
+Installer EXE or MSIX packaging should be tracked separately if tester feedback shows that a signed zip is not enough.

--- a/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
+++ b/windows/docs/WINDOWS_VALIDATION_CHECKLIST.md
@@ -198,9 +198,12 @@ dotnet run --project windows/src/BugNarrator.Windows/BugNarrator.Windows.csproj 
 - Probe silent output, Bluetooth/headset output, device changes, and unavailable loopback devices.
 
 ## WIN-009: Signed Tester Release
-- Produce the release package.
-- Sign the executable and distributable artifact with a certificate stored outside the repo.
-- Verify signatures and timestamps.
+- Produce the signed tester release package with `powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 -Runtime win-x64`.
+- Confirm the release package is `windows/artifacts/packages/BugNarrator-windows-win-x64.zip`.
+- Confirm the executable inside the publish output is signed with a certificate stored outside the repo.
+- Confirm `windows/artifacts/validation/BugNarrator-windows-win-x64-signature.json` reports Authenticode `Valid` status and includes the signer thumbprint.
+- Confirm `windows/artifacts/validation/BugNarrator-windows-win-x64-validation.json` exists and the packaged-file hashes match the signed publish output.
+- Confirm `windows/artifacts/validation/BugNarrator-windows-win-x64-release-notes.md` includes the artifact path, SHA-256, signature evidence path, and validation evidence path.
 - Validate the signed artifact on a clean Windows machine.
 - Record the artifact path, certificate identity, validation machine, and release notes location.
 

--- a/windows/scripts/release-windows-tester.ps1
+++ b/windows/scripts/release-windows-tester.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Release")]
+    [string]$Configuration = "Release",
+    [string]$Runtime = "win-x64",
+    [string]$OutputRoot = "windows/artifacts",
+    [string]$TimestampUrl = "http://timestamp.digicert.com",
+    [string]$DigestAlgorithm = "sha256",
+    [string]$SignToolPath = "signtool.exe",
+    [string]$ReleaseNotesPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$publishDirectory = Join-Path $repoRoot "$OutputRoot\publish\$Runtime"
+$packageDirectory = Join-Path $repoRoot "$OutputRoot\packages"
+$validationDirectory = Join-Path $repoRoot "$OutputRoot\validation"
+$packagePath = Join-Path $packageDirectory "BugNarrator-windows-$Runtime.zip"
+$executablePath = Join-Path $publishDirectory "BugNarrator.Windows.exe"
+$signatureReportPath = Join-Path $validationDirectory "BugNarrator-windows-$Runtime-signature.json"
+$validationReportPath = Join-Path $validationDirectory "BugNarrator-windows-$Runtime-validation.json"
+
+function Get-RelativeArtifactPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $rootPath = [System.IO.Path]::GetFullPath($repoRoot)
+    if (-not $rootPath.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $rootPath = "$rootPath$([System.IO.Path]::DirectorySeparatorChar)"
+    }
+
+    $rootUri = [System.Uri]::new($rootPath)
+    $pathUri = [System.Uri]::new([System.IO.Path]::GetFullPath($Path))
+    return [System.Uri]::UnescapeDataString($rootUri.MakeRelativeUri($pathUri).ToString()).Replace('\', '/')
+}
+
+if (-not $env:BUGNARRATOR_CERT_PATH) {
+    throw "Set BUGNARRATOR_CERT_PATH to an external Windows code-signing certificate before producing a signed tester release."
+}
+
+if (-not $env:BUGNARRATOR_CERT_PASSWORD) {
+    throw "Set BUGNARRATOR_CERT_PASSWORD before producing a signed tester release."
+}
+
+Push-Location $repoRoot
+try {
+    & "$PSScriptRoot\package-windows.ps1" -Configuration $Configuration -Runtime $Runtime -OutputRoot $OutputRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw "package-windows.ps1 failed."
+    }
+
+    & "$PSScriptRoot\sign-windows.ps1" `
+        -FilePath $executablePath `
+        -TimestampUrl $TimestampUrl `
+        -DigestAlgorithm $DigestAlgorithm `
+        -SignToolPath $SignToolPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "sign-windows.ps1 failed."
+    }
+
+    & "$PSScriptRoot\verify-windows-signature.ps1" `
+        -FilePath $executablePath `
+        -ReportPath $signatureReportPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "verify-windows-signature.ps1 failed."
+    }
+
+    if (Test-Path $packagePath) {
+        Remove-Item $packagePath -Force
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $publishDirectory,
+        $packagePath,
+        [System.IO.Compression.CompressionLevel]::Optimal,
+        $false)
+
+    & "$PSScriptRoot\validate-windows-package.ps1" -Runtime $Runtime -OutputRoot $OutputRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw "validate-windows-package.ps1 failed."
+    }
+
+    if (-not $ReleaseNotesPath) {
+        $ReleaseNotesPath = Join-Path $validationDirectory "BugNarrator-windows-$Runtime-release-notes.md"
+    }
+    $releaseNotesDirectory = Split-Path -Parent $ReleaseNotesPath
+    if ($releaseNotesDirectory) {
+        New-Item -ItemType Directory -Force -Path $releaseNotesDirectory | Out-Null
+    }
+
+    $packageHash = (Get-FileHash -Path $packagePath -Algorithm SHA256).Hash
+    $signatureReport = Get-Content $signatureReportPath -Raw | ConvertFrom-Json
+    $signerSubject = $signatureReport.signerCertificate.subject
+    $signerThumbprint = $signatureReport.signerCertificate.thumbprint
+
+    @(
+        "# BugNarrator Windows tester release",
+        "",
+        "- Artifact: ``$(Get-RelativeArtifactPath -Path $packagePath)``",
+        "- SHA-256: ``$packageHash``",
+        "- Runtime: ``$Runtime``",
+        "- Configuration: ``$Configuration``",
+        "- Signed executable: ``$(Get-RelativeArtifactPath -Path $executablePath)``",
+        "- Authenticode signer: ``$signerSubject``",
+        "- Authenticode thumbprint: ``$signerThumbprint``",
+        "- Signature evidence: ``$(Get-RelativeArtifactPath -Path $signatureReportPath)``",
+        "- Package validation evidence: ``$(Get-RelativeArtifactPath -Path $validationReportPath)``",
+        "",
+        "Clean-machine validation is still required before broad tester distribution. Run the Windows validation checklist on a fresh Windows machine or VM and attach the resulting notes to the GitHub Release."
+    ) | Set-Content -Path $ReleaseNotesPath
+
+    Write-Host "Signed Windows tester package created at $packagePath"
+    Write-Host "Release notes written to $ReleaseNotesPath"
+}
+finally {
+    Pop-Location
+}

--- a/windows/scripts/verify-windows-signature.ps1
+++ b/windows/scripts/verify-windows-signature.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+    [string]$ReportPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $FilePath)) {
+    throw "The signed file was not found: $FilePath"
+}
+
+$signature = Get-AuthenticodeSignature -FilePath $FilePath
+if ($signature.Status -ne "Valid") {
+    throw "Authenticode signature is not valid for $FilePath. Status: $($signature.Status). Message: $($signature.StatusMessage)"
+}
+
+$report = [PSCustomObject]@{
+    filePath = (Resolve-Path $FilePath).Path
+    status = [string]$signature.Status
+    statusMessage = $signature.StatusMessage
+    signerCertificate = if ($signature.SignerCertificate) {
+        [PSCustomObject]@{
+            subject = $signature.SignerCertificate.Subject
+            issuer = $signature.SignerCertificate.Issuer
+            thumbprint = $signature.SignerCertificate.Thumbprint
+            notBefore = $signature.SignerCertificate.NotBefore.ToUniversalTime().ToString("o")
+            notAfter = $signature.SignerCertificate.NotAfter.ToUniversalTime().ToString("o")
+        }
+    } else {
+        $null
+    }
+    timeStamperCertificate = if ($signature.TimeStamperCertificate) {
+        [PSCustomObject]@{
+            subject = $signature.TimeStamperCertificate.Subject
+            issuer = $signature.TimeStamperCertificate.Issuer
+            thumbprint = $signature.TimeStamperCertificate.Thumbprint
+            notBefore = $signature.TimeStamperCertificate.NotBefore.ToUniversalTime().ToString("o")
+            notAfter = $signature.TimeStamperCertificate.NotAfter.ToUniversalTime().ToString("o")
+        }
+    } else {
+        $null
+    }
+    verifiedAt = (Get-Date).ToUniversalTime().ToString("o")
+}
+
+if ($ReportPath) {
+    $reportDirectory = Split-Path -Parent $ReportPath
+    if ($reportDirectory) {
+        New-Item -ItemType Directory -Force -Path $reportDirectory | Out-Null
+    }
+    $report | ConvertTo-Json -Depth 6 | Set-Content -Path $ReportPath
+}
+
+Write-Host "Authenticode signature is valid for $FilePath"
+if ($signature.SignerCertificate) {
+    Write-Host "Signer: $($signature.SignerCertificate.Subject)"
+    Write-Host "Thumbprint: $($signature.SignerCertificate.Thumbprint)"
+}


### PR DESCRIPTION
## Summary
- add a Windows tester release workflow_dispatch that decodes an external PFX secret, signs the Windows executable, uploads evidence, and publishes a GitHub Release
- add release-windows-tester.ps1 to package, sign, verify Authenticode status, repack, validate, and write release notes/evidence
- add verify-windows-signature.ps1 plus Windows release/checklist/parity docs for the signed-zip tester path

Refs #75

## Validation
- ruby -e 'require "psych"; Psych.load_file(".github/workflows/windows-tester-release.yml"); puts "workflow yaml ok"'\n- git diff --check\n- ./scripts/validate.sh origin/main (passed; generated semgrep status artifact was reverted)\n- dotnet restore windows/BugNarrator.Windows.sln (blocked locally: NuGet source https://api.nuget.org/v3/index.json returned No route to host)\n- dotnet restore windows/BugNarrator.Windows.sln --ignore-failed-sources (same NuGet network blocker)\n\n## Credential dependency\nThis PR does not fake or embed a signature. A real signed tester release still requires an external Windows code-signing certificate configured as BUGNARRATOR_WINDOWS_CERT_BASE64 and BUGNARRATOR_WINDOWS_CERT_PASSWORD in GitHub, or BUGNARRATOR_CERT_PATH and BUGNARRATOR_CERT_PASSWORD locally. Clean-machine Windows validation also remains a release step after producing the signed artifact.\n\n## Release format decision\nThe first tester artifact is a zip containing signed BugNarrator.Windows.exe plus signature, package-validation, and release-note evidence. Installer EXE/MSIX can follow if tester distribution needs it.