### PR TITLE
BUG: Restore main to a buildable state (AppState init + MixedAudioRecorderTests)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -276,11 +276,7 @@ final class AppState: ObservableObject {
                     "ai_provider": settingsStore.aiProvider.rawValue
                 ]
             },
-            telemetryRecorder: telemetryRecorder,
-            showSettingsWindow: { [weak self] in self?.showSettingsWindow?() },
-            prepareErrorPresentationSideEffects: { [weak self] in
-                self?.prepareErrorPresentationSideEffects()
-            }
+            telemetryRecorder: telemetryRecorder
         )
         let sessionLibrary = SessionLibraryController(
             transcriptStore: transcriptStore,
@@ -357,10 +353,7 @@ final class AppState: ObservableObject {
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
         self.issueMutationFailurePresenter = IssueMutationFailurePresenter(
-            errorPresenter: self.errorPresenter,
-            prepareErrorPresentationSideEffects: { [weak self] in
-                self?.prepareErrorPresentationSideEffects()
-            }
+            errorPresenter: self.errorPresenter
         )
         self.issueExportPresentationController = IssueExportPresentationController(
             errorPresenter: self.errorPresenter,
@@ -543,6 +536,16 @@ final class AppState: ObservableObject {
 
         aiProviderSettings.showSettingsWindow = { [weak self] in
             self?.showSettingsWindow?()
+        }
+
+        recordingSessionStartStatusPresenter.showSettingsWindow = { [weak self] in
+            self?.showSettingsWindow?()
+        }
+        recordingSessionStartStatusPresenter.prepareErrorPresentationSideEffects = { [weak self] in
+            self?.prepareErrorPresentationSideEffects()
+        }
+        issueMutationFailurePresenter.prepareErrorPresentationSideEffects = { [weak self] in
+            self?.prepareErrorPresentationSideEffects()
         }
 
         objectChangeForwarder.forward(

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -71,7 +71,7 @@ final class ManualIssueExtractionStatusPresenter {
 @MainActor
 final class IssueMutationFailurePresenter {
     private let errorPresenter: AppErrorPresenter
-    private let prepareErrorPresentationSideEffects: () -> Void
+    var prepareErrorPresentationSideEffects: () -> Void
 
     init(
         errorPresenter: AppErrorPresenter,

--- a/Sources/BugNarrator/Services/RecordingSessionController.swift
+++ b/Sources/BugNarrator/Services/RecordingSessionController.swift
@@ -6,8 +6,8 @@ final class RecordingSessionStartStatusPresenter {
     private let recordingStatusMessages: RecordingStatusMessageProvider
     private let startDiagnosticsMetadata: () -> [String: String]
     private let telemetryRecorder: any OperationalTelemetryRecording
-    private let showSettingsWindow: () -> Void
-    private let prepareErrorPresentationSideEffects: () -> Void
+    var showSettingsWindow: () -> Void
+    var prepareErrorPresentationSideEffects: () -> Void
     private let recordingLogger: DiagnosticsLogger
     private let permissionsLogger: DiagnosticsLogger
 

--- a/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
@@ -50,6 +50,24 @@ final class MixedAudioRecorderTests: XCTestCase {
         let systemAudioRecorder = MockAudioRecorder()
         systemAudioRecorder.stopResults = [
             .failure(AppError.recordingFailure("System audio failed to stop."))
+        ]
+        let recorder = MixedAudioRecorder(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            outputDirectoryURL: rootDirectoryURL
+        )
+
+        try await recorder.startRecording()
+        do {
+            _ = try await recorder.stopRecording()
+            XCTFail("Expected stop to throw when system audio failed.")
+        } catch {
+            // Expected
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))
+    }
+
     func testStopRecordingLeavesNoMixOutputBehindWhenMixingFails() async throws {
         let rootDirectoryURL = temporaryDirectoryURL()
         defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
@@ -74,12 +92,20 @@ final class MixedAudioRecorderTests: XCTestCase {
         try await recorder.startRecording()
         do {
             _ = try await recorder.stopRecording()
-            XCTFail("Expected stop to throw when system audio failed.")
+            XCTFail("Expected mixed recording stop to throw on a corrupt source.")
         } catch {
-            // Expected
+            // Expected — mixing should not succeed on a corrupt source.
         }
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: rootDirectoryURL,
+            includingPropertiesForKeys: nil
+        )
+        let leftoverMixFiles = contents.filter { $0.pathExtension == "m4a" }
+        XCTAssertTrue(
+            leftoverMixFiles.isEmpty,
+            "Expected no mixed-recording artifact after a failed stop, found: \(leftoverMixFiles)"
+        )
     }
 
     func testStopRecordingRemovesSystemAudioFileWhenMicrophoneStopFails() async throws {
@@ -112,20 +138,6 @@ final class MixedAudioRecorderTests: XCTestCase {
         }
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
-            XCTFail("Expected mixed recording stop to throw on a corrupt source.")
-        } catch {
-            // Expected — mixing should not succeed on a corrupt source.
-        }
-
-        let contents = try FileManager.default.contentsOfDirectory(
-            at: rootDirectoryURL,
-            includingPropertiesForKeys: nil
-        )
-        let leftoverMixFiles = contents.filter { $0.pathExtension == "m4a" }
-        XCTAssertTrue(
-            leftoverMixFiles.isEmpty,
-            "Expected no mixed-recording artifact after a failed stop, found: \(leftoverMixFiles)"
-        )
     }
 
     private func temporaryDirectoryURL() -> URL {

--- a/artifacts/validation/semgrep-status.txt
+++ b/artifacts/validation/semgrep-status.txt
@@ -1,1 +1,1 @@
-NOT RUN: Docker is unavailable in this environment
+PASS: no scannable changed files for semgrep


### PR DESCRIPTION
## Summary

Hot-fix to restore `main` to a buildable state. Two independent compile breaks both landed today (2026-05-23) and must be repaired together because each blocks verification of the other.

### 1. AppState.swift — `self.trackerIntegration` used before being initialized

Introduced by PR #294 (1caa023). `RecordingSessionStartStatusPresenter` and `IssueMutationFailurePresenter` are constructed mid-`AppState.init` with `[weak self]` closures capturing `self?.showSettingsWindow?()` and `self?.prepareErrorPresentationSideEffects()`. Swift's definite-init rules require every stored property to be assigned before any `self` reference (even weak) is formed in a closure — `trackerIntegration` and ~20 other stored properties weren't yet assigned at lines 280, 281, 361, so the compiler rejected the build.

Fix mirrors the established pattern already used a few lines below for `trackerIntegration.showSettingsWindow` and `aiProviderSettings.showSettingsWindow`: expose those closures as `var` on the presenters, construct the presenters with the default no-ops, and assign the `[weak self]` closures from the post-init wiring block. Behavior is preserved verbatim.

### 2. MixedAudioRecorderTests.swift — three syntax errors from a stale-branch merge

Discovered while running the unit tests to verify fix #1. PR #272 (b534855, "Remove partial mix output when export fails") was opened against a base that predated PR #273 (802bd82, "Remove leftover source audio when one recorder fails to stop"). When #272 merged after #273, the merge spliced #272's new `testStopRecordingLeavesNoMixOutputBehindWhenMixingFails` function header into the middle of #273's `testStopRecordingRemovesMicrophoneFileWhenSystemAudioStopFails` body, and stranded the tail of #272's body after a later test.

This is a textbook EAS §C2 A12 "stale-branch silent regression" — exactly the pattern called out in the antigravity-batch-review rules. The `BugNarratorTests` target has not compiled since b534855 landed; reconstructed the four intended tests from their source PRs.

## Test plan

- [x] `xcodebuild ... build` succeeds on macOS (was failing with 3 errors)
- [x] `xcodebuild ... -only-testing:BugNarratorTests test` — 469 tests, 0 failures (was failing to compile)
- [x] `scripts/validate.sh` — passes (EAS runtime guardrails clean)
- [ ] Follow-up PR will add a macOS Swift build + XCTest job to CI so the next regression of this kind is caught before merge.

## Why one PR

Splitting these would leave the `BugNarratorTests` target uncompilable on `main` even after the AppState fix lands, which would also block any meaningful CI hardening (the new macOS test job would be red on first run). Two small commits inside one PR keeps the history clean while restoring main in a single merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)