### PR TITLE
[patch] BUG: Continue importing remaining recovered recordings after one fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Continued importing the remaining recovered recordings when a single file fails to copy or persist, removed the half-created artifacts directory for the failed file, and surfaced the failure in diagnostics.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
+++ b/Sources/BugNarrator/Services/RecoveredRecordingImporter.swift
@@ -6,16 +6,19 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
     private let fileManager: FileManager
     private let recoveryDirectoryURL: URL
     private let qualityInspector: TranscriptQualityInspector
+    private let logger: DiagnosticsLogger
 
     init(
         fileManager: FileManager = .default,
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
             .appendingPathComponent("RecoveredRecordings", isDirectory: true),
-        qualityInspector: TranscriptQualityInspector = TranscriptQualityInspector()
+        qualityInspector: TranscriptQualityInspector = TranscriptQualityInspector(),
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .sessionLibrary)
     ) {
         self.fileManager = fileManager
         self.recoveryDirectoryURL = recoveryDirectoryURL
         self.qualityInspector = qualityInspector
+        self.logger = logger
     }
 
     @MainActor
@@ -46,63 +49,88 @@ struct RecoveredRecordingImporter: RecoveredRecordingImporting {
         var importedCount = 0
         for audioFileURL in audioFiles {
             let sessionID = UUID()
-            let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
-            let preservedAudioURL = artifactsService.makeRecordedAudioURL(
-                in: artifactsDirectoryURL,
-                sourceFileURL: audioFileURL
-            )
+            do {
+                let artifactsDirectoryURL = try artifactsService.createArtifactsDirectory(for: sessionID)
+                do {
+                    let preservedAudioURL = artifactsService.makeRecordedAudioURL(
+                        in: artifactsDirectoryURL,
+                        sourceFileURL: audioFileURL
+                    )
 
-            if fileManager.fileExists(atPath: preservedAudioURL.path) {
-                try fileManager.removeItem(at: preservedAudioURL)
+                    if fileManager.fileExists(atPath: preservedAudioURL.path) {
+                        try fileManager.removeItem(at: preservedAudioURL)
+                    }
+                    try fileManager.copyItem(at: audioFileURL, to: preservedAudioURL)
+
+                    let transcriptText = recoveredTranscriptText(for: audioFileURL)
+                    let duration: TimeInterval = 0
+                    let session: TranscriptSession
+
+                    if let transcriptText, !transcriptText.isEmpty {
+                        let sections = TranscriptSectionBuilder.buildSections(
+                            transcript: transcriptText,
+                            segments: [],
+                            markers: [],
+                            duration: duration
+                        )
+                        session = TranscriptSession(
+                            id: sessionID,
+                            createdAt: modificationDate(for: audioFileURL),
+                            transcript: transcriptText,
+                            duration: duration,
+                            model: "recovered",
+                            languageHint: nil,
+                            prompt: nil,
+                            sections: sections,
+                            transcriptQualityFindings: qualityInspector.findings(for: transcriptText),
+                            recoveredSourceFileName: audioFileURL.lastPathComponent,
+                            artifactsDirectoryPath: artifactsDirectoryURL.path
+                        )
+                    } else {
+                        session = TranscriptSession(
+                            id: sessionID,
+                            createdAt: modificationDate(for: audioFileURL),
+                            transcript: "",
+                            duration: duration,
+                            model: "whisper-1",
+                            languageHint: nil,
+                            prompt: nil,
+                            pendingTranscription: PendingTranscription(
+                                audioFileName: preservedAudioURL.lastPathComponent,
+                                failureReason: .crashRecovery,
+                                preservedAt: Date(),
+                                recoveredSourceFileName: audioFileURL.lastPathComponent
+                            ),
+                            recoveredSourceFileName: audioFileURL.lastPathComponent,
+                            artifactsDirectoryPath: artifactsDirectoryURL.path
+                        )
+                    }
+
+                    try transcriptStore.add(session)
+                    importedCount += 1
+                } catch {
+                    try? fileManager.removeItem(at: artifactsDirectoryURL)
+                    logger.error(
+                        "recovered_recording_import_skipped",
+                        "A recovered recording could not be imported and was skipped.",
+                        metadata: [
+                            "source_file_name": audioFileURL.lastPathComponent,
+                            "session_id": sessionID.uuidString,
+                            "underlying_error": error.localizedDescription
+                        ]
+                    )
+                }
+            } catch {
+                logger.error(
+                    "recovered_recording_artifacts_directory_failed",
+                    "A recovered recording artifacts directory could not be created and the file was skipped.",
+                    metadata: [
+                        "source_file_name": audioFileURL.lastPathComponent,
+                        "session_id": sessionID.uuidString,
+                        "underlying_error": error.localizedDescription
+                    ]
+                )
             }
-            try fileManager.copyItem(at: audioFileURL, to: preservedAudioURL)
-
-            let transcriptText = recoveredTranscriptText(for: audioFileURL)
-            let duration: TimeInterval = 0
-            let session: TranscriptSession
-
-            if let transcriptText, !transcriptText.isEmpty {
-                let sections = TranscriptSectionBuilder.buildSections(
-                    transcript: transcriptText,
-                    segments: [],
-                    markers: [],
-                    duration: duration
-                )
-                session = TranscriptSession(
-                    id: sessionID,
-                    createdAt: modificationDate(for: audioFileURL),
-                    transcript: transcriptText,
-                    duration: duration,
-                    model: "recovered",
-                    languageHint: nil,
-                    prompt: nil,
-                    sections: sections,
-                    transcriptQualityFindings: qualityInspector.findings(for: transcriptText),
-                    recoveredSourceFileName: audioFileURL.lastPathComponent,
-                    artifactsDirectoryPath: artifactsDirectoryURL.path
-                )
-            } else {
-                session = TranscriptSession(
-                    id: sessionID,
-                    createdAt: modificationDate(for: audioFileURL),
-                    transcript: "",
-                    duration: duration,
-                    model: "whisper-1",
-                    languageHint: nil,
-                    prompt: nil,
-                    pendingTranscription: PendingTranscription(
-                        audioFileName: preservedAudioURL.lastPathComponent,
-                        failureReason: .crashRecovery,
-                        preservedAt: Date(),
-                        recoveredSourceFileName: audioFileURL.lastPathComponent
-                    ),
-                    recoveredSourceFileName: audioFileURL.lastPathComponent,
-                    artifactsDirectoryPath: artifactsDirectoryURL.path
-                )
-            }
-
-            try transcriptStore.add(session)
-            importedCount += 1
         }
 
         return importedCount

--- a/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
+++ b/Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift
@@ -140,10 +140,72 @@ final class RecoveredRecordingImporterTests: XCTestCase {
         XCTAssertTrue(store.sessions.isEmpty)
     }
 
+    func testImporterContinuesAfterPerFileFailureAndCleansOrphanArtifacts() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
+
+        let firstAudioURL = recoveryDirectoryURL.appendingPathComponent("first-recording.m4a")
+        let secondAudioURL = recoveryDirectoryURL.appendingPathComponent("second-recording.m4a")
+        try Data("first".utf8).write(to: firstAudioURL)
+        try Data("second".utf8).write(to: secondAudioURL)
+        let attributes: [FileAttributeKey: Any] = [.modificationDate: Date(timeIntervalSinceNow: -60)]
+        try FileManager.default.setAttributes(attributes, ofItemAtPath: secondAudioURL.path)
+
+        let store = TranscriptStore(storageURL: rootDirectoryURL.appendingPathComponent("sessions.json"))
+        let underlyingService = MockArtifactsService(rootDirectoryURL: rootDirectoryURL.appendingPathComponent("artifacts"))
+        let failingService = FailFirstArtifactsService(underlying: underlyingService)
+        let importer = RecoveredRecordingImporter(recoveryDirectoryURL: recoveryDirectoryURL)
+
+        XCTAssertEqual(
+            try importer.importRecoverableRecordings(into: store, artifactsService: failingService),
+            1
+        )
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(store.sessions.first?.recoveredSourceFileName, "second-recording.m4a")
+        XCTAssertEqual(failingService.createCallCount, 2)
+        XCTAssertEqual(underlyingService.createdDirectories.count, 1)
+    }
+
     private func makeTempDirectory() -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-RecoveredRecordingImporterTests-\(UUID().uuidString)", isDirectory: true)
         try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         return directoryURL
+    }
+}
+
+private final class FailFirstArtifactsService: SessionArtifactsManaging {
+    private let underlying: MockArtifactsService
+    private(set) var createCallCount = 0
+
+    init(underlying: MockArtifactsService) {
+        self.underlying = underlying
+    }
+
+    func createArtifactsDirectory(for sessionID: UUID) throws -> URL {
+        createCallCount += 1
+        if createCallCount == 1 {
+            throw NSError(
+                domain: "FailFirstArtifactsService",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Simulated artifacts directory failure."]
+            )
+        }
+        return try underlying.createArtifactsDirectory(for: sessionID)
+    }
+
+    func makeRecordedAudioURL(in directoryURL: URL, sourceFileURL: URL) -> URL {
+        underlying.makeRecordedAudioURL(in: directoryURL, sourceFileURL: sourceFileURL)
+    }
+
+    func makeScreenshotURL(in directoryURL: URL, prefix: String, index: Int, elapsedTime: TimeInterval) -> URL {
+        underlying.makeScreenshotURL(in: directoryURL, prefix: prefix, index: index, elapsedTime: elapsedTime)
+    }
+
+    func removeArtifactsDirectory(at directoryURL: URL) {
+        underlying.removeArtifactsDirectory(at: directoryURL)
     }
 }


### PR DESCRIPTION
Closes #263

## Summary
- Per-file failures in `importRecoverableRecordings` no longer abort the whole batch. Wrap the body in nested `do/catch`, remove the orphan artifacts directory on failure, log the per-file error, and continue with the rest of the batch.

## Acceptance criteria mirror

- [ ] A failing copy or persist on the first recovered file does not block the second valid file from importing.
- [ ] The orphan artifacts directory created for the failed file is removed.
- [ ] `RecoveredRecordingImporterTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/RecoveredRecordingImporter.swift` — nested `do/catch` for per-file isolation; injectable `logger`; cleanup of the half-created artifacts directory.
- `Tests/BugNarratorTests/RecoveredRecordingImporterTests.swift` — regression test using a `FailFirstArtifactsService` stub that fails the first `createArtifactsDirectory` call and succeeds the second, asserting the second valid file is still imported.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RecoveredRecordingImporterTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Continued importing the remaining recovered recordings when a single file fails to copy or persist, removed the half-created artifacts directory for the failed file, and surfaced the failure in diagnostics.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_