### PR TITLE
[patch] BUG: Close system audio writer before invalidating tap session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Closed the system-audio file writer and drained in-flight Core Audio IO callbacks before invalidating the tap session in `SystemAudioRecorder.stopRecording` / `cancelRecording`, removing a race where a callback could write to a soon-to-be-released `AVAudioFile`.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -108,8 +108,9 @@ final class SystemAudioRecorder: AudioRecording {
             metadata: ["file_name": currentFileURL.lastPathComponent]
         )
 
-        tapSession.invalidate()
         activeWriter.close()
+        ioQueue.sync { }
+        tapSession.invalidate()
         cleanupActiveState()
 
         try validateRecordedAudioFile(at: currentFileURL)
@@ -128,8 +129,9 @@ final class SystemAudioRecorder: AudioRecording {
 
     func cancelRecording(preserveFile: Bool) async {
         let fileURL = currentFileURL
-        tapSession?.invalidate()
         activeWriter?.close()
+        ioQueue.sync { }
+        tapSession?.invalidate()
         cleanupActiveState()
 
         guard !preserveFile, let fileURL else {


### PR DESCRIPTION
Closes #282

## Summary
- Invert the stop/cancel ordering in `SystemAudioRecorder`: close the writer first (marks `file = nil` under its lock), `ioQueue.sync { }` to drain in-flight Core Audio IO callbacks, then invalidate the tap session and `cleanupActiveState`. The previous order let in-flight `AudioDeviceIOProc` blocks contend for the writer's lock after `cleanupActiveState` had dropped its last strong reference, producing a write-after-effective-lifetime against the `AVAudioFile`.

## Acceptance criteria mirror

- [ ] `stopRecording` closes the writer first, drains the IO queue, then invalidates the tap session.
- [ ] No write occurs against a nilled file or invalidated tap after `stopRecording` returns.
- [ ] `cancelRecording` follows the same ordering.

## Changes
- `Sources/BugNarrator/Services/SystemAudioRecorder.swift` — swap close/invalidate order and add `ioQueue.sync { }` drain in both `stopRecording` and `cancelRecording`. Safe from `@MainActor` since the IO callbacks do not re-dispatch to MainActor.

No automated test: deterministically forcing the race requires injecting Core Audio callback timing, which is not exposed by AudioToolbox. Fix is by inspection; the race analysis is documented in the linked issue.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS'
- Manual: start a recording with system audio, stop it; verify no thread-sanitizer reports under Xcode's TSan-enabled scheme.
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Closed the system-audio file writer and drained in-flight Core Audio IO callbacks before invalidating the tap session in `SystemAudioRecorder.stopRecording` / `cancelRecording`, removing a race where a callback could write to a soon-to-be-released `AVAudioFile`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_