### PR TITLE
[patch] CI: configure auto-merge trusted authors

### DIFF
--- a/.github/auto-merge-allowed-authors
+++ b/.github/auto-merge-allowed-authors
@@ -1,0 +1,5 @@
+# Authors allowed past the EAS trusted_author auto-merge gate.
+# Keep this intentionally narrow: branch protection, required checks, review
+# threads, blocking labels, and linked issue gates still apply.
+deffenda
+app/dependabot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [INTERNAL] Added the EAS auto-merge trusted-author allowlist so eligible green PRs do not repeatedly fail on missing gate configuration.
 - [INTERNAL] Added effort-leak guardrails so stale AI issue states, duplicate PR claims, and superseded CI runs are caught before agents spend more time.
 
 ## 1.0.36 - 2026-05-27


### PR DESCRIPTION
## Summary

Adds the trusted-author allowlist expected by the EAS auto-merge gate so eligible green PRs stop burning cycles on a missing-file failure. The list is intentionally narrow: `deffenda` for local/agent-authored repo work and `app/dependabot` for dependency bot PRs.

## Linked issue

Closes #322

## Changes

- Added `.github/auto-merge-allowed-authors` with the intended trusted author set.
- Added a changelog entry for the repo-ops hardening.

## Acceptance criteria mirror

- [x] Auto-merge can evaluate trusted author status without repeated missing-file gate failures, while keeping merge authority scoped to intended repo automation actors.

## Test plan

- `git diff --check`
- `./scripts/validate.sh origin/main`
- `scripts/effort-leak-audit.sh`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/eas-auto-merge.yml`\n\n## Changelog entry\n\n- [INTERNAL] Added the EAS auto-merge trusted-author allowlist so eligible green PRs do not repeatedly fail on missing gate configuration.\n