### PR TITLE
[patch] Guard local validation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [INTERNAL] Added a repository docs audit to keep maintainer docs aligned with the local-first validation path and CI unit-test scope.
 - [INTERNAL] Added a cheap Windows tester release preflight so missing signing secrets fail before reserving a Windows runner.
 - [INTERNAL] Moved Swift/project change detection ahead of the self-hosted macOS CI job so config-only PRs no longer reserve macOS runner slots.
 - [INTERNAL] Added the EAS auto-merge trusted-author allowlist so eligible green PRs do not repeatedly fail on missing gate configuration.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ The debug bundle includes version info, macOS info, recent local logs, and safe 
 
 For the structured maintainer setup guide, see [docs/development/setup.md](docs/development/setup.md).
 
+Before opening a PR or spending CI runner time, run the cheap local-first validation entry point:
+
+```bash
+./scripts/validate.sh origin/main
+```
+
+That command mirrors the portable CI guardrails: changed-file Semgrep when available, Swift parse checks, local-transcription syntax checks, repository docs drift checks, and effort-leak issue/PR state checks.
+
 Open `BugNarrator.xcodeproj` in Xcode and build the `BugNarrator` scheme, or use:
 
 ```bash

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -39,16 +39,24 @@ If `project.yml` changed, regenerate the Xcode project:
 xcodegen generate
 ```
 
+Run the cheap local-first validator before opening a PR or spending GitHub Actions runner time:
+
+```bash
+./scripts/validate.sh origin/main
+```
+
+This is the portable validation entry point used by CI runtime guardrails. It records status files under `artifacts/validation/`, including Semgrep availability, Swift parse checks, local-transcription syntax checks, repository docs drift checks, and effort-leak issue/PR state checks.
+
 Build the app locally:
 
 ```bash
 xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO build
 ```
 
-Run tests:
+Run the CI-aligned macOS unit-test scope:
 
 ```bash
-xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test
+xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test
 ```
 
 ## Local Release Validation

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -10,14 +10,24 @@ Detailed companion docs:
 
 ## Automated Baseline
 
-Current macOS validation baseline:
+Cheap local-first validation before opening a PR or spending GitHub Actions runner time:
+
+```bash
+./scripts/validate.sh origin/main
+```
+
+This is the portable CI runtime-guardrails entry point. It records status files under `artifacts/validation/`, including Semgrep availability, Swift parse checks, local-transcription syntax checks, repository docs drift checks, and effort-leak issue/PR state checks.
+
+Current macOS release-readiness baseline:
 
 ```bash
 ./scripts/release_smoke_test.sh
 ./scripts/accessibility_regression_check.sh
-xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug CODE_SIGNING_ALLOWED=NO test
+xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test
 xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Release CODE_SIGNING_ALLOWED=NO build
 ```
+
+The CI macOS job intentionally runs `BugNarratorTests` only; UI tests require a usable window server and remain a targeted local/manual validation path.
 
 Current Windows workspace validation baseline on Windows:
 

--- a/scripts/repo-docs-audit.sh
+++ b/scripts/repo-docs-audit.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Checks that maintainer-facing docs keep pointing at the canonical local
+# validation path instead of drifting back to ad hoc or CI-expensive commands.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAILURES=0
+
+require_literal() {
+  local file="$1"
+  local needle="$2"
+  local description="$3"
+
+  if grep -Fq -- "$needle" "$file"; then
+    printf 'ok  %s\n' "$description"
+  else
+    printf 'miss %s (%s)\n' "$description" "$file" >&2
+    FAILURES=1
+  fi
+}
+
+require_literal \
+  "README.md" \
+  "./scripts/validate.sh origin/main" \
+  "README names the cheap local-first validator"
+
+require_literal \
+  "docs/development/setup.md" \
+  "./scripts/validate.sh origin/main" \
+  "development setup names the cheap local-first validator"
+
+require_literal \
+  "docs/testing/testing.md" \
+  "./scripts/validate.sh origin/main" \
+  "testing guide names the cheap local-first validator"
+
+require_literal \
+  "docs/testing/testing.md" \
+  "-only-testing:BugNarratorTests" \
+  "testing guide documents the CI-aligned unit-test scope"
+
+require_literal \
+  ".github/workflows/ci.yml" \
+  "./scripts/validate.sh" \
+  "CI uses the same validator named in docs"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "Repository docs audit failed." >&2
+  exit 1
+fi
+
+echo "Repository docs audit passed."

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -32,6 +32,8 @@ LOCAL_TRANSCRIPTION_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/local-transcription-
 LOCAL_TRANSCRIPTION_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/local-transcription-output.txt"
 EFFORT_LEAK_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/effort-leak-status.txt"
 EFFORT_LEAK_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/effort-leak-output.txt"
+REPO_DOCS_STATUS_FILE="${VALIDATION_ARTIFACT_DIR}/repo-docs-status.txt"
+REPO_DOCS_OUTPUT_FILE="${VALIDATION_ARTIFACT_DIR}/repo-docs-output.txt"
 mkdir -p "$VALIDATION_ARTIFACT_DIR"
 rm -f \
   "$SEMGREP_STATUS_FILE" \
@@ -39,7 +41,9 @@ rm -f \
   "$LOCAL_TRANSCRIPTION_STATUS_FILE" \
   "$LOCAL_TRANSCRIPTION_OUTPUT_FILE" \
   "$EFFORT_LEAK_STATUS_FILE" \
-  "$EFFORT_LEAK_OUTPUT_FILE"
+  "$EFFORT_LEAK_OUTPUT_FILE" \
+  "$REPO_DOCS_STATUS_FILE" \
+  "$REPO_DOCS_OUTPUT_FILE"
 
 should_skip_semgrep_target() {
   local target="$1"
@@ -153,6 +157,16 @@ if [[ -x "$ROOT/scripts/effort-leak-audit.sh" ]]; then
     fi
   else
     cat "$EFFORT_LEAK_OUTPUT_FILE" >&2
+    exit 1
+  fi
+fi
+
+if [[ -x "$ROOT/scripts/repo-docs-audit.sh" ]]; then
+  if "$ROOT/scripts/repo-docs-audit.sh" >"$REPO_DOCS_OUTPUT_FILE" 2>&1; then
+    printf 'PASS: repository docs still name canonical local validation commands\n' \
+      >"$REPO_DOCS_STATUS_FILE"
+  else
+    cat "$REPO_DOCS_OUTPUT_FILE" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Closes #328

## Summary
- add a repository docs audit that keeps maintainer docs aligned with the local-first validation command and CI unit-test scope
- wire the audit into scripts/validate.sh so drift fails locally and in runtime guardrails
- update README, setup, and testing docs to name ./scripts/validate.sh origin/main before heavier build/test paths

## Effort leaks found
- P1: local maintainer docs did not clearly identify the cheap CI-aligned validator before heavier xcodebuild/release validation paths, causing repeated agent/human uncertainty and unnecessary runner or local build spend
- P2: docs did not explicitly preserve the CI macOS test scope of BugNarratorTests only, leaving agents likely to run UI tests in environments without a reliable window server

## Validation
- git diff --check
- scripts/repo-docs-audit.sh
- scripts/effort-leak-audit.sh
- ./scripts/validate.sh origin/main

## Remaining risk
- This pass does not change product code or release automation. It focuses on preventing validation-doc drift; deeper workflow consolidation should stay issue-scoped.