### PR TITLE
ci: add macOS Swift build + XCTest job to detect compile regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,54 @@ jobs:
       - name: Build docs site
         if: steps.docs_changes.outputs.changed == 'true'
         run: npm run build --prefix site
+
+  macos-build-and-test:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect Swift / project changes
+        id: swift_changes
+        shell: bash
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
+          if grep -Eq '(\.swift$|\.plist$|\.entitlements$|\.xcodeproj/|\.xcworkspace/|\.xcconfig$|^Resources/|^Sources/|^Tests/|^\.github/workflows/ci\.yml$|^Package\.swift$|^Package\.resolved$)' <<< "$changed_files"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Show toolchain
+        if: steps.swift_changes.outputs.changed == 'true'
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build (Debug, macOS)
+        if: steps.swift_changes.outputs.changed == 'true'
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project BugNarrator.xcodeproj \
+            -scheme BugNarrator \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Run unit tests (BugNarratorTests only; UITests need a window server)
+        if: steps.swift_changes.outputs.changed == 'true'
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project BugNarrator.xcodeproj \
+            -scheme BugNarrator \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -only-testing:BugNarratorTests \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: npm run build --prefix site
 
   macos-build-and-test:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -94,6 +94,21 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Select Xcode (project file requires Xcode 26)
+        if: steps.swift_changes.outputs.changed == 'true'
+        run: |
+          # The .xcodeproj is in objectVersion 77, which only Xcode 26+ can read.
+          # macos-26 default Xcode is 26.4.1; prefer the newest 26.x available.
+          XCODE_APP=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [[ -z "$XCODE_APP" ]]; then
+            echo "::error::No Xcode 26.x found. Installed Xcode apps:"
+            ls -d /Applications/Xcode*.app || true
+            exit 1
+          fi
+          echo "Selected $XCODE_APP"
+          sudo xcode-select -s "$XCODE_APP"
+          echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Show toolchain
         if: steps.swift_changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- Adds an additive `macos-build-and-test` job to `.github/workflows/ci.yml` on `macos-14`.
- Builds Debug for `platform=macOS` and runs `-only-testing:BugNarratorTests` (UITests skipped — they need a window server).
- Gated by a `git diff` path filter (Swift / project / Resources / Tests / Package.swift / this workflow itself) so docs- or script-only PRs don't burn a runner.
- Existing Ubuntu jobs (`runtime-guardrails`, `docs-site-validation`) are unchanged.

## Why

Two compile breaks landed on `main` within hours of each other on 2026-05-23 (the `AppState` `[weak self]`-before-init issue and the `MixedAudioRecorderTests` stale-branch interleaving), both fixed in PR #303. Neither was caught by CI because `ci.yml` only ran EAS runtime guardrails and a conditional docs build — nothing touched Swift. This job closes that gap. Both PR #303 fixes would have been caught on the originating PRs.

## Test plan

- [x] `scripts/validate.sh` passes locally (no impact on existing guardrails).
- [ ] The new job runs green on this PR (it touches `ci.yml`, which is in the path filter).
- [ ] Future Swift compile breaks fail the PR check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)