### PR TITLE
[patch] BUG: Restore Settings auto-open and stale-progress cleanup on recording start failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
+- [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.
 
 ## 1.0.35 - 2026-05-19
 

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -276,7 +276,11 @@ final class AppState: ObservableObject {
                     "ai_provider": settingsStore.aiProvider.rawValue
                 ]
             },
-            telemetryRecorder: telemetryRecorder
+            telemetryRecorder: telemetryRecorder,
+            showSettingsWindow: { [weak self] in self?.showSettingsWindow?() },
+            prepareErrorPresentationSideEffects: { [weak self] in
+                self?.prepareErrorPresentationSideEffects()
+            }
         )
         let sessionLibrary = SessionLibraryController(
             transcriptStore: transcriptStore,

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -6,6 +6,8 @@ final class RecordingSessionStartStatusPresenter {
     private let recordingStatusMessages: RecordingStatusMessageProvider
     private let startDiagnosticsMetadata: () -> [String: String]
     private let telemetryRecorder: any OperationalTelemetryRecording
+    private let showSettingsWindow: () -> Void
+    private let prepareErrorPresentationSideEffects: () -> Void
     private let recordingLogger: DiagnosticsLogger
     private let permissionsLogger: DiagnosticsLogger
 
@@ -14,6 +16,8 @@ final class RecordingSessionStartStatusPresenter {
         recordingStatusMessages: RecordingStatusMessageProvider,
         startDiagnosticsMetadata: @escaping () -> [String: String],
         telemetryRecorder: any OperationalTelemetryRecording,
+        showSettingsWindow: @escaping () -> Void = {},
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {},
         recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording),
         permissionsLogger: DiagnosticsLogger = DiagnosticsLogger(category: .permissions)
     ) {
@@ -21,6 +25,8 @@ final class RecordingSessionStartStatusPresenter {
         self.recordingStatusMessages = recordingStatusMessages
         self.startDiagnosticsMetadata = startDiagnosticsMetadata
         self.telemetryRecorder = telemetryRecorder
+        self.showSettingsWindow = showSettingsWindow
+        self.prepareErrorPresentationSideEffects = prepareErrorPresentationSideEffects
         self.recordingLogger = recordingLogger
         self.permissionsLogger = permissionsLogger
     }
@@ -43,10 +49,22 @@ final class RecordingSessionStartStatusPresenter {
 
         case .preflightFailure(let preflightError):
             permissionsLogger.warning(.sessionStartPreflightFailed, preflightError.userMessage)
-            _ = errorPresenter.presentError(preflightError, operation: .recordingStart)
+            prepareErrorPresentationSideEffects()
+            let result = errorPresenter.presentError(preflightError, operation: .recordingStart)
+            if result.shouldOpenSettingsWindow {
+                showSettingsWindow()
+            }
 
         case .failure(let error):
-            _ = errorPresenter.presentError(error, operation: .recordingStart, fallback: { .recordingFailure($0) })
+            prepareErrorPresentationSideEffects()
+            let result = errorPresenter.presentError(
+                error,
+                operation: .recordingStart,
+                fallback: { .recordingFailure($0) }
+            )
+            if result.shouldOpenSettingsWindow {
+                showSettingsWindow()
+            }
 
         case .started(let recordingSession):
             errorPresenter.setStatus(.recording(recordingStatusMessages.recordingDetailMessage()))

--- a/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
+++ b/Tests/BugNarratorTests/RecordingSessionControllerTests.swift
@@ -86,6 +86,53 @@ final class RecordingSessionControllerTests: XCTestCase {
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "recording_start")
     }
 
+    func testStartStatusPresenterOpensSettingsAndCleansUpOnCredentialPreflightFailure() {
+        var showSettingsCallCount = 0
+        var prepareCleanupCallCount = 0
+        let harness = makeStartStatusPresenter(
+            showSettingsWindow: { showSettingsCallCount += 1 },
+            prepareErrorPresentationSideEffects: { prepareCleanupCallCount += 1 }
+        )
+
+        harness.presenter.present(.preflightFailure(.missingAPIKey))
+
+        XCTAssertEqual(showSettingsCallCount, 1, "missingAPIKey preflight failure should open Settings.")
+        XCTAssertEqual(prepareCleanupCallCount, 1, "missingAPIKey preflight failure should run cleanup hook.")
+    }
+
+    func testStartStatusPresenterDoesNotOpenSettingsForMicrophoneFailure() {
+        var showSettingsCallCount = 0
+        var prepareCleanupCallCount = 0
+        let harness = makeStartStatusPresenter(
+            showSettingsWindow: { showSettingsCallCount += 1 },
+            prepareErrorPresentationSideEffects: { prepareCleanupCallCount += 1 }
+        )
+
+        harness.presenter.present(.preflightFailure(.microphonePermissionDenied))
+
+        XCTAssertEqual(showSettingsCallCount, 0, "Microphone permission failure should not open Settings.")
+        XCTAssertEqual(prepareCleanupCallCount, 1, "Cleanup hook should still run for non-credential failures.")
+    }
+
+    func testStartStatusPresenterRunsCleanupOnGenericStartFailure() {
+        var showSettingsCallCount = 0
+        var prepareCleanupCallCount = 0
+        let harness = makeStartStatusPresenter(
+            showSettingsWindow: { showSettingsCallCount += 1 },
+            prepareErrorPresentationSideEffects: { prepareCleanupCallCount += 1 }
+        )
+
+        let underlyingError = NSError(
+            domain: "RecordingSessionControllerTests",
+            code: 13,
+            userInfo: [NSLocalizedDescriptionKey: "Recorder crashed."]
+        )
+        harness.presenter.present(.failure(underlyingError))
+
+        XCTAssertEqual(prepareCleanupCallCount, 1, "Generic start failure should run cleanup hook.")
+        XCTAssertEqual(showSettingsCallCount, 0, "Generic start failure should not open Settings.")
+    }
+
     func testStartStatusPresenterNormalizesGenericStartFailure() {
         let harness = makeStartStatusPresenter()
         let error = NSError(
@@ -393,7 +440,9 @@ final class RecordingSessionControllerTests: XCTestCase {
     }
 
     private func makeStartStatusPresenter(
-        status: AppStatus = .idle()
+        status: AppStatus = .idle(),
+        showSettingsWindow: @escaping () -> Void = {},
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {}
     ) -> (
         presenter: RecordingSessionStartStatusPresenter,
         presentationState: AppPresentationState,
@@ -424,7 +473,9 @@ final class RecordingSessionControllerTests: XCTestCase {
             ),
             recordingStatusMessages: statusMessages,
             startDiagnosticsMetadata: { diagnosticsMetadata },
-            telemetryRecorder: telemetryRecorder
+            telemetryRecorder: telemetryRecorder,
+            showSettingsWindow: showSettingsWindow,
+            prepareErrorPresentationSideEffects: prepareErrorPresentationSideEffects
         )
 
         return (


### PR DESCRIPTION
Closes #283

## Summary
- Inject `showSettingsWindow` and `prepareErrorPresentationSideEffects` closures into `RecordingSessionStartStatusPresenter` so `.preflightFailure` and `.failure` once again open Settings on credential errors and clear in-flight issue-extraction/export progress that the refactor #200 dropped when it moved this code out of `AppState.presentError`.

## Acceptance criteria mirror

- [ ] A start failure surfacing `missingAPIKey` / `invalidAPIKey` / `revokedAPIKey` opens Settings.
- [ ] A start failure clears in-flight issue extraction and export progress.
- [ ] `RecordingSessionControllerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/RecordingSessionController.swift` — `RecordingSessionStartStatusPresenter` gains optional `showSettingsWindow` and `prepareErrorPresentationSideEffects` closures (defaulted to no-ops), called on both failure branches; consults `result.shouldOpenSettingsWindow`.
- `Sources/BugNarrator/AppState.swift` — wire `showSettingsWindow` and the existing `prepareErrorPresentationSideEffects()` private method through `[weak self]` captures.
- `Tests/BugNarratorTests/RecordingSessionControllerTests.swift` — extend harness with the two closure parameters; add tests for missingAPIKey (Settings opens + cleanup), microphone failure (cleanup only), and generic failure (cleanup only).

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/RecordingSessionControllerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_