### PR TITLE
[patch] BUG: Log retry persistence failures during recordRetryableFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Logged a diagnostics error when the transcription retry attempt count cannot be saved durably, so operators can see when recovery state is in memory only instead of silently disappearing on the next launch.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -303,6 +303,16 @@ final class TranscriptionRecoveryController: ObservableObject {
         do {
             try sessionLibrary.persistUpdatedSession(session)
         } catch {
+            transcriptionLogger.error(
+                "transcription_retry_state_persist_failed",
+                "Retry attempt count could not be saved durably; recovery state is in memory only.",
+                metadata: [
+                    "session_id": session.id.uuidString,
+                    "failure_reason": failureReason.rawValue,
+                    "attempt_count": "\(session.pendingTranscription?.attemptCount ?? 0)",
+                    "underlying_error": error.localizedDescription
+                ]
+            )
             sessionLibrary.stageCurrentTranscript(session)
         }
 

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -277,6 +277,52 @@ final class TranscriptionRecoveryControllerTests: XCTestCase {
         XCTAssertTrue(failure.statusMessage.contains("retried 3 times"))
     }
 
+    func testRecordRetryableFailureLogsPersistenceErrorWhenIndexCannotBeSaved() async throws {
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RetryPersistLog-\(UUID().uuidString)")
+            .appendingPathExtension("json")
+        let diagnosticsStore = DiagnosticsLogStore(storageURL: storeURL)
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+        let transcriptionLogger = DiagnosticsLogger(category: .transcription, store: diagnosticsStore)
+
+        let harness = try TranscriptionRecoveryControllerHarness(transcriptionLogger: transcriptionLogger)
+        defer { harness.cleanup() }
+
+        let session = try harness.addPendingSession(failureReason: .missingAPIKey, attemptCount: 1)
+        guard case .ready(let context) = harness.controller.retryContext(
+            for: session.id,
+            isRecording: false,
+            provider: .openAI,
+            hasUsableAIProviderCredential: true,
+            aiProviderCompatibilityIssue: nil
+        ) else {
+            return XCTFail("Expected ready retry context.")
+        }
+        XCTAssertTrue(harness.controller.beginRetry(for: session.id))
+
+        let indexURL = harness.rootDirectoryURL.appendingPathComponent("sessions.index.json")
+        try? FileManager.default.removeItem(at: indexURL)
+        try FileManager.default.createDirectory(at: indexURL, withIntermediateDirectories: true)
+
+        let failure = try XCTUnwrap(
+            harness.controller.recordRetryableFailure(AppError.invalidAPIKey, context: context, provider: .openAI)
+        )
+
+        XCTAssertEqual(failure.appError, .invalidAPIKey)
+        XCTAssertNil(harness.controller.retryingSessionID)
+        XCTAssertEqual(harness.sessionLibrary.currentTranscript?.id, session.id)
+
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let entries = await diagnosticsStore.recentEntries()
+        let entry = try XCTUnwrap(
+            entries.first { $0.event == "transcription_retry_state_persist_failed" }
+        )
+        XCTAssertEqual(entry.metadata["session_id"], session.id.uuidString)
+        XCTAssertEqual(entry.metadata["failure_reason"], PendingTranscriptionFailureReason.invalidAPIKey.rawValue)
+        XCTAssertEqual(entry.metadata["attempt_count"], "2")
+        XCTAssertNotNil(entry.metadata["underlying_error"])
+    }
+
     func testCleanupPreservedRetryAudioHonorsDebugMode() throws {
         let harness = try TranscriptionRecoveryControllerHarness()
         defer { harness.cleanup() }
@@ -300,7 +346,7 @@ private struct TranscriptionRecoveryControllerHarness {
     let controller: TranscriptionRecoveryController
     let request = TranscriptionRequest(model: "whisper-1", languageHint: nil, prompt: nil)
 
-    init() throws {
+    init(transcriptionLogger: DiagnosticsLogger? = nil) throws {
         rootDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptionRecoveryControllerTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
@@ -316,10 +362,18 @@ private struct TranscriptionRecoveryControllerHarness {
             artifactsService: artifactsService,
             clipboardService: MockClipboardService()
         )
-        controller = TranscriptionRecoveryController(
-            sessionLibrary: sessionLibrary,
-            artifactsService: artifactsService
-        )
+        if let transcriptionLogger {
+            controller = TranscriptionRecoveryController(
+                sessionLibrary: sessionLibrary,
+                artifactsService: artifactsService,
+                transcriptionLogger: transcriptionLogger
+            )
+        } else {
+            controller = TranscriptionRecoveryController(
+                sessionLibrary: sessionLibrary,
+                artifactsService: artifactsService
+            )
+        }
     }
 
     func addPendingSession(


### PR DESCRIPTION
Closes #266

## Summary
- Log a `transcription_retry_state_persist_failed` diagnostics error when `persistUpdatedSession` throws inside `recordRetryableFailure`, so the in-memory `stageCurrentTranscript` fallback is visible to operators instead of silently losing the updated attempt count and failure reason on the next launch.

## Acceptance criteria mirror

- [ ] A `persistUpdatedSession` failure during `recordRetryableFailure` emits a `transcription_retry_state_persist_failed` log entry with `session_id`, `failure_reason`, and `attempt_count` metadata.
- [ ] Behavior on the happy path is unchanged.
- [ ] `TranscriptionRecoveryControllerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/TranscriptionRecoveryController.swift` — emit a diagnostics error before falling back to `stageCurrentTranscript`.
- `Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift` — extend the harness to accept an injected `DiagnosticsLogger`; add a regression test that forces the index file write to fail and asserts the log entry is recorded.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/TranscriptionRecoveryControllerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Logged a diagnostics error when the transcription retry attempt count cannot be saved durably, so operators can see when recovery state is in memory only instead of silently disappearing on the next launch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_