### PR TITLE
[patch] BUG: Render AppErrorPresenter messages with the active AI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Routed `AppErrorPresenter` status messages, post-transcription error text, settings-window prompts, and diagnostics logs through the active AI provider, so Local (Parakeet) users no longer see OpenAI-specific copy when transcription or post-transcription steps fail.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -239,7 +239,8 @@ final class AppState: ObservableObject {
         self.presentationState = presentationState
         self.errorPresenter = AppErrorPresenter(
             presentationState: presentationState,
-            telemetryRecorder: telemetryRecorder
+            telemetryRecorder: telemetryRecorder,
+            provider: { [settingsStore] in settingsStore.aiProvider }
         )
         let transientToastController = TransientToastController(presentationState: presentationState)
         self.transientToastController = transientToastController

--- a/Sources/BugNarrator/Services/AppErrorPresenter.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresenter.swift
@@ -57,7 +57,10 @@ final class TranscriptPersistenceFailurePresenter {
             "Transcription succeeded, but saving the transcript locally failed.",
             metadata: metadata
         )
-        errorPresenter.setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+        errorPresenter.setStatus(
+            .error("Transcript ready, but \(appError.userMessage(for: errorPresenter.activeProvider))"),
+            error: appError
+        )
         showTranscriptWindow()
     }
 }
