### PR TITLE
[patch] CI: preflight Windows release signing secrets

### DIFF
--- a/.github/workflows/windows-tester-release.yml
+++ b/.github/workflows/windows-tester-release.yml
@@ -27,7 +27,28 @@ permissions:
   contents: write
 
 jobs:
+  release-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm signing secrets exist before reserving Windows runner
+        env:
+          CERT_BASE64: ${{ secrets.BUGNARRATOR_WINDOWS_CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.BUGNARRATOR_WINDOWS_CERT_PASSWORD }}
+        run: |
+          missing=()
+          if [[ -z "$CERT_BASE64" ]]; then
+            missing+=("BUGNARRATOR_WINDOWS_CERT_BASE64")
+          fi
+          if [[ -z "$CERT_PASSWORD" ]]; then
+            missing+=("BUGNARRATOR_WINDOWS_CERT_PASSWORD")
+          fi
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            printf '::error::Windows tester release is blocked before runner allocation. Missing repository secret(s): %s\n' "${missing[*]}"
+            exit 1
+          fi
+
   signed-windows-tester-release:
+    needs: release-preflight
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [INTERNAL] Added a cheap Windows tester release preflight so missing signing secrets fail before reserving a Windows runner.
 - [INTERNAL] Moved Swift/project change detection ahead of the self-hosted macOS CI job so config-only PRs no longer reserve macOS runner slots.
 - [INTERNAL] Added the EAS auto-merge trusted-author allowlist so eligible green PRs do not repeatedly fail on missing gate configuration.
 - [INTERNAL] Added effort-leak guardrails so stale AI issue states, duplicate PR claims, and superseded CI runs are caught before agents spend more time.


### PR DESCRIPTION
## Summary

Adds a cheap Ubuntu preflight to the manual Windows tester release workflow so missing signing secrets fail before the workflow reserves a Windows runner. This keeps #75 blocked explicitly without burning Windows runner time on accidental manual runs.

## Linked issue

Closes #326

## Changes

- Added `release-preflight` to `.github/workflows/windows-tester-release.yml`.
- Made `signed-windows-tester-release` depend on the preflight before scheduling `windows-latest`.
- Added a changelog entry for the runner-spend guardrail.

## Acceptance criteria mirror

- [x] The Windows tester release workflow checks required signing secrets in a cheap preflight job before scheduling the Windows release runner.

## Test plan

- `git diff --check`
- `./scripts/validate.sh origin/main`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/windows-tester-release.yml`\n- `scripts/effort-leak-audit.sh`\n\n## Changelog entry\n\n- [INTERNAL] Added a cheap Windows tester release preflight so missing signing secrets fail before reserving a Windows runner.\n