### PR TITLE
[patch] BUG: Provider-aware transcription pending timeline entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.
+- [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.
 
 ## 1.0.35 - 2026-05-19
 

--- a/Sources/BugNarrator/Utilities/ReviewWorkspace.swift
+++ b/Sources/BugNarrator/Utilities/ReviewWorkspace.swift
@@ -32,7 +32,10 @@ enum ReviewWorkspace {
         return .rawTranscript
     }
 
-    static func timelineEntries(for session: TranscriptSession) -> [ReviewWorkspaceTimelineEntry] {
+    static func timelineEntries(
+        for session: TranscriptSession,
+        provider: AIProvider = .openAI
+    ) -> [ReviewWorkspaceTimelineEntry] {
         var entries: [ReviewWorkspaceTimelineEntry] = []
 
         if session.requiresTranscriptionRetry {
@@ -42,7 +45,8 @@ enum ReviewWorkspace {
                     timestamp: 0,
                     kind: .transcript,
                     title: "Transcription Pending",
-                    text: session.transcriptionRecoveryMessage ?? "Retry transcription after restoring the provider setup.",
+                    text: session.transcriptionRecoveryMessage(for: provider)
+                        ?? "Retry transcription after restoring the provider setup.",
                     secondaryText: "The finished audio was preserved with this session.",
                     index: nil,
                     screenshotID: nil

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -883,7 +883,10 @@ struct TranscriptView: View {
     }
 
     private func rawTranscriptSection(_ session: TranscriptSession, availableWidth: CGFloat) -> some View {
-        let entries = ReviewWorkspace.timelineEntries(for: session)
+        let entries = ReviewWorkspace.timelineEntries(
+            for: session,
+            provider: appState.settingsStore.aiProvider
+        )
 
         return LazyVStack(alignment: .leading, spacing: 12) {
             ForEach(entries) { entry in

--- a/Tests/BugNarratorTests/ReviewWorkspaceTests.swift
+++ b/Tests/BugNarratorTests/ReviewWorkspaceTests.swift
@@ -163,6 +163,32 @@ final class ReviewWorkspaceTests: XCTestCase {
         )
     }
 
+    func testPendingTranscriptionSessionUsesProviderSpecificRecoveryTimelineEntry() throws {
+        let session = TranscriptSession(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            transcript: "",
+            duration: 5,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            pendingTranscription: PendingTranscription(
+                audioFileName: "recording.m4a",
+                failureReason: .missingAPIKey,
+                preservedAt: Date(timeIntervalSince1970: 1_700_000_010)
+            )
+        )
+
+        let entries = ReviewWorkspace.timelineEntries(for: session, provider: .parakeetLocal)
+
+        XCTAssertEqual(entries.first?.title, "Transcription Pending")
+        let pendingText = try XCTUnwrap(entries.first?.text)
+        XCTAssertFalse(pendingText.contains("OpenAI"), "Parakeet-mode pending text should not mention OpenAI: \(pendingText)")
+        XCTAssertTrue(
+            pendingText.contains(AIProvider.parakeetLocal.displayName),
+            "Parakeet-mode pending text should reference the active provider: \(pendingText)"
+        )
+    }
+
     func testSelectedIssueSummaryCountsOnlySelectedIssues() {
         let issues = [
             ExtractedIssue(


### PR DESCRIPTION
Closes #265

## Summary
- Forward the active `AIProvider` into `ReviewWorkspace.timelineEntries` so the "Transcription Pending" review entry renders the provider-aware recovery message instead of the OpenAI-defaulting `session.transcriptionRecoveryMessage`.

## Acceptance criteria mirror

- [ ] A pending session viewed in Parakeet mode shows Local (Parakeet) recovery text in the timeline.
- [ ] OpenAI-mode pending text is unchanged.
- [ ] Affected tests pass locally.

## Changes
- `Sources/BugNarrator/Utilities/ReviewWorkspace.swift` — `timelineEntries(for:provider:)` takes an `AIProvider` (defaulting to `.openAI` for source compatibility) and routes the pending entry through `session.transcriptionRecoveryMessage(for: provider)`.
- `Sources/BugNarrator/Views/TranscriptView.swift` — pass `appState.settingsStore.aiProvider` at the call site.
- `Tests/BugNarratorTests/ReviewWorkspaceTests.swift` — regression test asserting that Parakeet-mode pending text references the active provider and does not contain "OpenAI".

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/ReviewWorkspaceTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_