### PR TITLE
chore: canonicalize repo identity in Swift source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [CHANGE] Repointed the default GitHub export repository and in-app project links from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`. Fresh installs and UI-test seeded settings now resolve to the canonical organization repo; existing installs keep whatever owner/repo the user previously configured.
 - [FIX] Cleared in-flight issue-extraction/export progress when an issue mutation (toggle selection, edit) write fails, so the extraction progress spinner no longer keeps running on top of an unrelated error toast.
 - [FIX] Restored the auto-open of Settings on credential-failure recording starts and the in-flight progress cleanup on any recording-start failure, so a missing/invalid API key surface still directs the user to Settings and stale issue-extraction/export badges from a prior pipeline no longer linger.
 - [FIX] Rendered the "Transcription Pending" timeline entry in the review workspace using the active AI provider's recovery guidance, so Local (Parakeet) sessions no longer surface OpenAI-specific text in the review surface.

--- a/Sources/BugNarrator/Utilities/AppBootstrap.swift
+++ b/Sources/BugNarrator/Utilities/AppBootstrap.swift
@@ -125,8 +125,8 @@ enum UITestRuntimeSupport {
 
         settingsStore.apiKey = "sk-ui-test"
         settingsStore.githubToken = "github_pat_ui_test"
-        settingsStore.githubRepositoryID = "deffenda/bug-narrator"
-        settingsStore.githubRepositoryOwner = "deffenda"
+        settingsStore.githubRepositoryID = "ABD-Enterprises/bug-narrator"
+        settingsStore.githubRepositoryOwner = "ABD-Enterprises"
         settingsStore.githubRepositoryName = "bug-narrator"
         settingsStore.githubDefaultLabels = "bug, ui-test"
         settingsStore.jiraBaseURL = "https://example.atlassian.net"
@@ -383,8 +383,8 @@ private actor UITestIssueExportService: IssueExporting {
     func fetchGitHubRepositories(token: String) async throws -> [GitHubRepositoryOption] {
         [
             GitHubRepositoryOption(
-                repositoryID: "deffenda/bug-narrator",
-                owner: "deffenda",
+                repositoryID: "ABD-Enterprises/bug-narrator",
+                owner: "ABD-Enterprises",
                 name: "bug-narrator",
                 description: "BugNarrator"
             ),

--- a/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 enum BugNarratorLinks {
-    static let repository = URL(string: "https://github.com/deffenda/bug-narrator")!
-    static let documentation = URL(string: "https://github.com/deffenda/bug-narrator/blob/main/docs/UserGuide.md")!
-    static let issues = URL(string: "https://github.com/deffenda/bug-narrator/issues/new")!
-    static let releases = URL(string: "https://github.com/deffenda/bug-narrator/releases")!
+    static let repository = URL(string: "https://github.com/ABD-Enterprises/bug-narrator")!
+    static let documentation = URL(string: "https://github.com/ABD-Enterprises/bug-narrator/blob/main/docs/UserGuide.md")!
+    static let issues = URL(string: "https://github.com/ABD-Enterprises/bug-narrator/issues/new")!
+    static let releases = URL(string: "https://github.com/ABD-Enterprises/bug-narrator/releases")!
     static let supportDevelopment = URL(string: "https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8")!
     static let microphonePrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
     static let screenRecordingPrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -93,10 +93,10 @@ final class AppStateTests: XCTestCase {
             fingerprint: "github:fixture",
             sourceIssueID: UUID(),
             destination: .github,
-            targetIdentity: "deffenda/bug-narrator",
+            targetIdentity: "ABD-Enterprises/bug-narrator",
             state: .succeeded,
             remoteIdentifier: "#42",
-            remoteURL: URL(string: "https://github.com/deffenda/bug-narrator/issues/42"),
+            remoteURL: URL(string: "https://github.com/ABD-Enterprises/bug-narrator/issues/42"),
             updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
         await harness.exportService.setExportReceipts([receipt])

--- a/Tests/BugNarratorTests/ExportHistoryControllerTests.swift
+++ b/Tests/BugNarratorTests/ExportHistoryControllerTests.swift
@@ -31,10 +31,10 @@ final class ExportHistoryControllerTests: XCTestCase {
             fingerprint: fingerprint,
             sourceIssueID: UUID(),
             destination: .github,
-            targetIdentity: "deffenda/bug-narrator",
+            targetIdentity: "ABD-Enterprises/bug-narrator",
             state: .succeeded,
             remoteIdentifier: "#42",
-            remoteURL: URL(string: "https://github.com/deffenda/bug-narrator/issues/42"),
+            remoteURL: URL(string: "https://github.com/ABD-Enterprises/bug-narrator/issues/42"),
             updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
         )
     }

--- a/Tests/BugNarratorTests/PrivacyDataExporterTests.swift
+++ b/Tests/BugNarratorTests/PrivacyDataExporterTests.swift
@@ -19,7 +19,7 @@ final class PrivacyDataExporterTests: XCTestCase {
         settingsStore.githubToken = "github_pat_secret"
         settingsStore.jiraAPIToken = "jira-secret"
         settingsStore.jiraEmail = "person@example.com"
-        settingsStore.githubRepositoryOwner = "deffenda"
+        settingsStore.githubRepositoryOwner = "ABD-Enterprises"
         settingsStore.githubRepositoryName = "bug-narrator"
         settingsStore.githubDefaultLabels = "bug,export"
         settingsStore.jiraBaseURL = "https://example.atlassian.net"
@@ -63,7 +63,7 @@ final class PrivacyDataExporterTests: XCTestCase {
         XCTAssertEqual(manifest?["includesSecrets"] as? Bool, false)
         XCTAssertEqual(manifest?["sessionCount"] as? Int, 1)
         XCTAssertEqual(sessions, [session])
-        XCTAssertEqual(writtenSettings.gitHubRepositoryOwner, "deffenda")
+        XCTAssertEqual(writtenSettings.gitHubRepositoryOwner, "ABD-Enterprises")
         XCTAssertEqual(writtenSettings.jiraProjectKey, "UCAP")
         XCTAssertEqual(writtenDiagnostics.recentTelemetryEvents.count, 1)
         let combinedText = String(data: manifestData + sessionsData + settingsData + diagnosticsData, encoding: .utf8) ?? ""

--- a/Tests/BugNarratorTests/ProductInfoTests.swift
+++ b/Tests/BugNarratorTests/ProductInfoTests.swift
@@ -30,10 +30,10 @@ final class ProductInfoTests: XCTestCase {
     }
 
     func testProjectLinksUseExpectedPublicURLs() {
-        XCTAssertEqual(BugNarratorLinks.repository.absoluteString, "https://github.com/deffenda/bug-narrator")
-        XCTAssertEqual(BugNarratorLinks.documentation.absoluteString, "https://github.com/deffenda/bug-narrator/blob/main/docs/UserGuide.md")
-        XCTAssertEqual(BugNarratorLinks.issues.absoluteString, "https://github.com/deffenda/bug-narrator/issues/new")
-        XCTAssertEqual(BugNarratorLinks.releases.absoluteString, "https://github.com/deffenda/bug-narrator/releases")
+        XCTAssertEqual(BugNarratorLinks.repository.absoluteString, "https://github.com/ABD-Enterprises/bug-narrator")
+        XCTAssertEqual(BugNarratorLinks.documentation.absoluteString, "https://github.com/ABD-Enterprises/bug-narrator/blob/main/docs/UserGuide.md")
+        XCTAssertEqual(BugNarratorLinks.issues.absoluteString, "https://github.com/ABD-Enterprises/bug-narrator/issues/new")
+        XCTAssertEqual(BugNarratorLinks.releases.absoluteString, "https://github.com/ABD-Enterprises/bug-narrator/releases")
         XCTAssertEqual(BugNarratorLinks.supportDevelopment.absoluteString, "https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8")
     }
 

--- a/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
+++ b/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
@@ -121,7 +121,7 @@ final class BugNarratorSettingsUITests: XCTestCase {
 
         let gitHubOwnerField = app.textFields["GitHub repository owner"]
         XCTAssertTrue(waitForSettingsElement(gitHubOwnerField, in: settingsWindow))
-        replaceText(in: gitHubOwnerField, with: "deffenda")
+        replaceText(in: gitHubOwnerField, with: "ABD-Enterprises")
 
         let gitHubRepoField = app.textFields["GitHub repository name"]
         XCTAssertTrue(waitForSettingsElement(gitHubRepoField, in: settingsWindow))
@@ -192,7 +192,7 @@ final class BugNarratorSettingsUITests: XCTestCase {
 
         let gitHubOwner = app.textFields["GitHub repository owner for Settings export smoke issue updated"]
         XCTAssertTrue(waitForElement(gitHubOwner, in: sessionsWindow))
-        replaceText(in: gitHubOwner, with: "deffenda")
+        replaceText(in: gitHubOwner, with: "ABD-Enterprises")
 
         let gitHubRepo = app.textFields["GitHub repository name for Settings export smoke issue updated"]
         XCTAssertTrue(waitForElement(gitHubRepo, in: sessionsWindow))


### PR DESCRIPTION
## Summary

- Repointed default GitHub export repository and in-app project links (repository, documentation, issues, releases) from `deffenda/bug-narrator` to `ABD-Enterprises/bug-narrator`.
- Updated XCTest fixtures and UI-test seeding to match. The `deffenda/new-project-2` synthetic second-repo fixture was left intact on purpose.
- CHANGELOG entry covers the user-visible behavior change: fresh installs and UI-test seeded settings resolve to the canonical org repo; existing installs keep whatever owner/repo the user previously configured.

Companion docs PR: ABD-Enterprises/bug-narrator#302

## Test plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → BUILD SUCCEEDED
- [ ] CI test job (XCTest + UITests) runs green
- [ ] Verified `grep -rn 'deffenda/bug-narrator\|\"deffenda\"' Sources Tests` returns only the `deffenda/new-project-2` fixture owner field

🤖 Generated with [Claude Code](https://claude.com/claude-code)