### PR TITLE
[patch] BUG: Respect cancellation during screenshot capture and write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Respected task cancellation between resolving displays and writing the screenshot file, so cancelling a region screenshot mid-flight no longer drops a PNG on disk after the user dismissed the selection.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
+++ b/Sources/BugNarrator/Services/ScreenshotCaptureService.swift
@@ -272,15 +272,19 @@ struct ScreenshotCaptureService: ScreenshotCapturing {
             ]
         )
 
+        try Task.checkCancellation()
+
         var capturedDisplays: [CapturedDisplayImage] = []
         capturedDisplays.reserveCapacity(intersectingDisplays.count)
         for (display, sourceRect) in intersectingDisplays {
+            try Task.checkCancellation()
             capturedDisplays.append(
                 try await imageProvider.captureDisplayImage(for: display, sourceRect: sourceRect)
             )
         }
 
         let image = try makeCompositeImage(from: capturedDisplays, bounds: selectionRect)
+        try Task.checkCancellation()
         try imageWriter.writePNG(image, to: url)
         try validateCapturedScreenshotFile(at: url)
         screenshotLogger.info(

--- a/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift
@@ -166,6 +166,87 @@ final class ScreenshotCaptureServiceTests: XCTestCase {
         }
     }
 
+    func testCaptureScreenshotCancellationAfterDisplaysResolvedSkipsCaptureAndWrite() async throws {
+        let temporaryRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let display = ScreenCaptureDisplaySnapshot(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            pixelWidth: 100,
+            pixelHeight: 100
+        )
+        let provider = MockScreenCaptureImageProvider(
+            displays: [display],
+            imagesByDisplayID: [
+                1: try makeSolidImage(width: 100, height: 100, color: CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+            ]
+        )
+        let service = ScreenshotCaptureService(
+            imageProvider: provider,
+            imageWriter: PNGScreenshotImageWriter()
+        )
+        let outputURL = temporaryRoot.appendingPathComponent("capture.png")
+
+        let cancellationBox = TaskCancellationBox()
+        provider.afterAvailableDisplays = { cancellationBox.cancel() }
+        let task = Task {
+            try await service.captureScreenshot(in: CGRect(x: 0, y: 0, width: 100, height: 100), to: outputURL)
+        }
+        cancellationBox.task = task
+
+        do {
+            try await task.value
+            XCTFail("Expected screenshot capture cancellation.")
+        } catch is CancellationError {
+            XCTAssertEqual(provider.availableDisplaysCallCount, 1)
+            XCTAssertEqual(provider.captureDisplayImageCallCount, 0)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+        } catch {
+            XCTFail("Expected CancellationError, got \(error).")
+        }
+    }
+
+    func testCaptureScreenshotCancellationAfterCaptureDoesNotWriteFile() async throws {
+        let temporaryRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let display = ScreenCaptureDisplaySnapshot(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            pixelWidth: 100,
+            pixelHeight: 100
+        )
+        let provider = MockScreenCaptureImageProvider(
+            displays: [display],
+            imagesByDisplayID: [
+                1: try makeSolidImage(width: 100, height: 100, color: CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+            ]
+        )
+        let service = ScreenshotCaptureService(
+            imageProvider: provider,
+            imageWriter: PNGScreenshotImageWriter()
+        )
+        let outputURL = temporaryRoot.appendingPathComponent("capture.png")
+
+        let cancellationBox = TaskCancellationBox()
+        provider.afterCaptureDisplayImage = { cancellationBox.cancel() }
+        let task = Task {
+            try await service.captureScreenshot(in: CGRect(x: 0, y: 0, width: 100, height: 100), to: outputURL)
+        }
+        cancellationBox.task = task
+
+        do {
+            try await task.value
+            XCTFail("Expected screenshot capture cancellation.")
+        } catch is CancellationError {
+            XCTAssertEqual(provider.captureDisplayImageCallCount, 1)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+        } catch {
+            XCTFail("Expected CancellationError, got \(error).")
+        }
+    }
+
     func testCaptureScreenshotFailsWhenNoDisplaysAreAvailable() async {
         let service = ScreenshotCaptureService(
             imageProvider: MockScreenCaptureImageProvider(displays: []),
@@ -240,10 +321,20 @@ final class ScreenshotCaptureServiceTests: XCTestCase {
     }
 }
 
+private final class TaskCancellationBox: @unchecked Sendable {
+    var task: Task<Void, Error>?
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
 private final class MockScreenCaptureImageProvider: ScreenCaptureImageProviding {
     var displays: [ScreenCaptureDisplaySnapshot] = []
     var imagesByDisplayID: [CGDirectDisplayID: CGImage] = [:]
     var error: Error?
+    var afterAvailableDisplays: (() -> Void)?
+    var afterCaptureDisplayImage: (() -> Void)?
     private(set) var requestedSourceRects: [CGRect] = []
     private(set) var availableDisplaysCallCount = 0
     private(set) var captureDisplayImageCallCount = 0
@@ -266,6 +357,7 @@ private final class MockScreenCaptureImageProvider: ScreenCaptureImageProviding 
             throw error
         }
 
+        afterAvailableDisplays?()
         return displays
     }
 
@@ -297,6 +389,7 @@ private final class MockScreenCaptureImageProvider: ScreenCaptureImageProviding 
             )
         } ?? display.frame
 
+        afterCaptureDisplayImage?()
         return CapturedDisplayImage(display: display, capturedFrame: capturedFrame, image: image)
     }
 }


### PR DESCRIPTION
Closes #267

## Summary
- Honor `Task.checkCancellation()` between resolving displays and the per-display capture loop, on every loop iteration, and immediately before the PNG write so cancelling a region screenshot mid-flight no longer drops a file on disk.

## Acceptance criteria mirror

- [ ] A cancellation that arrives between the pre-capture sleep and the write step prevents the PNG from being written.
- [ ] The happy-path screenshot capture is unchanged.
- [ ] `ScreenshotCaptureServiceTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/ScreenshotCaptureService.swift` — add three `Task.checkCancellation()` checks: after displays resolve, inside the per-display capture loop, and right before `imageWriter.writePNG`.
- `Tests/BugNarratorTests/ScreenshotCaptureServiceTests.swift` — add cancellation hooks to the mock provider and two regression tests covering cancellation after displays resolve and after the first capture returns.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/ScreenshotCaptureServiceTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Respected task cancellation between resolving displays and writing the screenshot file, so cancelling a region screenshot mid-flight no longer drops a PNG on disk after the user dismissed the selection.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_