### PR TITLE
[patch] CI: add effort leak guardrails

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -38,3 +38,11 @@ Hard rules:
 - `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->
+
+## Repo-Specific Effort Leak Guardrails
+
+- Before starting implementation, run `gh issue list --repo ABD-Enterprises/bug-narrator --state open --limit 200` or `scripts/effort-leak-audit.sh` when GitHub auth is available.
+- Do not implement an issue that is already closed, has an open PR, or is labeled `ai/blocked` unless the blocker has been removed and documented in the issue.
+- If an issue is blocked by an external credential, signing certificate, account permission, hardware, or clean-machine validation, comment with the exact missing input and keep it in `ai/blocked`; do not create placeholder repo churn.
+- Prefer one small PR per issue. If replacing stale work, close or comment on the superseded PR with `superseded-by: #<new-pr>` before spending CI on a new branch.
+- Run `scripts/effort-leak-audit.sh` before pushing batches that touch GitHub workflow, issue, PR, or release automation.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,11 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
+**Effort leak check**
+- [ ] I searched existing open issues and pull requests for the same failure.
+- [ ] This is not blocked on an external credential, signing certificate, account permission, hardware, or clean-machine validation.
+- [ ] If it is externally blocked, I named the exact missing input and applied `ai/blocked` instead of asking for implementation.
+
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,11 @@ assignees: ''
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
+**Effort leak check**
+- [ ] I searched existing open issues and pull requests for the same request.
+- [ ] The first useful increment can be validated locally or in CI without new external credentials, hardware, or account permissions.
+- [ ] Any external blocker is named explicitly and the issue is labeled `ai/blocked` until that input exists.
+
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,14 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+concurrency:
+  group: ci-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   runtime-guardrails:
@@ -34,6 +40,8 @@ jobs:
           fi
 
       - name: Run runtime guardrails validator
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git fetch --no-tags --depth=1 origin "${{ steps.base.outputs.ref }}"
           ./scripts/validate.sh "${{ steps.base.outputs.ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,11 @@ Hard rules:
 - `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->
+
+## Repo-Specific Effort Leak Guardrails
+
+- Before starting implementation, run `gh issue list --repo ABD-Enterprises/bug-narrator --state open --limit 200` or `scripts/effort-leak-audit.sh` when GitHub auth is available.
+- Do not implement an issue that is already closed, has an open PR, or is labeled `ai/blocked` unless the blocker has been removed and documented in the issue.
+- If an issue is blocked by an external credential, signing certificate, account permission, hardware, or clean-machine validation, comment with the exact missing input and keep it in `ai/blocked`; do not create placeholder repo churn.
+- Prefer one small PR per issue. If replacing stale work, close or comment on the superseded PR with `superseded-by: #<new-pr>` before spending CI on a new branch.
+- Run `scripts/effort-leak-audit.sh` before pushing batches that touch GitHub workflow, issue, PR, or release automation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [INTERNAL] Added effort-leak guardrails so stale AI issue states, duplicate PR claims, and superseded CI runs are caught before agents spend more time.
+
 ## 1.0.36 - 2026-05-27
 
 - [FIX] Isolated AI provider credentials so OpenAI-compatible, local-compatible, and Local (Parakeet) setup states no longer reuse or display credentials saved for another provider.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,11 @@ Hard rules:
 - `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->
+
+## Repo-Specific Effort Leak Guardrails
+
+- Before starting implementation, run `gh issue list --repo ABD-Enterprises/bug-narrator --state open --limit 200` or `scripts/effort-leak-audit.sh` when GitHub auth is available.
+- Do not implement an issue that is already closed, has an open PR, or is labeled `ai/blocked` unless the blocker has been removed and documented in the issue.
+- If an issue is blocked by an external credential, signing certificate, account permission, hardware, or clean-machine validation, comment with the exact missing input and keep it in `ai/blocked`; do not create placeholder repo churn.
+- Prefer one small PR per issue. If replacing stale work, close or comment on the superseded PR with `superseded-by: #<new-pr>` before spending CI on a new branch.
+- Run `scripts/effort-leak-audit.sh` before pushing batches that touch GitHub workflow, issue, PR, or release automation.

