### PR TITLE
[patch] BUG: Remove partial mix output when export fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.
 - [FIX] Removed the successful side's leftover audio file when only one of the microphone or system-audio recorders fails to stop a mixed recording, so the abandoned file is no longer picked up as a crash-recovery candidate on the next launch.
 - [FIX] Removed the zero-byte preserved retry audio file when transcription preservation rejects an empty recording, so the session artifacts directory no longer keeps an unusable audio file behind.
+- [FIX] Removed the partial mixed-recording output file when the export or post-export size check fails, so a corrupt artifact is no longer left in the recovered-recordings directory to be imported as a crash recovery on the next launch.
 
 ## 1.0.35 - 2026-05-19
 

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -161,6 +161,13 @@ final class MixedAudioRecorder: AudioRecording {
         try FileManager.default.createDirectory(at: outputDirectoryURL, withIntermediateDirectories: true)
         try? FileManager.default.removeItem(at: outputURL)
 
+        var mixSucceeded = false
+        defer {
+            if !mixSucceeded {
+                try? FileManager.default.removeItem(at: outputURL)
+            }
+        }
+
         let composition = AVMutableComposition()
         var mixParameters: [AVAudioMixInputParameters] = []
 
@@ -212,6 +219,7 @@ final class MixedAudioRecorder: AudioRecording {
             throw AppError.recordingFailure("The mixed audio file was empty.")
         }
 
+        mixSucceeded = true
         return RecordedAudio(
             fileURL: outputURL,
             duration: max(microphoneAudio.duration, systemAudio.duration)

--- a/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
@@ -50,6 +50,20 @@ final class MixedAudioRecorderTests: XCTestCase {
         let systemAudioRecorder = MockAudioRecorder()
         systemAudioRecorder.stopResults = [
             .failure(AppError.recordingFailure("System audio failed to stop."))
+    func testStopRecordingLeavesNoMixOutputBehindWhenMixingFails() async throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let corruptURL = rootDirectoryURL.appendingPathComponent("corrupt.wav")
+        try Data("not audio".utf8).write(to: corruptURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: corruptURL, duration: 0.1))
+        ]
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: corruptURL, duration: 0.1))
         ]
         let recorder = MixedAudioRecorder(
             microphoneRecorder: microphoneRecorder,
@@ -98,6 +112,20 @@ final class MixedAudioRecorderTests: XCTestCase {
         }
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
+            XCTFail("Expected mixed recording stop to throw on a corrupt source.")
+        } catch {
+            // Expected — mixing should not succeed on a corrupt source.
+        }
+
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: rootDirectoryURL,
+            includingPropertiesForKeys: nil
+        )
+        let leftoverMixFiles = contents.filter { $0.pathExtension == "m4a" }
+        XCTAssertTrue(
+            leftoverMixFiles.isEmpty,
+            "Expected no mixed-recording artifact after a failed stop, found: \(leftoverMixFiles)"
+        )
     }
 
     private func temporaryDirectoryURL() -> URL {


### PR DESCRIPTION
Closes #260

## Summary
- Guard `mixAudioFiles` with a `defer` block that removes the partial mix output on every throwing path so a failed export, cancelled export, default-branch resolution, or empty-file size-check rejection no longer leaves a corrupt `.m4a` in the recovered-recordings directory.

## Acceptance criteria mirror

- [ ] A failed mix export does not leave a file at the mix `outputURL`.
- [ ] An empty mix output is removed before the recording failure is thrown.
- [ ] `MixedAudioRecorderTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/MixedAudioRecorder.swift` — `defer` cleanup of `outputURL` unless `mixSucceeded` flips true at the end of the function.
- `Tests/BugNarratorTests/MixedAudioRecorderTests.swift` — regression test that drives `stopRecording` with a corrupt source and asserts no `.m4a` artifact remains in the output directory after the failure.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/MixedAudioRecorderTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Removed the partial mixed-recording output file when the export or post-export size check fails, so a corrupt artifact is no longer left in the recovered-recordings directory to be imported as a crash recovery on the next launch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_