### PR TITLE
[patch] BUG: Retry transcription on transient network failures, not only rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Retried transcription uploads on transient `URLError` network failures (timeout, connection lost, host unreachable) with the same exponential backoff used for rate-limit retries, so a single network blip during upload no longer fails the whole transcription.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -182,12 +182,13 @@ actor TranscriptionClient: TranscriptionServing {
             do {
                 return try await attemptTranscription(fileURL: fileURL, apiKey: apiKey, request: request, attempt: attempt)
             } catch let error as AppError {
-                if case .rateLimited(let retryAfter) = error, attempt < Self.maxRetryAttempts - 1 {
-                    let delay = retryAfter ?? (Self.initialBackoffSeconds * pow(2, Double(attempt)))
+                let isLastAttempt = attempt >= Self.maxRetryAttempts - 1
+                if case .rateLimited(let retryAfter) = error, !isLastAttempt {
+                    let delay = retryAfter ?? Self.exponentialBackoff(for: attempt)
                     let clampedDelay = min(delay, 60)
                     logger.warning(
                         "transcription_rate_limited_retrying",
-                        "OpenAI rate limit hit. Backing off before retry.",
+                        "Rate limit hit. Backing off before retry.",
                         metadata: [
                             "attempt": "\(attempt + 1)",
                             "backoff_seconds": String(format: "%.1f", clampedDelay)
@@ -197,13 +198,51 @@ actor TranscriptionClient: TranscriptionServing {
                     lastError = error
                     continue
                 }
+                if Self.shouldRetryTransientFailure(error), !isLastAttempt {
+                    let delay = Self.exponentialBackoff(for: attempt)
+                    logger.warning(
+                        "transcription_transient_failure_retrying",
+                        "Transient transport failure. Backing off before retry.",
+                        metadata: [
+                            "attempt": "\(attempt + 1)",
+                            "backoff_seconds": String(format: "%.1f", delay),
+                            "error_type": Self.errorTypeForLogging(error)
+                        ]
+                    )
+                    try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    lastError = error
+                    continue
+                }
                 throw error
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 throw error
             }
         }
 
         throw lastError ?? AppError.transcriptionFailure("Transcription failed after retries.")
+    }
+
+    private static func exponentialBackoff(for attempt: Int) -> TimeInterval {
+        initialBackoffSeconds * pow(2, Double(attempt))
+    }
+
+    private static func shouldRetryTransientFailure(_ error: AppError) -> Bool {
+        switch error {
+        case .networkTimeout, .networkFailure:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func errorTypeForLogging(_ error: AppError) -> String {
+        switch error {
+        case .networkTimeout: return "network_timeout"
+        case .networkFailure: return "network_failure"
+        default: return "other"
+        }
     }
 
     private func attemptTranscription(


### PR DESCRIPTION
Closes #281

## Summary
- Retry transcription on transient `URLError` failures (timeout, connection lost, host unreachable) with the same exponential backoff used for rate-limit retries, so a single network blip during upload no longer fails the whole transcription. The retry loop previously only continued on `.rateLimited`, making `maxRetryAttempts = 3` effectively `1` for transport blips.

## Acceptance criteria mirror

- [ ] A single `URLError` network blip during transcription is retried with exponential backoff.
- [ ] A persistent failure still raises after `maxRetryAttempts`.
- [ ] Rate-limit handling continues to honor `Retry-After`.
- [ ] `CancellationError` still propagates immediately (not retried).

## Changes
- `Sources/BugNarrator/Services/TranscriptionClient.swift` — extract `exponentialBackoff(for:)`, add `shouldRetryTransientFailure`, and a transient-failure retry branch that logs each retry with the kind. `CancellationError` is explicitly re-thrown without retry.

No automated test in this change: exercising the retry through the real URLSession with backoffs would require either a 2s+ delay in CI or a new test-only clock seam on TranscriptionClient; the fix is small and inspection-verified. Happy to add an instrumented test in a follow-up if the team prefers.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/TranscriptionClientTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Retried transcription uploads on transient `URLError` network failures (timeout, connection lost, host unreachable) with the same exponential backoff used for rate-limit retries, so a single network blip during upload no longer fails the whole transcription.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_