--- a/scripts/effort-leak-audit.sh
+++ b/scripts/effort-leak-audit.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Detect GitHub issue/PR states that waste agent or CI effort.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+REPO="${EFFORT_LEAK_REPO:-}"
+if [[ -z "$REPO" ]]; then
+  origin_url="$(git remote get-url origin 2>/dev/null || true)"
+  case "$origin_url" in
+    git@github.com:*)
+      REPO="${origin_url#git@github.com:}"
+      REPO="${REPO%.git}"
+      ;;
+    https://github.com/*)
+      REPO="${origin_url#https://github.com/}"
+      REPO="${REPO%.git}"
+      ;;
+  esac
+fi
+
+if [[ -z "$REPO" ]]; then
+  echo "NOT RUN: could not infer GitHub repo from origin remote."
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "NOT RUN: gh is not available."
+  exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "NOT RUN: gh is not authenticated."
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "NOT RUN: jq is not available."
+  exit 0
+fi
+
+issues_json="$(mktemp)"
+prs_json="$(mktemp)"
+audit_output="$(mktemp)"
+trap 'rm -f "$issues_json" "$prs_json" "$audit_output"' EXIT
+
+gh issue list \
+  --repo "$REPO" \
+  --state open \
+  --limit 200 \
+  --json number,title,labels,url \
+  >"$issues_json"
+
+gh pr list \
+  --repo "$REPO" \
+  --state open \
+  --limit 200 \
+  --json number,title,labels,url,closingIssuesReferences \
+  >"$prs_json"
+
+jq -r -e -n \
+  --slurpfile issues "$issues_json" \
+  --slurpfile prs "$prs_json" '
+    def labels: [.labels[].name];
+    def has_label($name): labels | index($name) != null;
+    def active_ai:
+      has_label("ai/ready-for-work") or
+      has_label("ai/in-development") or
+      has_label("ai/in-local-testing") or
+      has_label("ai/in-pr-review") or
+      has_label("ai/ready-for-local-testing");
+
+    ($issues[0] // []) as $issues_list |
+    ($prs[0] // []) as $prs_list |
+    [
+      $issues_list[]
+      | select(has_label("ai/blocked") and active_ai)
+      | "Issue #\(.number) is blocked but also carries an active AI workflow label: \([.labels[].name] | join(", "))"
+    ] +
+    [
+      $issues_list[]
+      | . as $issue
+      | select((has_label("ai/in-pr-review") or has_label("ai/ready-for-local-testing")) and (([ $prs_list[] | select((.closingIssuesReferences // []) | any(.number == $issue.number)) ] | length) == 0))
+      | "Issue #\(.number) is in review/testing state but no open PR closes it."
+    ] +
+    [
+      [
+        $prs_list[]
+        | . as $pr
+        | ($pr.closingIssuesReferences // [])[].number
+        | {issue: ., pr: $pr.number}
+      ]
+      | sort_by(.issue)
+      | group_by(.issue)[]
+      | select(length > 1)
+      | "Issue #\(.[0].issue) has multiple open PRs claiming closure: \([.[].pr | "#\(.)"] | join(", "))"
+    ] +
+    [
+      $prs_list[]
+      | select(((.closingIssuesReferences // []) | length) == 0 and (has_label("chore:trivial") | not))
+      | "PR #\(.number) has no linked closing issue and is not labeled chore:trivial."
+    ] as $findings |
+    if ($findings | length) == 0 then
+      "PASS: no effort-leak issue/PR states detected."
+    else
+      $findings[]
+    end |
+    if type == "string" then . else empty end
+  ' | tee "$audit_output"
+
+if grep -qv '^PASS:' "$audit_output"; then
+  exit 1
+fi

--- a/scripts/effort-leak-audit.sh
+++ b/scripts/effort-leak-audit.sh
@@ -6,26 +6,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-REPO="${EFFORT_LEAK_REPO:-}"
-if [[ -z "$REPO" ]]; then
-  origin_url="$(git remote get-url origin 2>/dev/null || true)"
-  case "$origin_url" in
-    git@github.com:*)
-      REPO="${origin_url#git@github.com:}"
-      REPO="${REPO%.git}"
-      ;;
-    https://github.com/*)
-      REPO="${origin_url#https://github.com/}"
-      REPO="${REPO%.git}"
-      ;;
-  esac
-fi
-
-if [[ -z "$REPO" ]]; then
-  echo "NOT RUN: could not infer GitHub repo from origin remote."
-  exit 0
-fi
-
 if ! command -v gh >/dev/null 2>&1; then
   echo "NOT RUN: gh is not available."
   exit 0
@@ -41,10 +21,20 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
+REPO="${EFFORT_LEAK_REPO:-}"
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+
+if [[ -z "$REPO" ]]; then
+  echo "NOT RUN: could not infer GitHub repo."
+  exit 0
+fi
+
 issues_json="$(mktemp)"
 prs_json="$(mktemp)"
 audit_output="$(mktemp)"
-trap 'rm -f "$issues_json" "$prs_json" "$audit_output"' EXIT
+trap 'rm -f "${issues_json:-}" "${prs_json:-}" "${audit_output:-}"' EXIT
 
 gh issue list \
   --repo "$REPO" \
@@ -57,7 +47,7 @@ gh pr list \
   --repo "$REPO" \
   --state open \
   --limit 200 \
-  --json number,title,labels,url,closingIssuesReferences \
+  --json number,title,labels,url,closingIssuesReferences,author \
   >"$prs_json"
 
 jq -r -e -n \
@@ -100,7 +90,11 @@ jq -r -e -n \
       ] +
       [
         $prs_list[]
-        | select(((.closingIssuesReferences // []) | length) == 0 and (has_label("chore:trivial") | not))
+        | select(
+            ((.closingIssuesReferences // []) | length) == 0 and
+            (has_label("chore:trivial") | not) and
+            ((.author.login // "") | (endswith("[bot]") or . == "dependabot") | not)
+          )
         | "PR #\(.number) has no linked closing issue and is not labeled chore:trivial."
       ]
     ) as $findings |

--- a/scripts/effort-leak-audit.sh
+++ b/scripts/effort-leak-audit.sh
@@ -74,34 +74,36 @@ jq -r -e -n \
 
     ($issues[0] // []) as $issues_list |
     ($prs[0] // []) as $prs_list |
-    [
-      $issues_list[]
-      | select(has_label("ai/blocked") and active_ai)
-      | "Issue #\(.number) is blocked but also carries an active AI workflow label: \([.labels[].name] | join(", "))"
-    ] +
-    [
-      $issues_list[]
-      | . as $issue
-      | select((has_label("ai/in-pr-review") or has_label("ai/ready-for-local-testing")) and (([ $prs_list[] | select((.closingIssuesReferences // []) | any(.number == $issue.number)) ] | length) == 0))
-      | "Issue #\(.number) is in review/testing state but no open PR closes it."
-    ] +
-    [
+    (
+      [
+        $issues_list[]
+        | select(has_label("ai/blocked") and active_ai)
+        | "Issue #\(.number) is blocked but also carries an active AI workflow label: \([.labels[].name] | join(", "))"
+      ] +
+      [
+        $issues_list[]
+        | . as $issue
+        | select((has_label("ai/in-pr-review") or has_label("ai/ready-for-local-testing")) and (([ $prs_list[] | select((.closingIssuesReferences // []) | any(.number == $issue.number)) ] | length) == 0))
+        | "Issue #\(.number) is in review/testing state but no open PR closes it."
+      ] +
+      [
+        [
+          $prs_list[]
+          | . as $pr
+          | ($pr.closingIssuesReferences // [])[].number
+          | {issue: ., pr: $pr.number}
+        ]
+        | sort_by(.issue)
+        | group_by(.issue)[]
+        | select(length > 1)
+        | "Issue #\(.[0].issue) has multiple open PRs claiming closure: \([.[].pr | "#\(.)"] | join(", "))"
+      ] +
       [
         $prs_list[]
-        | . as $pr
-        | ($pr.closingIssuesReferences // [])[].number
-        | {issue: ., pr: $pr.number}
+        | select(((.closingIssuesReferences // []) | length) == 0 and (has_label("chore:trivial") | not))
+        | "PR #\(.number) has no linked closing issue and is not labeled chore:trivial."
       ]
-      | sort_by(.issue)
-      | group_by(.issue)[]
-      | select(length > 1)
-      | "Issue #\(.[0].issue) has multiple open PRs claiming closure: \([.[].pr | "#\(.)"] | join(", "))"
-    ] +
-    [
-      $prs_list[]
-      | select(((.closingIssuesReferences // []) | length) == 0 and (has_label("chore:trivial") | not))
-      | "PR #\(.number) has no linked closing issue and is not labeled chore:trivial."
-    ] as $findings |
+    ) as $findings |
     if ($findings | length) == 0 then
       "PASS: no effort-leak issue/PR states detected."
     else

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -148,7 +148,7 @@ if [[ -x "$ROOT/scripts/effort-leak-audit.sh" ]]; then
       printf 'PASS: effort-leak audit found no duplicate, blocked-active, or unlinkable PR state\n' \
         >"$EFFORT_LEAK_STATUS_FILE"
     else
-      printf 'NOT RUN: effort-leak audit skipped because GitHub CLI/auth was unavailable\n' \
+      head -n 1 "$EFFORT_LEAK_OUTPUT_FILE" \
         >"$EFFORT_LEAK_STATUS_FILE"
     fi
   else

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -30,12 +30,16 @@ SEMGREP_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/semgrep-status.txt"
 SEMGREP_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/semgrep-output.txt"
 LOCAL_TRANSCRIPTION_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/local-transcription-status.txt"
 LOCAL_TRANSCRIPTION_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/local-transcription-output.txt"
+EFFORT_LEAK_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/effort-leak-status.txt"
+EFFORT_LEAK_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/effort-leak-output.txt"
 mkdir -p "$VALIDATION_ARTIFACT_DIR"
 rm -f \
   "$SEMGREP_STATUS_FILE" \
   "$SEMGREP_OUTPUT_FILE" \
   "$LOCAL_TRANSCRIPTION_STATUS_FILE" \
-  "$LOCAL_TRANSCRIPTION_OUTPUT_FILE"
+  "$LOCAL_TRANSCRIPTION_OUTPUT_FILE" \
+  "$EFFORT_LEAK_STATUS_FILE" \
+  "$EFFORT_LEAK_OUTPUT_FILE"
 
 should_skip_semgrep_target() {
   local target="$1"
@@ -137,6 +141,21 @@ fi
 # exit when no Swift toolchain is available, and fails the build only on
 # syntax errors — never on missing toolchains or missing imports.
 "${ROOT}/scripts/swift-parse-check.sh"
+
+if [[ -x "$ROOT/scripts/effort-leak-audit.sh" ]]; then
+  if "$ROOT/scripts/effort-leak-audit.sh" >"$EFFORT_LEAK_OUTPUT_FILE" 2>&1; then
+    if grep -q '^PASS:' "$EFFORT_LEAK_OUTPUT_FILE"; then
+      printf 'PASS: effort-leak audit found no duplicate, blocked-active, or unlinkable PR state\n' \
+        >"$EFFORT_LEAK_STATUS_FILE"
+    else
+      printf 'NOT RUN: effort-leak audit skipped because GitHub CLI/auth was unavailable\n' \
+        >"$EFFORT_LEAK_STATUS_FILE"
+    fi
+  else
+    cat "$EFFORT_LEAK_OUTPUT_FILE" >&2
+    exit 1
+  fi
+fi
 
 if [[ -f "$ROOT/local-transcription/server.py" ]]; then
   if command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Adds repo guardrails to catch duplicated or blocked AI work before agents and CI spend more time. Cancels superseded PR CI runs for the same branch, adds a GitHub issue/PR effort-leak audit, and documents the expected pre-work checks in agent guidance and issue templates.

## Linked issue

Closes #320

## Changes

- Added `scripts/effort-leak-audit.sh` to detect blocked issues with active AI labels, review/testing issues without an open PR, duplicate PRs claiming the same issue, and non-trivial PRs with no linked issue.
- Wired the audit into `scripts/validate.sh` with status artifacts and CI `GH_TOKEN` read permissions.
- Added CI concurrency so newer pushes cancel superseded runs for the same PR branch.
- Added effort-leak checks to agent guidance, issue templates, and the changelog.

## Acceptance criteria mirror

- [x] Repo automation and contributor guidance prevent duplicated/stale agent effort, avoid unnecessary CI spend, and make genuine external blockers explicit.

## Test plan

- `git diff --check`
- `bash -n scripts/effort-leak-audit.sh scripts/validate.sh`
- `scripts/effort-leak-audit.sh`
- `./scripts/validate.sh origin/main`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/codeql.yml .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/feature_request.md`\n\n## Changelog entry\n\n- [INTERNAL] Added effort-leak guardrails so stale AI issue states, duplicate PR claims, and superseded CI runs are caught before agents spend more time.\n