### PR TITLE
[patch] BUG: Remove zero-byte preserved retry audio on validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.
 - [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.
 - [FIX] Removed the successful side's leftover audio file when only one of the microphone or system-audio recorders fails to stop a mixed recording, so the abandoned file is no longer picked up as a crash-recovery candidate on the next launch.
+- [FIX] Removed the zero-byte preserved retry audio file when transcription preservation rejects an empty recording, so the session artifacts directory no longer keeps an unusable audio file behind.
 
 ## 1.0.35 - 2026-05-19
 

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -411,6 +411,7 @@ final class TranscriptionRecoveryController: ObservableObject {
         let attributes = try fileManager.attributesOfItem(atPath: preservedAudioURL.path)
         let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
         guard fileSize > 0 else {
+            try? fileManager.removeItem(at: preservedAudioURL)
             throw AppError.recordingFailure("The preserved audio file was empty.")
         }
     }

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -199,6 +199,32 @@ final class TranscriptionRecoveryControllerTests: XCTestCase {
         }
         XCTAssertEqual(error, .recordingFailure("The preserved audio file was empty."))
         XCTAssertNil(harness.transcriptStore.session(with: recordingSession.sessionID))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
+    func testPreserveRetryableSessionRemovesEmptyCopiedPreservedAudio() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let recordingSession = try harness.makeRecordingSession()
+        let recordedAudio = try harness.makeRecordedAudio(fileName: "empty-source", contents: "")
+
+        let result = harness.controller.preserveRetryableSession(
+            from: recordingSession,
+            recordedAudio: recordedAudio,
+            request: harness.request,
+            failureReason: .invalidAPIKey
+        )
+
+        guard case .preservationFailure(let error as AppError) = result else {
+            return XCTFail("Expected empty preserved audio to fail preservation.")
+        }
+        XCTAssertEqual(error, .recordingFailure("The preserved audio file was empty."))
+
+        let preservedAudioURL = recordingSession.artifactsDirectoryURL
+            .appendingPathComponent("recording")
+            .appendingPathExtension("m4a")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: preservedAudioURL.path))
     }
 
     func testPreserveRetryableSessionPersistenceFailureStagesCurrentTranscript() throws {


### PR DESCRIPTION
Closes #268

## Summary
- Remove the preserved retry audio file in `validatePreservedAudio` when it rejects a zero-byte recording, so the session artifacts directory no longer keeps an unusable empty audio file.

## Acceptance criteria mirror

- [ ] `validatePreservedAudio` leaves no zero-byte file behind when it rejects an empty preserved audio.
- [ ] `TranscriptionRecoveryControllerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/TranscriptionRecoveryController.swift` — `try? fileManager.removeItem(at: preservedAudioURL)` immediately before the empty-file `throw`.
- `Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift` — extend the existing same-path empty test with a file-existence assertion and add a new test for the copied-source empty case.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Removed the zero-byte preserved retry audio file when transcription preservation rejects an empty recording, so the session artifacts directory no longer keeps an unusable audio file behind.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_