### PR TITLE
[patch] BUG: Stop forwarding the saved OpenAI key to non-OpenAI providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [SECURITY] Stopped forwarding the saved OpenAI API key in the Authorization header to non-OpenAI providers (Local Parakeet, Local-Compatible, OpenAI-Compatible), so a previously-configured OpenAI key is no longer leaked to localhost or third-party gateways during validation or transcription.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -530,18 +530,17 @@ final class SettingsStore: ObservableObject {
     }
 
     func aiProviderCredentialForUserInitiatedAccess() -> String? {
-        let resolvedKey = openAIAPIKeyForUserInitiatedAccess()
         let trimmedBaseURL = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if aiProvider.requiresAPIKey {
-            return resolvedKey
+            return openAIAPIKeyForUserInitiatedAccess()
         }
 
         guard !trimmedBaseURL.isEmpty else {
             return nil
         }
 
-        return resolvedKey ?? ""
+        return ""
     }
 
     var trimmedGitHubToken: String {

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -310,6 +310,35 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.aiProviderCredentialForUserInitiatedAccess(), "")
     }
 
+    func testNonAPIKeyProviderDoesNotForwardSavedOpenAIKey() {
+        let suiteName = "BugNarrator-SettingsNonAPIKeyProviderLeak-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        store.aiProvider = .openAI
+        store.apiKey = "sk-saved-openai-key"
+        XCTAssertEqual(store.aiProviderCredentialForUserInitiatedAccess(), "sk-saved-openai-key")
+
+        store.aiProvider = .parakeetLocal
+        store.openAIBaseURL = "http://localhost:8422"
+
+        XCTAssertEqual(
+            store.aiProviderCredentialForUserInitiatedAccess(),
+            "",
+            "Switching to a non-requiresAPIKey provider must not return the saved OpenAI key."
+        )
+
+        store.aiProvider = .localCompatible
+        store.openAIBaseURL = "http://localhost:1234/v1"
+        XCTAssertEqual(
+            store.aiProviderCredentialForUserInitiatedAccess(),
+            "",
+            "A non-requiresAPIKey provider must never forward a saved OpenAI key."
+        )
+    }
+
     func testSettingsLoadFromLegacyDefaultsDomain() throws {
         let suiteName = "BugNarrator-SettingsLegacyDefaultsTests-\(UUID().uuidString)"
         let legacyDomainName = "com.abdenterprises.sessionmic.tests.\(UUID().uuidString)"


### PR DESCRIPTION
Closes #278

## Summary
- Stop returning the saved OpenAI API key from `aiProviderCredentialForUserInitiatedAccess` when the active provider does not require an API key, so a previously-saved OpenAI key is no longer forwarded as an `Authorization: Bearer` header to Local Parakeet, Local-Compatible, or OpenAI-Compatible base URLs.

## Acceptance criteria mirror

- [ ] `aiProviderCredentialForUserInitiatedAccess` returns `""` (not the OpenAI key) when `aiProvider.requiresAPIKey` is false and a saved OpenAI key exists.
- [ ] The Parakeet validation request no longer sends an `Authorization` header sourced from the OpenAI key.
- [ ] `SettingsStoreTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/SettingsStore.swift` — non-`requiresAPIKey` branch returns `""` (or `nil` if the base URL is empty); never returns `resolvedKey`.
- `Tests/BugNarratorTests/SettingsStoreTests.swift` — regression test that sets `apiKey` on OpenAI, switches to Parakeet and to Local-Compatible, and asserts the helper does not return the saved key.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/SettingsStoreTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [SECURITY] Stopped forwarding the saved OpenAI API key in the `Authorization` header to non-OpenAI providers, so a previously-configured OpenAI key is no longer leaked to localhost or third-party gateways during validation or transcription.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_