### PR TITLE
[patch] CI: avoid unnecessary macOS runner scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,35 @@ permissions:
   pull-requests: read
 
 jobs:
+  detect-ci-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_changed: ${{ steps.changes.outputs.docs_changed }}
+      swift_changed: ${{ steps.changes.outputs.swift_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect CI-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
+          if grep -Eq '^(docs/|site/|README\.md|QUICKSTART\.md|SECURITY\.md|CONTRIBUTING\.md)' <<< "$changed_files"; then
+            echo "docs_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -Eq '(\.swift$|\.plist$|\.entitlements$|\.xcodeproj/|\.xcworkspace/|\.xcconfig$|^Resources/|^Sources/|^Tests/|^\.github/workflows/ci\.yml$|^Package\.swift$|^Package\.resolved$)' <<< "$changed_files"; then
+            echo "swift_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "swift_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   runtime-guardrails:
     runs-on: ubuntu-latest
     steps:
@@ -47,7 +76,10 @@ jobs:
           ./scripts/validate.sh "${{ steps.base.outputs.ref }}"
 
   docs-site-validation:
-    needs: runtime-guardrails
+    needs:
+      - detect-ci-changes
+      - runtime-guardrails
+    if: needs.detect-ci-changes.outputs.docs_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,20 +87,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Detect docs site changes
-        id: docs_changes
-        shell: bash
-        run: |
-          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
-          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
-          if grep -Eq '^(docs/|site/|README\.md|QUICKSTART\.md|SECURITY\.md|CONTRIBUTING\.md)' <<< "$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup Node
-        if: steps.docs_changes.outputs.changed == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -76,14 +95,16 @@ jobs:
           cache-dependency-path: site/package-lock.json
 
       - name: Install docs site dependencies
-        if: steps.docs_changes.outputs.changed == 'true'
         run: npm ci --prefix site
 
       - name: Build docs site
-        if: steps.docs_changes.outputs.changed == 'true'
         run: npm run build --prefix site
 
   macos-build-and-test:
+    needs:
+      - detect-ci-changes
+      - runtime-guardrails
+    if: needs.detect-ci-changes.outputs.swift_changed == 'true'
     # Self-hosted ABD-Enterprises org runner with Xcode 26.5; declared
     # in deffenda/brew-sync manifests/github-runners.yaml. Falls back to
     # macos-26 (GitHub-hosted, with the 10x minute multiplier) by manual
@@ -96,20 +117,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Detect Swift / project changes
-        id: swift_changes
-        shell: bash
-        run: |
-          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
-          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
-          if grep -Eq '(\.swift$|\.plist$|\.entitlements$|\.xcodeproj/|\.xcworkspace/|\.xcconfig$|^Resources/|^Sources/|^Tests/|^\.github/workflows/ci\.yml$|^Package\.swift$|^Package\.resolved$)' <<< "$changed_files"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Select Xcode (project file requires Xcode 26)
-        if: steps.swift_changes.outputs.changed == 'true'
         run: |
           # The .xcodeproj is in objectVersion 77, which only Xcode 26+
           # can read. Two valid layouts:
@@ -144,13 +152,11 @@ jobs:
           echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
 
       - name: Show toolchain
-        if: steps.swift_changes.outputs.changed == 'true'
         run: |
           xcodebuild -version
           swift --version
 
       - name: Build (Debug, macOS)
-        if: steps.swift_changes.outputs.changed == 'true'
         run: |
           set -o pipefail
           xcodebuild \
@@ -162,7 +168,6 @@ jobs:
             build
 
       - name: Run unit tests (BugNarratorTests only; UITests need a window server)
-        if: steps.swift_changes.outputs.changed == 'true'
         run: |
           set -o pipefail
           xcodebuild \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             echo "docs_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if grep -Eq '(\.swift$|\.plist$|\.entitlements$|\.xcodeproj/|\.xcworkspace/|\.xcconfig$|^Resources/|^Sources/|^Tests/|^\.github/workflows/ci\.yml$|^Package\.swift$|^Package\.resolved$)' <<< "$changed_files"; then
+          if grep -Eq '(\.swift$|\.plist$|\.entitlements$|\.xcodeproj/|\.xcworkspace/|\.xcconfig$|^Resources/|^Sources/|^Tests/|^\.github/workflows/ci\.yml$|^Package\.swift$|^Package\.resolved$|^project\.ya?ml$)' <<< "$changed_files"; then
             echo "swift_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "swift_changed=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [INTERNAL] Moved Swift/project change detection ahead of the self-hosted macOS CI job so config-only PRs no longer reserve macOS runner slots.
 - [INTERNAL] Added the EAS auto-merge trusted-author allowlist so eligible green PRs do not repeatedly fail on missing gate configuration.
 - [INTERNAL] Added effort-leak guardrails so stale AI issue states, duplicate PR claims, and superseded CI runs are caught before agents spend more time.
 


### PR DESCRIPTION
## Summary

Moves Swift/project change detection into a cheap Ubuntu preflight job so the self-hosted macOS runner is only scheduled when Swift, project, resource, or CI workflow changes require the macOS build/test job.

## Linked issue

Closes #324

## Changes

- Added a `detect-ci-changes` job that exposes `docs_changed` and `swift_changed` outputs.
- Made `docs-site-validation` and `macos-build-and-test` job-level conditional on those outputs.
- Removed in-job skip checks from the macOS job so it only starts when it has real work.
- Added a changelog entry for the CI runner scheduling hardening.

## Acceptance criteria mirror

- [x] CI detects Swift/project changes before scheduling the self-hosted macOS job, so docs/config-only PRs do not consume macOS runner slots.

## Test plan

- `git diff --check`
- `./scripts/validate.sh origin/main`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml`\n- `scripts/effort-leak-audit.sh`\n\n## Changelog entry\n\n- [INTERNAL] Moved Swift/project change detection ahead of the self-hosted macOS CI job so config-only PRs no longer reserve macOS runner slots.\n