### PR TITLE
[patch] BUG: End recording activity when manual issue extraction fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Ended the recording-controller activity when a manual issue extraction throws, so a failed extraction no longer leaves the process in `.userInitiated, .idleSystemSleepDisabled` activity preventing idle-sleep until the next recording starts.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -1066,6 +1066,7 @@ final class AppState: ObservableObject {
                 recordingSessionController.endActivity()
                 manualIssueExtractionStatusPresenter.presentCompletion(issueCount: extraction.issues.count)
             } catch {
+                recordingSessionController.endActivity()
                 manualIssueExtractionStatusPresenter.presentFailure(error)
             }
 


### PR DESCRIPTION
Closes #279

## Summary
- `extractIssuesForDisplayedTranscript` calls `recordingSessionController.beginActivity(reason: "Extracting review issues")` and `endActivity()` on the success path, but the catch path (post-refactor #202) only called `presentFailure`. Add `endActivity()` to the catch so a failed extraction no longer keeps the process in `.userInitiated, .idleSystemSleepDisabled` activity.

## Acceptance criteria mirror

- [ ] A failing manual issue extraction calls `recordingSessionController.endActivity()` before the failure is presented.
- [ ] The system can idle-sleep after a failed manual extraction.

## Changes
- `Sources/BugNarrator/AppState.swift` — `recordingSessionController.endActivity()` in the catch of `extractIssuesForDisplayedTranscript` before `manualIssueExtractionStatusPresenter.presentFailure(error)`.

No new test: `processActivity` is private to `RecordingSessionController` and `endActivity()` is idempotent, so behavioral assertions on the counter would require an intrusive testing seam for a one-line, inspection-verified fix. The existing `testExtractIssuesWithoutAPIKeyFailsAndOpensSettings` still exercises this path.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS'
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Ended the recording-controller activity when a manual issue extraction throws, so a failed extraction no longer leaves the process in `.userInitiated, .idleSystemSleepDisabled` activity preventing idle-sleep until the next recording starts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_