### PR TITLE
[patch] BUG: Clear in-flight progress on session library save/delete failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Cleared in-flight issue-extraction/export progress and ended recording activity when a session library save or delete fails, so stale spinners no longer linger on top of the failure toast.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -285,7 +285,10 @@ final class AppState: ObservableObject {
         )
         self.sessionLibrary = sessionLibrary
         self.sessionLibraryStatusPresenter = SessionLibraryStatusPresenter(
-            errorPresenter: self.errorPresenter
+            errorPresenter: self.errorPresenter,
+            prepareErrorPresentationSideEffects: { [weak self] in
+                self?.prepareErrorPresentationSideEffects()
+            }
         )
         self.exportHistoryController = ExportHistoryController(exportService: exportService)
         let recoveredRecordingImportController = RecoveredRecordingImportController(

--- a/Sources/BugNarrator/Services/SessionLibraryController.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryController.swift
@@ -43,9 +43,14 @@ enum SessionDeletionStatusPresenter {
 @MainActor
 final class SessionLibraryStatusPresenter {
     private let errorPresenter: AppErrorPresenter
+    private let prepareErrorPresentationSideEffects: () -> Void
 
-    init(errorPresenter: AppErrorPresenter) {
+    init(
+        errorPresenter: AppErrorPresenter,
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {}
+    ) {
         self.errorPresenter = errorPresenter
+        self.prepareErrorPresentationSideEffects = prepareErrorPresentationSideEffects
     }
 
     func presentDisplayedTranscriptCopyResult(_ result: DisplayedTranscriptCopyResult) {
@@ -67,6 +72,7 @@ final class SessionLibraryStatusPresenter {
     }
 
     func presentFailure(_ error: Error) {
+        prepareErrorPresentationSideEffects()
         _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
     }
 }

--- a/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryControllerTests.swift
@@ -202,6 +202,22 @@ final class SessionLibraryControllerTests: XCTestCase {
         XCTAssertTrue(harness.telemetryRecorder.recordedEvents.isEmpty)
     }
 
+    func testSessionLibraryStatusPresenterRunsCleanupHookOnFailure() {
+        var cleanupCallCount = 0
+        let harness = makeSessionLibraryStatusPresenter(
+            prepareErrorPresentationSideEffects: { cleanupCallCount += 1 }
+        )
+
+        harness.presenter.presentFailure(AppError.storageFailure("Disk locked."))
+
+        XCTAssertEqual(cleanupCallCount, 1, "presentFailure must run the cleanup hook before delegating to errorPresenter.")
+        XCTAssertEqual(
+            harness.presentationState.status,
+            .error(AppError.storageFailure("Disk locked.").userMessage)
+        )
+        XCTAssertEqual(harness.presentationState.currentError, .storageFailure("Disk locked."))
+    }
+
     func testSessionLibraryStatusPresenterLeavesStatusForNoDeletedSessions() {
         let harness = makeSessionLibraryStatusPresenter(status: .idle("Ready."))
 
@@ -318,7 +334,8 @@ final class SessionLibraryControllerTests: XCTestCase {
     }
 
     private func makeSessionLibraryStatusPresenter(
-        status: AppStatus = .idle()
+        status: AppStatus = .idle(),
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {}
     ) -> (
         presenter: SessionLibraryStatusPresenter,
         presentationState: AppPresentationState,
@@ -330,7 +347,8 @@ final class SessionLibraryControllerTests: XCTestCase {
             errorPresenter: AppErrorPresenter(
                 presentationState: presentationState,
                 telemetryRecorder: telemetryRecorder
-            )
+            ),
+            prepareErrorPresentationSideEffects: prepareErrorPresentationSideEffects
         )
 
         return (


### PR DESCRIPTION
Closes #284

## Summary
- Inject a `prepareErrorPresentationSideEffects` closure into `SessionLibraryStatusPresenter` so `presentFailure` clears in-flight issue-extraction/export progress and ends recording activity before delegating to `errorPresenter.presentError` — restoring the cleanup that refactor #206 dropped.

## Acceptance criteria mirror

- [ ] A failing `saveCurrentTranscriptToHistory` clears in-flight issue extraction and export progress and ends activity.
- [ ] `SessionLibraryControllerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/SessionLibraryController.swift` — `SessionLibraryStatusPresenter` gains optional `prepareErrorPresentationSideEffects` closure (defaulted to no-op) and calls it from `presentFailure`.
- `Sources/BugNarrator/AppState.swift` — wire the closure to `prepareErrorPresentationSideEffects()` via `[weak self]`.
- `Tests/BugNarratorTests/SessionLibraryControllerTests.swift` — extend harness; add regression test asserting the cleanup hook fires when `presentFailure` is called.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/SessionLibraryControllerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Cleared in-flight issue-extraction/export progress and ended recording activity when a session library save or delete fails, so stale spinners no longer linger on top of the failure toast.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_