@@ -90,6 +93,7 @@ final class PostTranscriptionFailurePresenter {
 final class AppErrorPresenter {
     private let presentationState: AppPresentationState
     private let telemetryRecorder: any OperationalTelemetryRecording
+    private let provider: () -> AIProvider
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
     private let sessionLibraryLogger = DiagnosticsLogger(category: .sessionLibrary)
@@ -100,10 +104,16 @@ final class AppErrorPresenter {
 
     init(
         presentationState: AppPresentationState,
-        telemetryRecorder: any OperationalTelemetryRecording
+        telemetryRecorder: any OperationalTelemetryRecording,
+        provider: @escaping () -> AIProvider = { .openAI }
     ) {
         self.presentationState = presentationState
         self.telemetryRecorder = telemetryRecorder
+        self.provider = provider
+    }
+
+    var activeProvider: AIProvider {
+        provider()
     }
 
     func setStatus(_ status: AppStatus, error: AppError? = nil) {
@@ -117,8 +127,9 @@ final class AppErrorPresenter {
     ) -> AppErrorPresentationResult {
         let normalizedError = normalizeError(error, operation: operation, fallback: fallback)
         let appError = normalizedError.appError
+        let currentProvider = provider()
         logAppError(normalizedError, context: "present_error")
-        setStatus(.error(appError.userMessage), error: appError)
+        setStatus(.error(appError.userMessage(for: currentProvider)), error: appError)
         return AppErrorPresentationResult(
             appError: appError,
             shouldOpenSettingsWindow: shouldOpenSettingsWindowAfterPresenting(appError)
@@ -135,11 +146,15 @@ final class AppErrorPresenter {
             fallback: { .issueExtractionFailure($0) }
         )
         let appError = normalizedError.appError
+        let currentProvider = provider()
         logAppError(normalizedError, context: "present_post_transcription_error")
-        setStatus(.error("Transcript ready, but \(appError.userMessage)"), error: appError)
+        setStatus(
+            .error("Transcript ready, but \(appError.userMessage(for: currentProvider))"),
+            error: appError
+        )
         return AppErrorPresentationResult(
             appError: appError,
-            shouldOpenSettingsWindow: appError.suggestsOpenAISettings
+            shouldOpenSettingsWindow: appError.suggestsProviderSettings(for: currentProvider)
         )
     }
 
@@ -182,6 +197,7 @@ final class AppErrorPresenter {
     func logAppError(_ normalizedError: AppErrorNormalization, context: String) {
         let error = normalizedError.appError
         let metadata = appErrorMetadata(for: normalizedError, context: context)
+        let message = error.userMessage(for: provider())
 
         telemetryRecorder.record(.appError, metadata: metadata)
 
@@ -193,23 +209,23 @@ final class AppErrorPresenter {
              .systemAudioConsentRequired,
              .systemAudioUnavailable,
              .screenRecordingPermissionDenied:
-            permissionsLogger.warning(.appError, error.userMessage, metadata: metadata)
+            permissionsLogger.warning(.appError, message, metadata: metadata)
         case .missingAPIKey, .invalidAPIKey, .revokedAPIKey:
-            settingsLogger.warning(.appError, error.userMessage, metadata: metadata)
+            settingsLogger.warning(.appError, message, metadata: metadata)
         case .recordingFailure:
-            recordingLogger.error(.appError, error.userMessage, metadata: metadata)
+            recordingLogger.error(.appError, message, metadata: metadata)
         case .transcriptionFailure, .openAIRequestRejected, .issueExtractionFailure, .emptyTranscript, .networkTimeout, .networkFailure, .rateLimited:
-            transcriptionLogger.error(.appError, error.userMessage, metadata: metadata)
+            transcriptionLogger.error(.appError, message, metadata: metadata)
         case .screenshotCaptureFailure:
-            screenshotLogger.error(.appError, error.userMessage, metadata: metadata)
+            screenshotLogger.error(.appError, message, metadata: metadata)
         case .exportConfigurationMissing, .exportFailure:
-            exportLogger.error(.appError, error.userMessage, metadata: metadata)
+            exportLogger.error(.appError, message, metadata: metadata)
         case .storageFailure:
-            sessionLibraryLogger.error(.appError, error.userMessage, metadata: metadata)
+            sessionLibraryLogger.error(.appError, message, metadata: metadata)
         case .noActiveSession:
-            recordingLogger.warning(.appError, error.userMessage, metadata: metadata)
+            recordingLogger.warning(.appError, message, metadata: metadata)
         case .diagnosticsFailure:
-            settingsLogger.error(.appError, error.userMessage, metadata: metadata)
+            settingsLogger.error(.appError, message, metadata: metadata)
         }
     }
 

--- a/Tests/BugNarratorTests/AppErrorPresenterTests.swift
+++ b/Tests/BugNarratorTests/AppErrorPresenterTests.swift
@@ -121,6 +121,35 @@ final class AppErrorPresenterTests: XCTestCase {
         XCTAssertEqual(telemetry.metadata["error_type"], "invalid_api_key")
     }
 
+    func testPresentErrorRendersActiveProviderMessageWhenProviderIsParakeet() {
+        let harness = AppErrorPresenterHarness(provider: { .parakeetLocal })
+
+        _ = harness.presenter.presentError(AppError.networkTimeout, operation: .transcription)
+
+        let status = harness.presentationState.status
+        guard case .error(let text) = status else {
+            return XCTFail("Expected error status, got \(status).")
+        }
+        XCTAssertFalse(text.contains("OpenAI"), "Parakeet error text should not contain OpenAI: \(text)")
+        XCTAssertTrue(
+            text.contains(AIProvider.parakeetLocal.displayName),
+            "Parakeet error text should reference active provider: \(text)"
+        )
+    }
+
+    func testPresentPostTranscriptionErrorOpensSettingsForParakeetCredentialFailure() {
+        let harness = AppErrorPresenterHarness(provider: { .parakeetLocal })
+
+        let result = harness.presenter.presentPostTranscriptionError(AppError.missingAPIKey)
+
+        XCTAssertTrue(result.shouldOpenSettingsWindow)
+        let status = harness.presentationState.status
+        guard case .error(let text) = status else {
+            return XCTFail("Expected error status, got \(status).")
+        }
+        XCTAssertFalse(text.contains("OpenAI"), "Parakeet error text should not contain OpenAI: \(text)")
+    }
+
     func testTranscriptPersistenceFailurePresenterPrefixesStatusAndOpensTranscript() throws {
         let harness = AppErrorPresenterHarness()
         let underlyingError = NSError(
@@ -157,10 +186,11 @@ private final class AppErrorPresenterHarness {
     let telemetryRecorder = MockOperationalTelemetryRecorder()
     let presenter: AppErrorPresenter
 
-    init() {
+    init(provider: @escaping () -> AIProvider = { .openAI }) {
         self.presenter = AppErrorPresenter(
             presentationState: presentationState,
-            telemetryRecorder: telemetryRecorder
+            telemetryRecorder: telemetryRecorder,
+            provider: provider
         )
     }
 


### PR DESCRIPTION
Closes #264

## Summary
- Inject a `provider: () -> AIProvider` closure into `AppErrorPresenter` and route every `userMessage` / `suggestsOpenAISettings` call through the provider-aware overloads, so error text, post-transcription status, settings-window prompts, and diagnostics logs reflect the active AI provider instead of hardcoded OpenAI copy.

## Acceptance criteria mirror

- [ ] A Parakeet-mode transcription failure routed through `presentPostTranscriptionError` surfaces Local (Parakeet) text rather than OpenAI text.
- [ ] A Parakeet-mode `missingAPIKey` error opens the provider-aware settings hint.
- [ ] `AppErrorPresenterTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/AppErrorPresenter.swift` — add `provider: () -> AIProvider` (defaulting to `{ .openAI }` for source-compatibility), expose `activeProvider`, route `presentError`, `presentPostTranscriptionError`, `logAppError`, and `TranscriptPersistenceFailurePresenter.present` through `userMessage(for:)` and `suggestsProviderSettings(for:)`.
- `Sources/BugNarrator/AppState.swift` — wire the closure to `settingsStore.aiProvider` so the live app uses the selected provider.
- `Tests/BugNarratorTests/AppErrorPresenterTests.swift` — extend the harness with a provider parameter; add two regression tests asserting Parakeet-mode `presentError` and `presentPostTranscriptionError` render without "OpenAI" and still open settings for credential failures.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppErrorPresenterTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Routed `AppErrorPresenter` status messages, post-transcription error text, settings-window prompts, and diagnostics logs through the active AI provider, so Local (Parakeet) users no longer see OpenAI-specific copy when transcription or post-transcription steps fail.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_