### PR TITLE
[patch] BUG: Avoid volatile fallback for Application Support directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Preferred Caches and the user home directory before the volatile system temporary directory when Application Support is unavailable, so persistent session and diagnostics state is not silently purged across launches.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Utilities/AppSupportLocation.swift
+++ b/Sources/BugNarrator/Utilities/AppSupportLocation.swift
@@ -1,7 +1,9 @@
 import Foundation
+import os.log
 
 enum AppSupportLocation {
     private static let currentAppDirectoryName = "BugNarrator"
+    private static let fallbackDirectoryName = "BugNarrator-ApplicationSupportFallback"
     private static let legacyAppDirectoryNames = ["SessionMic"]
 
     static func appDirectory(fileManager: FileManager = .default) -> URL {
@@ -22,11 +24,28 @@ enum AppSupportLocation {
     }
 
     private static func applicationSupportBaseURL(fileManager: FileManager) -> URL {
-        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ??
-            fileManager.temporaryDirectory.appendingPathComponent(
-                "\(currentAppDirectoryName)-ApplicationSupportFallback",
-                isDirectory: true
-            )
+        if let url = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return url
+        }
+
+        if let url = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            logFallbackSelection("caches")
+            return url.appendingPathComponent(fallbackDirectoryName, isDirectory: true)
+        }
+
+        let homeURL = fileManager.homeDirectoryForCurrentUser
+        if !homeURL.path.isEmpty, homeURL.path != "/" {
+            logFallbackSelection("home")
+            return homeURL.appendingPathComponent(fallbackDirectoryName, isDirectory: true)
+        }
+
+        logFallbackSelection("temporary")
+        return fileManager.temporaryDirectory.appendingPathComponent(fallbackDirectoryName, isDirectory: true)
+    }
+
+    private static func logFallbackSelection(_ fallback: String) {
+        let logger = Logger(subsystem: BugNarratorDiagnostics.subsystem, category: "app-support-location")
+        logger.error("Application Support directory unavailable; using \(fallback, privacy: .public) fallback location.")
     }
 
     private static func migrateLegacyDirectoryIfNeeded(

--- a/Tests/BugNarratorTests/AppSupportLocationTests.swift
+++ b/Tests/BugNarratorTests/AppSupportLocationTests.swift
@@ -2,14 +2,50 @@ import XCTest
 @testable import BugNarrator
 
 final class AppSupportLocationTests: XCTestCase {
-    func testAppDirectoryFallsBackWhenApplicationSupportURLIsUnavailable() {
-        let fileManager = StubApplicationSupportFileManager(applicationSupportURLs: [])
+    func testAppDirectoryFallsBackToCachesWhenApplicationSupportURLIsUnavailable() {
+        let cachesRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: cachesRoot) }
+
+        let fileManager = StubApplicationSupportFileManager(
+            applicationSupportURLs: [],
+            cachesURLs: [cachesRoot]
+        )
 
         let appDirectoryURL = AppSupportLocation.appDirectory(fileManager: fileManager)
-        defer { try? FileManager.default.removeItem(at: appDirectoryURL.deletingLastPathComponent()) }
 
         XCTAssertEqual(appDirectoryURL.lastPathComponent, "BugNarrator")
-        XCTAssertEqual(appDirectoryURL.deletingLastPathComponent().lastPathComponent, "BugNarrator-ApplicationSupportFallback")
+        XCTAssertEqual(
+            appDirectoryURL.deletingLastPathComponent().lastPathComponent,
+            "BugNarrator-ApplicationSupportFallback"
+        )
+        XCTAssertEqual(
+            appDirectoryURL.deletingLastPathComponent().deletingLastPathComponent().standardizedFileURL,
+            cachesRoot.standardizedFileURL
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: appDirectoryURL.path))
+    }
+
+    func testAppDirectoryFallsBackToHomeWhenApplicationSupportAndCachesAreUnavailable() {
+        let homeRoot = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: homeRoot) }
+
+        let fileManager = StubApplicationSupportFileManager(
+            applicationSupportURLs: [],
+            cachesURLs: [],
+            homeURL: homeRoot
+        )
+
+        let appDirectoryURL = AppSupportLocation.appDirectory(fileManager: fileManager)
+
+        XCTAssertEqual(appDirectoryURL.lastPathComponent, "BugNarrator")
+        XCTAssertEqual(
+            appDirectoryURL.deletingLastPathComponent().lastPathComponent,
+            "BugNarrator-ApplicationSupportFallback"
+        )
+        XCTAssertEqual(
+            appDirectoryURL.deletingLastPathComponent().deletingLastPathComponent().standardizedFileURL,
+            homeRoot.standardizedFileURL
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: appDirectoryURL.path))
     }
 
@@ -38,9 +74,17 @@ final class AppSupportLocationTests: XCTestCase {
 
 private final class StubApplicationSupportFileManager: FileManager {
     private let applicationSupportURLs: [URL]
+    private let cachesURLs: [URL]
+    private let homeURL: URL?
 
-    init(applicationSupportURLs: [URL]) {
+    init(
+        applicationSupportURLs: [URL],
+        cachesURLs: [URL] = [],
+        homeURL: URL? = nil
+    ) {
         self.applicationSupportURLs = applicationSupportURLs
+        self.cachesURLs = cachesURLs
+        self.homeURL = homeURL
         super.init()
     }
 
@@ -52,6 +96,18 @@ private final class StubApplicationSupportFileManager: FileManager {
             return applicationSupportURLs
         }
 
+        if directory == .cachesDirectory, domainMask == .userDomainMask {
+            return cachesURLs
+        }
+
         return super.urls(for: directory, in: domainMask)
+    }
+
+    override var homeDirectoryForCurrentUser: URL {
+        if let homeURL {
+            return homeURL
+        }
+
+        return super.homeDirectoryForCurrentUser
     }
 }


### PR DESCRIPTION
Closes #262

## Summary
- When `applicationSupportDirectory` is not available, prefer Caches, then the user home directory, before falling back to the system temporary directory. Emit an `os.log` error so the degraded state is visible in diagnostics.

## Acceptance criteria mirror

- [ ] `applicationSupportBaseURL` prefers Caches over home over temporary directory.
- [ ] A diagnostics log entry is emitted when any non-Application-Support fallback is selected.
- [ ] `AppSupportLocationTests` pass locally.

## Changes
- `Sources/BugNarrator/Utilities/AppSupportLocation.swift` — chain `applicationSupport → caches → home → temporary` and emit a labelled `os.Logger` error when any fallback is chosen. Uses `os.Logger` directly to avoid the static-init cycle through `DiagnosticsLogStore`, which itself depends on `AppSupportLocation.appDirectory()`.
- `Tests/BugNarratorTests/AppSupportLocationTests.swift` — extend the stub with caches and home overrides; cover the Caches fallback and the home fallback explicitly; keep the legacy-migration test.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppSupportLocationTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Preferred Caches and the user home directory before the volatile system temporary directory when Application Support is unavailable, so persistent session and diagnostics state is not silently purged across launches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_