### PR TITLE
[patch] BUG: Clear in-flight progress on issue mutation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
+
 ## 1.0.35 - 2026-05-19
 
 - Added local Parakeet transcription server for offline, zero-cost speech-to-text on Apple Silicon via MLX.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -353,7 +353,10 @@ final class AppState: ObservableObject {
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
         self.issueMutationFailurePresenter = IssueMutationFailurePresenter(
-            errorPresenter: self.errorPresenter
+            errorPresenter: self.errorPresenter,
+            prepareErrorPresentationSideEffects: { [weak self] in
+                self?.prepareErrorPresentationSideEffects()
+            }
         )
         self.issueExportPresentationController = IssueExportPresentationController(
             errorPresenter: self.errorPresenter,

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -71,12 +71,18 @@ final class ManualIssueExtractionStatusPresenter {
 @MainActor
 final class IssueMutationFailurePresenter {
     private let errorPresenter: AppErrorPresenter
+    private let prepareErrorPresentationSideEffects: () -> Void
 
-    init(errorPresenter: AppErrorPresenter) {
+    init(
+        errorPresenter: AppErrorPresenter,
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {}
+    ) {
         self.errorPresenter = errorPresenter
+        self.prepareErrorPresentationSideEffects = prepareErrorPresentationSideEffects
     }
 
     func presentFailure(_ error: Error) {
+        prepareErrorPresentationSideEffects()
         _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
     }
 }

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -91,6 +91,17 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
     }
 
+    func testIssueMutationFailurePresenterRunsCleanupHookOnFailure() {
+        var cleanupCallCount = 0
+        let harness = makeIssueMutationFailurePresenter(
+            prepareErrorPresentationSideEffects: { cleanupCallCount += 1 }
+        )
+
+        harness.presenter.presentFailure(AppError.storageFailure("Could not save."))
+
+        XCTAssertEqual(cleanupCallCount, 1, "presentFailure must run the cleanup hook before delegating to errorPresenter.")
+    }
+
     func testPreflightMapsCredentialTranscriptAndRecordingFailures() throws {
         let harness = try IssueExtractionControllerHarness()
         defer { harness.cleanup() }
@@ -218,7 +229,8 @@ final class IssueExtractionControllerTests: XCTestCase {
     }
 
     private func makeIssueMutationFailurePresenter(
-        status: AppStatus = .idle()
+        status: AppStatus = .idle(),
+        prepareErrorPresentationSideEffects: @escaping () -> Void = {}
     ) -> (
         presenter: IssueMutationFailurePresenter,
         presentationState: AppPresentationState,
@@ -230,7 +242,8 @@ final class IssueExtractionControllerTests: XCTestCase {
             errorPresenter: AppErrorPresenter(
                 presentationState: presentationState,
                 telemetryRecorder: telemetryRecorder
-            )
+            ),
+            prepareErrorPresentationSideEffects: prepareErrorPresentationSideEffects
         )
 
         return (


### PR DESCRIPTION
Closes #285

## Summary
- Inject a `prepareErrorPresentationSideEffects` closure into `IssueMutationFailurePresenter` so `presentFailure` runs the in-flight progress cleanup (clear extraction/export, etc.) before delegating to `errorPresenter.presentError` — restoring the side effect that refactor #210 dropped.

## Acceptance criteria mirror

- [ ] A failing issue-mutation write clears in-flight issue extraction and export progress.
- [ ] `IssueExtractionControllerTests` pass locally.

## Changes
- `Sources/BugNarrator/Services/IssueExtractionController.swift` — `IssueMutationFailurePresenter` gains optional `prepareErrorPresentationSideEffects` closure (defaulted to no-op).
- `Sources/BugNarrator/AppState.swift` — wire closure to `prepareErrorPresentationSideEffects()` via `[weak self]`.
- `Tests/BugNarratorTests/IssueExtractionControllerTests.swift` — extend harness; add regression test asserting the cleanup hook fires.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/IssueExtractionControllerTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_