### PR TITLE
[patch] BUG: End activity on retry post-transcription persistence failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Ended the recording-controller process activity when a retry post-transcription persistence step fails, so a disk-full save during retry no longer keeps the process in `.userInitiated, .idleSystemSleepDisabled` activity.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -236,6 +236,7 @@ final class RetryPostTranscriptionResultHandler {
 
         case .persistenceFailure(_, let error):
             transcriptionRecovery.finishRetry()
+            recordingSessionController.endActivity()
             sessionLibraryStatusPresenter.presentFailure(error)
 
         case .postTranscriptionFailure(let error):

--- a/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
@@ -40,6 +40,8 @@ final class RetryPostTranscriptionResultHandlerTests: XCTestCase {
         let context = try harness.makeRetryContext(index: 3)
 
         XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+        harness.recordingSessionController.beginActivity(reason: "Retry post-transcription")
+        XCTAssertTrue(harness.recordingSessionController.hasActiveProcessActivity)
 
         harness.handler.handle(
             .persistenceFailure(session: context.session, error: AppError.storageFailure("Disk full.")),
@@ -47,6 +49,10 @@ final class RetryPostTranscriptionResultHandlerTests: XCTestCase {
         )
 
         XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        XCTAssertFalse(
+            harness.recordingSessionController.hasActiveProcessActivity,
+            "Retry persistence failure must end the process activity."
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: context.audioFileURL.path))
         XCTAssertFalse(harness.transcriptWindowSpy.didShow)
         XCTAssertEqual(harness.presentationState.status.phase, .error)


### PR DESCRIPTION
Closes #280

## Summary
- Call `recordingSessionController.endActivity()` on the `.persistenceFailure` branch of `RetryPostTranscriptionResultHandler.handle` so a save failure during retry no longer leaves the process in `.userInitiated, .idleSystemSleepDisabled` activity (the retry path called `swapActivity` before transcription and only the `.success` and `.postTranscriptionFailure` branches were ending it).

## Acceptance criteria mirror

- [ ] A persistence failure during retry post-transcription handling calls `recordingSessionController.endActivity()`.
- [ ] `RetryPostTranscriptionResultHandlerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift` — `endActivity()` before `presentFailure` in `.persistenceFailure`.
- `Sources/BugNarrator/Services/RecordingSessionController.swift` — add `hasActiveProcessActivity: Bool` (non-invasive testing seam).
- `Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift` — extend the persistence-failure test to begin an activity before invoking the handler and assert it is released afterwards.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RetryPostTranscriptionResultHandlerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Ended the recording-controller process activity when a retry post-transcription persistence step fails, so a disk-full save during retry no longer keeps the process in `.userInitiated, .idleSystemSleepDisabled` activity.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_