### PR TITLE
[patch] CHORE: Make local validation and CI useful for cloud/phone development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ local-transcription/venv/
 local-transcription/build/
 local-transcription/dist/
 .worktrees/
+
+# scripts/validate.sh and scripts/swift-parse-check.sh write status/output
+# files here on every run; they should never be committed.
+artifacts/validation/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [INTERNAL] Made local + CI validation useful for cloud / phone development: `scripts/validate.sh` now falls back to a locally installed `semgrep` (pip / pipx / Homebrew) when Docker is unavailable, and a new `scripts/swift-parse-check.sh` runs `swiftc -parse` on every source file so any Swift toolchain catches syntax errors without needing Xcode or resolvable imports.
 - [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.

--- a/artifacts/validation/semgrep-status.txt
+++ b/artifacts/validation/semgrep-status.txt
@@ -1,1 +1,0 @@
-PASS: no scannable changed files for semgrep

--- a/scripts/swift-parse-check.sh
+++ b/scripts/swift-parse-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Swift parse-only syntax check for the BugNarrator source tree.
+#
+# Runs `swiftc -parse` on every Sources/**/*.swift file. The `-parse` action
+# only performs lexing + parsing — no type checking, no import resolution — so
+# this catches Swift syntax errors in any environment that has a Swift
+# toolchain (macOS Xcode, Linux swift.org toolchain, cloud sandbox), without
+# needing the macOS-only Foundation/AppKit modules that BugNarrator imports
+# in semantic-checked builds.
+#
+# Designed for use from validate.sh and from cloud development sessions
+# (Claude Code on the web/phone) where xcodebuild is unavailable.
+#
+# Exit codes:
+#   0 on success or when swift is unavailable (clean skip)
+#   non-zero if swiftc -parse reports a syntax error
+#
+# Status is written to artifacts/validation/swift-parse-status.txt so the
+# outcome is visible in CI artifacts.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VALIDATION_ARTIFACT_DIR="artifacts/validation"
+STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/swift-parse-status.txt"
+OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/swift-parse-output.txt"
+mkdir -p "$VALIDATION_ARTIFACT_DIR"
+rm -f "$STATUS_FILE" "$OUTPUT_FILE"
+
+SWIFT_BIN=""
+if command -v swiftc >/dev/null 2>&1; then
+  SWIFT_BIN="swiftc"
+elif command -v swift >/dev/null 2>&1; then
+  SWIFT_BIN="swift"
+fi
+
+if [[ -z "$SWIFT_BIN" ]]; then
+  printf 'NOT RUN: swift toolchain unavailable in this environment\n' >"$STATUS_FILE"
+  exit 0
+fi
+
+if [[ ! -d "Sources" ]]; then
+  printf 'NOT RUN: Sources directory not found\n' >"$STATUS_FILE"
+  exit 0
+fi
+
+# Collect every Swift source file under Sources/.
+SWIFT_FILES=()
+while IFS= read -r -d '' file; do
+  SWIFT_FILES+=("$file")
+done < <(find Sources -type f -name '*.swift' -print0)
+
+if [[ ${#SWIFT_FILES[@]} -eq 0 ]]; then
+  printf 'NOT RUN: no Swift source files found under Sources/\n' >"$STATUS_FILE"
+  exit 0
+fi
+
+# Run parse-only on the whole tree. The -parse action does not require
+# resolvable imports; it stops after syntax + name binding.
+if [[ "$SWIFT_BIN" == "swiftc" ]]; then
+  PARSE_CMD=(swiftc -parse)
+else
+  PARSE_CMD=(swift -frontend -parse)
+fi
+
+if "${PARSE_CMD[@]}" "${SWIFT_FILES[@]}" >"$OUTPUT_FILE" 2>&1; then
+  printf 'PASS: swift parse succeeded for %d files via %s\n' "${#SWIFT_FILES[@]}" "$SWIFT_BIN" >"$STATUS_FILE"
+  exit 0
+fi
+
+printf 'FAIL: swift parse reported errors via %s\n' "$SWIFT_BIN" >"$STATUS_FILE"
+cat "$OUTPUT_FILE" >&2
+exit 1

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+# Local + CI guardrails entry point.
+#
+# Runs semgrep against the changed files (Docker first, then a locally
+# installed `semgrep` on PATH — pip / pipx / Homebrew — as a fallback so cloud
+# / phone development sessions without Docker still produce a non-trivial
+# signal). Then runs swift-parse-check.sh which is cheap and portable across
+# macOS Xcode, Linux swift.org toolchains, and cloud sandboxes.
+#
+# Status outputs land under artifacts/validation/ so the source of each
+# check is visible in CI artifacts:
+#   semgrep-status.txt      PASS / NOT RUN with the runner that produced it
+#   swift-parse-status.txt  PASS / NOT RUN from swift-parse-check.sh
+
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,34 +43,91 @@ should_skip_semgrep_target() {
   return 1
 }
 
-if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-  SEMGREP_TARGETS=()
+# Build the changed-files target list, or fall back to scanning the whole
+# tree when there is no base ref available (e.g. first push of a branch).
+SEMGREP_TARGETS=()
+if [[ -n "$BASE_REF" ]]; then
+  while IFS= read -r target; do
+    [[ -n "$target" ]] || continue
+    [[ -f "$target" ]] || continue
+    should_skip_semgrep_target "$target" && continue
+    SEMGREP_TARGETS+=("$target")
+  done < <(git diff --name-only "${BASE_REF}...HEAD" --)
+fi
 
-  if [[ -n "$BASE_REF" ]]; then
-    while IFS= read -r target; do
-      [[ -n "$target" ]] || continue
-      [[ -f "$target" ]] || continue
-      should_skip_semgrep_target "$target" && continue
-      SEMGREP_TARGETS+=("$target")
-    done < <(git diff --name-only "${BASE_REF}...HEAD" --)
+# Returns 0 on semgrep pass, 1 on semgrep findings, 2 on "runner unavailable".
+run_semgrep_docker() {
+  if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    return 2
   fi
 
+  if docker run --rm -v "${ROOT}":/src -w /src -e SEMGREP_APP_TOKEN \
+    semgrep/semgrep semgrep scan --config=auto --error "$@" \
+    >"$SEMGREP_OUTPUT_FILE" 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+run_semgrep_local() {
+  if ! command -v semgrep >/dev/null 2>&1; then
+    return 2
+  fi
+
+  if semgrep scan --config=auto --error "$@" >"$SEMGREP_OUTPUT_FILE" 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+if [[ ${#SEMGREP_TARGETS[@]} -eq 0 && -n "$BASE_REF" ]]; then
+  printf 'PASS: no scannable changed files for semgrep\n' >"$SEMGREP_STATUS_FILE"
+else
   if [[ ${#SEMGREP_TARGETS[@]} -eq 0 ]]; then
-    if [[ -n "$BASE_REF" ]]; then
-      printf 'PASS: no scannable changed files for semgrep\n' >"$SEMGREP_STATUS_FILE"
-    else
-      SEMGREP_TARGETS=(.)
-    fi
+    SEMGREP_TARGETS=(.)
   fi
 
-  if [[ ${#SEMGREP_TARGETS[@]} -gt 0 ]]; then
-    if docker run --rm -v "${ROOT}":/src -w /src -e SEMGREP_APP_TOKEN semgrep/semgrep semgrep scan --config=auto --error "${SEMGREP_TARGETS[@]}" >"$SEMGREP_OUTPUT_FILE" 2>&1; then
-      printf 'PASS: semgrep completed successfully\n' >"$SEMGREP_STATUS_FILE"
-    else
+  semgrep_outcome="unknown"
+  set +e
+  run_semgrep_docker "${SEMGREP_TARGETS[@]}"
+  docker_status=$?
+  set -e
+
+  case "$docker_status" in
+    0)
+      printf 'PASS: semgrep completed successfully via docker\n' >"$SEMGREP_STATUS_FILE"
+      semgrep_outcome="pass"
+      ;;
+    1)
       cat "$SEMGREP_OUTPUT_FILE" >&2
       exit 1
-    fi
-  fi
-else
-  printf 'NOT RUN: Docker is unavailable in this environment\n' >"$SEMGREP_STATUS_FILE"
+      ;;
+    *)
+      set +e
+      run_semgrep_local "${SEMGREP_TARGETS[@]}"
+      local_status=$?
+      set -e
+
+      case "$local_status" in
+        0)
+          printf 'PASS: semgrep completed successfully via local PATH\n' >"$SEMGREP_STATUS_FILE"
+          semgrep_outcome="pass"
+          ;;
+        1)
+          cat "$SEMGREP_OUTPUT_FILE" >&2
+          exit 1
+          ;;
+        *)
+          printf 'NOT RUN: neither docker nor a local semgrep on PATH is available\n' >"$SEMGREP_STATUS_FILE"
+          semgrep_outcome="skipped"
+          ;;
+      esac
+      ;;
+  esac
+  : "$semgrep_outcome"
 fi
+
+# Always run the cloud-portable Swift parse check. It self-skips with a clean
+# exit when no Swift toolchain is available, and fails the build only on
+# syntax errors — never on missing toolchains or missing imports.
+"${ROOT}/scripts/swift-parse-check.sh"


### PR DESCRIPTION
Closes #288

## Summary
- `scripts/validate.sh` falls back to a locally installed `semgrep` on PATH (pip / pipx / Homebrew) when Docker is unavailable, so cloud and phone development sessions actually validate something instead of silently passing.
- New `scripts/swift-parse-check.sh` runs `swiftc -parse` on every source file. `-parse` skips type checking and import resolution, so any Swift toolchain (macOS Xcode, Linux swift.org, cloud sandbox) can catch syntax errors without needing the macOS-only `Foundation` / `AppKit` modules. Wired into `validate.sh`, so CI's `runtime-guardrails` job now also runs the parse check.

## Acceptance criteria mirror

- [ ] `scripts/validate.sh` runs semgrep locally when Docker is missing but pip/pipx semgrep is available.
- [ ] `scripts/swift-parse-check.sh` detects syntax errors when a Swift toolchain is present and passes cleanly on the existing `Sources/`.
- [ ] CI runs both checks and fails on regressions.
- [ ] Cloud / phone development sessions get a non-trivial validation signal before pushing.

## Changes
- `scripts/validate.sh` — refactor semgrep invocation into `run_semgrep_docker` / `run_semgrep_local` with status codes; chain docker → local; record which runner produced the pass.
- `scripts/swift-parse-check.sh` — new, executable; finds `swiftc` (or `swift -frontend -parse`); writes status to `artifacts/validation/swift-parse-status.txt`; clean-skips when no toolchain is present.
- Both scripts are invoked by `validate.sh`; `.github/workflows/ci.yml` already calls `validate.sh`, so no workflow changes are needed.

## Smoke test (this sandbox: Linux, no Docker, no Swift)

```
$ ./scripts/validate.sh origin/main; echo "exit=$?"
exit=0
$ cat artifacts/validation/semgrep-status.txt
PASS: no scannable changed files for semgrep
$ cat artifacts/validation/swift-parse-status.txt
NOT RUN: swift toolchain unavailable in this environment
```

`pip install semgrep` in this sandbox was blocked by an unrelated PyJWT conflict; the local-semgrep fallback was inspection-verified.

## Test plan

- ./scripts/validate.sh origin/main
- ./scripts/swift-parse-check.sh
- act pull_request -j runtime-guardrails --container-architecture linux/amd64

## Changelog entry

- [INTERNAL] Made local + CI validation useful for cloud / phone development: `scripts/validate.sh` now falls back to a locally installed `semgrep` (pip / pipx / Homebrew) when Docker is unavailable, and a new `scripts/swift-parse-check.sh` runs `swiftc -parse` on every source file so any Swift toolchain catches syntax errors without needing Xcode or resolvable imports.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs65CFZAhiHPxNPcWqv17u)_