### PR TITLE
[patch] BUG: Harden Retry-After parsing against zero, HTTP-date, and case variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Hardened `Retry-After` parsing to floor at one second, accept RFC 7231 HTTP-date values, and look up the header case-insensitively, so a server-sent `Retry-After: 0` no longer produces a no-backoff retry loop and date-form responses no longer fall through to exponential backoff.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/Sources/BugNarrator/Services/OpenAIErrorMapper.swift
+++ b/Sources/BugNarrator/Services/OpenAIErrorMapper.swift
@@ -35,12 +35,50 @@ enum OpenAIErrorMapper {
         return fallback(message)
     }
 
-    private static func parseRetryAfter(from headers: [AnyHashable: Any]?) -> TimeInterval? {
-        guard let retryValue = headers?["Retry-After"] as? String ?? headers?["retry-after"] as? String else {
+    static func parseRetryAfter(from headers: [AnyHashable: Any]?, now: Date = Date()) -> TimeInterval? {
+        guard let retryValue = retryAfterHeaderValue(in: headers) else {
             return nil
         }
-        return TimeInterval(retryValue)
+
+        let trimmed = retryValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let seconds = TimeInterval(trimmed) {
+            return max(seconds, 1)
+        }
+
+        if let date = httpDateFormatter.date(from: trimmed) {
+            let interval = date.timeIntervalSince(now)
+            return max(interval, 1)
+        }
+
+        return nil
     }
+
+    private static func retryAfterHeaderValue(in headers: [AnyHashable: Any]?) -> String? {
+        guard let headers else {
+            return nil
+        }
+
+        for (key, value) in headers {
+            guard let name = key as? String else {
+                continue
+            }
+            if name.caseInsensitiveCompare("Retry-After") == .orderedSame,
+               let stringValue = value as? String {
+                return stringValue
+            }
+        }
+
+        return nil
+    }
+
+    private static let httpDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
 
     static func mapTransportError(_ error: Error, fallback: (String) -> AppError) -> AppError {
         if let appError = error as? AppError {

--- a/Tests/BugNarratorTests/OpenAIErrorMapperTests.swift
+++ b/Tests/BugNarratorTests/OpenAIErrorMapperTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import BugNarrator
+
+final class OpenAIErrorMapperTests: XCTestCase {
+    func testParseRetryAfterAcceptsCaseInsensitiveHeaderName() {
+        let headers: [AnyHashable: Any] = ["RETRY-AFTER": "12"]
+        XCTAssertEqual(OpenAIErrorMapper.parseRetryAfter(from: headers), 12)
+    }
+
+    func testParseRetryAfterFloorsZeroAtOneSecond() {
+        let headers: [AnyHashable: Any] = ["Retry-After": "0"]
+        XCTAssertEqual(OpenAIErrorMapper.parseRetryAfter(from: headers), 1)
+    }
+
+    func testParseRetryAfterFloorsNegativeValueAtOneSecond() {
+        let headers: [AnyHashable: Any] = ["Retry-After": "-5"]
+        XCTAssertEqual(OpenAIErrorMapper.parseRetryAfter(from: headers), 1)
+    }
+
+    func testParseRetryAfterReturnsSecondsForNumericValue() {
+        let headers: [AnyHashable: Any] = ["Retry-After": "30"]
+        XCTAssertEqual(OpenAIErrorMapper.parseRetryAfter(from: headers), 30)
+    }
+
+    func testParseRetryAfterParsesHTTPDateFormat() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let later = now.addingTimeInterval(15)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        let headers: [AnyHashable: Any] = ["Retry-After": formatter.string(from: later)]
+
+        let parsed = OpenAIErrorMapper.parseRetryAfter(from: headers, now: now)
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed!, 15, accuracy: 1.0)
+    }
+
+    func testParseRetryAfterReturnsNilForMissingHeader() {
+        XCTAssertNil(OpenAIErrorMapper.parseRetryAfter(from: nil))
+        XCTAssertNil(OpenAIErrorMapper.parseRetryAfter(from: [:]))
+    }
+
+    func testParseRetryAfterReturnsNilForUnparseableValue() {
+        let headers: [AnyHashable: Any] = ["Retry-After": "soon-ish"]
+        XCTAssertNil(OpenAIErrorMapper.parseRetryAfter(from: headers))
+    }
+
+    func testMapResponseHonorsCaseInsensitiveRetryAfter() {
+        let result = OpenAIErrorMapper.mapResponse(
+            statusCode: 429,
+            data: Data(),
+            fallback: AppError.transcriptionFailure,
+            responseHeaders: ["RETRY-AFTER": "0"]
+        )
+
+        guard case .rateLimited(let retryAfter) = result else {
+            return XCTFail("Expected .rateLimited, got \(result)")
+        }
+        XCTAssertEqual(retryAfter, 1, "Zero Retry-After should be floored at 1s instead of producing an immediate retry loop.")
+    }
+}


### PR DESCRIPTION
Closes #286

## Summary
- Floor `Retry-After` at 1 second so a server-sent `0` no longer produces an immediate-retry tight loop. Parse the RFC 7231 HTTP-date form via a fixed `en_US_POSIX`/`GMT` formatter. Look up the header by case-insensitive name so `RETRY-AFTER` / `retry-after` both parse.

## Acceptance criteria mirror

- [ ] `Retry-After: 0` produces at least a 1-second backoff.
- [ ] `Retry-After` in HTTP-date format produces equivalent seconds-from-now.
- [ ] `Retry-After: RETRY-AFTER` and lower-case `retry-after` both parse.

## Changes
- `Sources/BugNarrator/Services/OpenAIErrorMapper.swift` — make `parseRetryAfter` `static` (no longer `private`), add an optional `now: Date = Date()` for testability, floor numeric values at 1s, add HTTP-date fallback, and case-insensitive header lookup helper.
- `Tests/BugNarratorTests/OpenAIErrorMapperTests.swift` — new test file covering numeric, zero, negative, HTTP-date, missing, unparseable, case-variation, and the end-to-end 429 → `.rateLimited(retryAfter: 1)` path.

## Test plan

- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/OpenAIErrorMapperTests
- ./scripts/validate.sh origin/main

## Changelog entry

- [FIX] Hardened `Retry-After` parsing to floor at one second, accept RFC 7231 HTTP-date values, and look up the header case-insensitively, so a server-sent `Retry-After: 0` no longer produces a no-backoff retry loop.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_