### PR TITLE
[patch] BUG: Remove leftover source audio when one recorder fails to stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.
 - [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.
+- [FIX] Removed the successful side's leftover audio file when only one of the microphone or system-audio recorders fails to stop a mixed recording, so the abandoned file is no longer picked up as a crash-recovery candidate on the next launch.
 
 ## 1.0.35 - 2026-05-19
 

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -101,6 +101,15 @@ final class MixedAudioRecorder: AudioRecording {
             throw AppError.recordingFailure("Microphone recording was unavailable.")
         }
 
+        switch (systemResult, microphoneResult) {
+        case (.failure, .success(let microphoneAudio)):
+            try? FileManager.default.removeItem(at: microphoneAudio.fileURL)
+        case (.success(let systemAudio), .failure):
+            try? FileManager.default.removeItem(at: systemAudio.fileURL)
+        default:
+            break
+        }
+
         let systemAudio = try systemResult.get()
         let microphoneAudio = try microphoneResult.get()
 

--- a/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
@@ -36,6 +36,70 @@ final class MixedAudioRecorderTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
     }
 
+    func testStopRecordingRemovesMicrophoneFileWhenSystemAudioStopFails() async throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let microphoneURL = rootDirectoryURL.appendingPathComponent("microphone.wav")
+        try writeSilentAudioFile(to: microphoneURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: microphoneURL, duration: 0.1))
+        ]
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.stopResults = [
+            .failure(AppError.recordingFailure("System audio failed to stop."))
+        ]
+        let recorder = MixedAudioRecorder(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            outputDirectoryURL: rootDirectoryURL
+        )
+
+        try await recorder.startRecording()
+        do {
+            _ = try await recorder.stopRecording()
+            XCTFail("Expected stop to throw when system audio failed.")
+        } catch {
+            // Expected
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))
+    }
+
+    func testStopRecordingRemovesSystemAudioFileWhenMicrophoneStopFails() async throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let systemAudioURL = rootDirectoryURL.appendingPathComponent("system.wav")
+        try writeSilentAudioFile(to: systemAudioURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.stopResults = [
+            .failure(AppError.recordingFailure("Microphone failed to stop."))
+        ]
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: systemAudioURL, duration: 0.1))
+        ]
+        let recorder = MixedAudioRecorder(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            outputDirectoryURL: rootDirectoryURL
+        )
+
+        try await recorder.startRecording()
+        do {
+            _ = try await recorder.stopRecording()
+            XCTFail("Expected stop to throw when microphone failed.")
+        } catch {
+            // Expected
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
+    }
+
     private func temporaryDirectoryURL() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
Closes #261

## Summary
- When `MixedAudioRecorder.stopRecording` captures one side as `.success` and the other as `.failure`, remove the successful side's audio file before throwing so an orphan recording is not picked up by `RecoveredRecordingImporter` on the next launch.

## Acceptance criteria mirror

- [ ] A successful microphone stop combined with a failed system-audio stop leaves no microphone file under the recordings directory.
- [ ] A successful system-audio stop combined with a failed microphone stop leaves no system audio file under the recordings directory.
- [ ] `MixedAudioRecorderTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/MixedAudioRecorder.swift` — switch over the `(systemResult, microphoneResult)` pair to clean up the successful side before the abort throw.
- `Tests/BugNarratorTests/MixedAudioRecorderTests.swift` — regression tests for both partial-failure orderings.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/MixedAudioRecorderTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Removed the successful side's leftover audio file when only one of the microphone or system-audio recorders fails to stop a mixed recording, so the abandoned file is no longer picked up as a crash-recovery candidate on the next launch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_