### PR TITLE
Stabilize AI setup and narration quality

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -14,25 +14,15 @@
 		05FAED3D483F3C16AEFFB7A5 /* TranscriptSectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */; };
 		0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */; };
 		099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */; };
+		09B048166CEEFA50BD278F7D /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */; };
 		0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */; };
-		300B00000000000000000001 /* APIKeyValidationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000001 /* APIKeyValidationStateTests.swift */; };
-		300B00000000000000000002 /* AppRuntimeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000002 /* AppRuntimeEnvironmentTests.swift */; };
-		300B00000000000000000003 /* AppStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000003 /* AppStatusTests.swift */; };
-		300B00000000000000000004 /* ChangelogDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000004 /* ChangelogDocumentTests.swift */; };
-		300B00000000000000000005 /* ElapsedTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000005 /* ElapsedTimeFormatterTests.swift */; };
-		300B00000000000000000006 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000006 /* HotkeyShortcutTests.swift */; };
-		300B00000000000000000007 /* RecordingAudioSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000007 /* RecordingAudioSourceTests.swift */; };
-		300B00000000000000000008 /* RecordingSessionDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000008 /* RecordingSessionDraftTests.swift */; };
-		300B00000000000000000009 /* SessionMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F00000000000000000009 /* SessionMarkerTests.swift */; };
-		300B0000000000000000000A /* SessionScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F0000000000000000000A /* SessionScreenshotTests.swift */; };
-		300B0000000000000000000B /* TranscriptQualityFindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F0000000000000000000B /* TranscriptQualityFindingTests.swift */; };
-		300B0000000000000000000C /* TranscriptSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F0000000000000000000C /* TranscriptSectionTests.swift */; };
-		300B0000000000000000000D /* TransientToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300F0000000000000000000D /* TransientToastTests.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
-		255A00000000000000000001 /* MixedAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255A00000000000000000002 /* MixedAudioRecorderTests.swift */; };
+		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
+		1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */; };
+		1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */; };
 		280973289AE78D9919ECD80C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5346EDB503C6B05C81C368 /* KeychainService.swift */; };
 		28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */; };
 		292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */; };
@@ -41,7 +31,10 @@
 		2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */; };
 		2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */; };
 		30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */; };
+		31D0FF8CFB99E767103A0561 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2173ED04BA5467313B6261 /* AppErrorPresenterTests.swift */; };
+		31DE75541AFCD7104ED7F09E /* AppStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */; };
 		334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554387017B49D9CD63967BE3 /* AppStateTests.swift */; };
+		33D0E3F65FCAE14DBC117B40 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */; };
 		33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800BFCC6407B534886C65D77 /* TranscriptionClient.swift */; };
 		3426E7C93FFCC254F7016A99 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F03E1852A3D56F888E98739E /* Assets.xcassets */; };
 		3893EB325B3915242FBD4BA6 /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */; };
@@ -56,59 +49,33 @@
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
-		107A00000000000000000001 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000003 /* IssueExportController.swift */; };
-		107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107A00000000000000000004 /* IssueExportControllerTests.swift */; };
-		117A00000000000000000001 /* AppErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000003 /* AppErrorPresenter.swift */; };
-		117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117A00000000000000000004 /* AppErrorPresenterTests.swift */; };
-		119A00000000000000000001 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000003 /* LocalDataDeletionController.swift */; };
-		119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */; };
-		121A00000000000000000001 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000003 /* AppUtilityActionController.swift */; };
-		121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121A00000000000000000004 /* AppUtilityActionControllerTests.swift */; };
-		253A00000000000000000001 /* AppSupportLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253A00000000000000000002 /* AppSupportLocationTests.swift */; };
-		125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000003 /* ApplicationTerminationController.swift */; };
-		125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */; };
-		127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000003 /* ScreenshotCaptureController.swift */; };
-		127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */; };
-		129A00000000000000000001 /* RecordingStatusMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */; };
-		129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */; };
-		189A00000000000000000001 /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */; };
-		131A00000000000000000001 /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000003 /* DebugSessionContextProvider.swift */; };
-		131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131A00000000000000000004 /* DebugSessionContextProviderTests.swift */; };
-		137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000003 /* TranscriptionSessionBuilder.swift */; };
-		137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */; };
-		227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000003 /* PostTranscriptionPipelineController.swift */; };
-		227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */; };
-		229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
-		231A00000000000000000001 /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */; };
-		235A00000000000000000001 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */; };
-		123A00000000000000000001 /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000003 /* TransientToastController.swift */; };
-		123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123A00000000000000000004 /* TransientToastControllerTests.swift */; };
-		113A00000000000000000001 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000003 /* ExportHistoryController.swift */; };
-		113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113A00000000000000000004 /* ExportHistoryControllerTests.swift */; };
-		109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000003 /* PermissionRecoveryController.swift */; };
-		109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */; };
-		111A00000000000000000001 /* SupportDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000003 /* SupportDataController.swift */; };
-		111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111A00000000000000000004 /* SupportDataControllerTests.swift */; };
-		105A00000000000000000001 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000003 /* IssueExtractionController.swift */; };
-		105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105A00000000000000000004 /* IssueExtractionControllerTests.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
 		4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */; };
+		4F09098206B2332C4BE82DCC /* LocalDataDeletionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E01384A3A5079D5BCBEF1B /* LocalDataDeletionControllerTests.swift */; };
 		5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */; };
+		5064BB4B0E4DD7CD0A925F8E /* PermissionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F7DD790A65A410DAF9831C /* PermissionRecoveryControllerTests.swift */; };
 		5090A54144CACF59295F137C /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22447E5581818B8003AA49F8 /* TestSupport.swift */; };
+		525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */; };
 		52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */; };
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
+		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
 		57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */; };
+		58E53F2092F34D45456CE5DF /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */; };
+		58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */; };
 		594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */; };
 		5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D753EF601F00C09C7FF276C /* TransientToast.swift */; };
 		5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */; };
+		5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49B2B79731E3A62B083174 /* IssueExportController.swift */; };
 		5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */; };
 		5CB8DACFD986D905D03D0E6A /* ChangelogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */; };
 		5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */; };
 		5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7322F6B6A58542DEDFC76CCA /* ExportService.swift */; };
 		634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */; };
 		6470CFDC78DB57C49819E4A9 /* SupportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DF81E6E8D3A702691797E56 /* SupportView.swift */; };
+		67FF2F23B7542897FC6BE68E /* TransientToastController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DF28E6CC5FB74499C91B74 /* TransientToastController.swift */; };
 		683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */; };
+		68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */; };
 		6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */; };
 		6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */; };
 		6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */; };
@@ -118,26 +85,36 @@
 		6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */; };
 		6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */; };
 		6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E006D3F529E46315F3585 /* HotkeyAction.swift */; };
+		6FFA4F6D7629DDCB2EBAA070 /* AppUtilityActionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFCA1A4773C2BB41581B37CB /* AppUtilityActionController.swift */; };
 		7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */; };
 		71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
+		75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */; };
+		7A05BD7256DB61E5ADA8C818 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2064E70346EE9E9D138A9D10 /* PendingTranscriptionRetryFailureHandlerTests.swift */; };
 		7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3104282993DE974208688237 /* TranscriptQualityFinding.swift */; };
 		7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */; };
 		7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
+		806F6B3953A77B84672AD2DA /* AppRuntimeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */; };
 		821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */; };
 		82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */; };
 		8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */; };
 		8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */; };
+		8839D4116A3265DB08430846 /* SupportDataController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE1E25C090853C38690595 /* SupportDataController.swift */; };
 		88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */; };
 		8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67770387C5BA986EEB40382E /* SessionLibraryTests.swift */; };
 		8CF257839BEA4B0681BEA508 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */; };
 		8E0DE1B3EABFCECD46EF5ED0 /* SessionDataProtectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */; };
+		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
+		93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */; };
 		9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */; };
+		952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */; };
 		954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */; };
+		9619964E0CEE6D5A039340F7 /* SessionScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */; };
+		977D86FA0E7E2C16A5B41D4D /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */; };
 		981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */; };
 		99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */; };
 		994C5601BD2578CC3A980002 /* AIProviderSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */; };
@@ -146,40 +123,65 @@
 		9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */; };
 		9E2FEC30CC71E38CBD59106C /* ExtractedIssue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B361DA07CDFA2543A36258F /* ExtractedIssue.swift */; };
 		9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EFF170BAD57E66A7CB20AB /* AppState.swift */; };
+		A0CCAAA3701FF6274B792685 /* APIKeyValidationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */; };
 		A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */; };
 		A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */; };
+		A4732193A022678F45A3BCFC /* TransientToastControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AE33EE76F55AE456924849 /* TransientToastControllerTests.swift */; };
+		A4E7DAB84ECCC217C655A67C /* TranscriptSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58645DF704D4244897938E77 /* TranscriptSectionTests.swift */; };
 		A514C06B61A203200CF118A1 /* AppBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */; };
+		A6922E228A52ADAA89226ED4 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
 		A6AF1CAA204EF971F9417E63 /* TranscriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */; };
 		A73F5969DB4A2C04BC83BF45 /* ExportReceiptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */; };
 		A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */; };
+		A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */; };
 		A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */; };
 		AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */; };
+		AD2549206170CE4F862AD61B /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */; };
+		B04FF93EC9D1DE838189B564 /* AISetupSectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB4AAA0A02B42A31386D0D7 /* AISetupSectionsView.swift */; };
+		B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */; };
 		B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */; };
 		B3F726638452CBD7F5A4DC16 /* WindowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */; };
+		B3FF6A0FB442CAC98A7B9E81 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */; };
 		B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A663ED1B160E290FCFAC3AED /* ClipboardService.swift */; };
 		B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */; };
 		BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */; };
+		C1FDA2B024230D874D06D08B /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */; };
+		C32D262C1E3A497D0B371C06 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */; };
+		C36540B4BE0CB254215654AB /* MixedAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */; };
 		C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78DB2CC94CABCD51955891BF /* AppStatus.swift */; };
 		C4DEF637FA4D2980FA55A9C9 /* APIKeyValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084D11633172FCB62C674D40 /* APIKeyValidationState.swift */; };
+		C739EC09645E2A0D6E7B52CA /* RecordingStatusMessageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C800B9028E34058B3B1544 /* RecordingStatusMessageBuilderTests.swift */; };
 		C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */; };
+		C90F9957B3AC369A5CD49C26 /* ElapsedTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */; };
 		C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */; };
 		CB9E1F15D2FB0B7CF38DD5F6 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB303E43134D880AB6207D21 /* AppError.swift */; };
 		CBE08ABB1F52871FE33471BA /* ScreenshotPreviewCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */; };
 		CEDAB8D8BF65455F21123B22 /* SessionLibraryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */; };
+		D05B48ECBEFAF80A63A7E3CF /* AppErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC68E525601D89A4E993FC89 /* AppErrorPresenter.swift */; };
 		D0754552F75E1CE6B4128800 /* TranscriptExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */; };
 		D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */; };
+		D7D868701BE0B53E59DD6DFD /* TranscriptQualityFindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */; };
 		D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */; };
+		DA186645807A441A35F08A44 /* HotkeyShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF1EE5E9EEE1A5D22F7A647 /* HotkeyShortcutTests.swift */; };
+		DABA5D4856C56172E1DFB2FF /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */; };
+		DB44B00A8FFA358E3239DA48 /* RecordingAudioSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A79F0CD44463306F35C431 /* RecordingAudioSourceTests.swift */; };
 		DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */; };
 		DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */; };
+		E1B0000CAD83CD900AA29EAD /* AppSupportLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */; };
 		E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */; };
 		E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */; };
+		E7512039897A180D1EC9DF3D /* RecordingSessionDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */; };
 		E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */; };
 		EA159F21E891A76BE6A4E825 /* RecordingSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */; };
 		EB26330B3289473ED7361280 /* BugNarratorDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */; };
+		EB5DAB7367CC0E4D69D936B6 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */; };
 		EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */; };
 		F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */; };
+		F6A698B3E54CEF73047BC042 /* SessionMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */; };
 		F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */; };
+		F715303DE87CE267F3336E39 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305726D5E9A576C4C9729670 /* TranscriptionSessionBuilder.swift */; };
 		F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */; };
+		FAF01A932489386F2FEFA1AB /* TransientToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */; };
 		FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */; };
 		FEFF63FB3DA83F5C8BC659C1 /* AppPresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE77CF3D9076FC05278390A6 /* AppPresentationState.swift */; };
 		FFF767231D9C465D49D307F8 /* AudioUploadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */; };
@@ -204,138 +206,118 @@
 
 /* Begin PBXFileReference section */
 		002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingTimerViewModel.swift; sourceTree = "<group>"; };
+		00F7DD790A65A410DAF9831C /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspector.swift; sourceTree = "<group>"; };
+		0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatterTests.swift; sourceTree = "<group>"; };
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
+		073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
-		300F00000000000000000001 /* APIKeyValidationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationStateTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000002 /* AppRuntimeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironmentTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000003 /* AppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000004 /* ChangelogDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogDocumentTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000005 /* ElapsedTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatterTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000006 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000007 /* RecordingAudioSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingAudioSourceTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000008 /* RecordingSessionDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraftTests.swift; sourceTree = "<group>"; };
-		300F00000000000000000009 /* SessionMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarkerTests.swift; sourceTree = "<group>"; };
-		300F0000000000000000000A /* SessionScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshotTests.swift; sourceTree = "<group>"; };
-		300F0000000000000000000B /* TranscriptQualityFindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFindingTests.swift; sourceTree = "<group>"; };
-		300F0000000000000000000C /* TranscriptSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSectionTests.swift; sourceTree = "<group>"; };
-		300F0000000000000000000D /* TransientToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTests.swift; sourceTree = "<group>"; };
 		0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingControlPanelView.swift; sourceTree = "<group>"; };
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
+		17E01384A3A5079D5BCBEF1B /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
 		17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionResolver.swift; sourceTree = "<group>"; };
 		1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTests.swift; sourceTree = "<group>"; };
 		1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportPayloadBudget.swift; sourceTree = "<group>"; };
 		1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironment.swift; sourceTree = "<group>"; };
+		1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTests.swift; sourceTree = "<group>"; };
+		2064E70346EE9E9D138A9D10 /* PendingTranscriptionRetryFailureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailureHandlerTests.swift; sourceTree = "<group>"; };
 		20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionServiceTests.swift; sourceTree = "<group>"; };
 		22447E5581818B8003AA49F8 /* TestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSupport.swift; sourceTree = "<group>"; };
 		22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraft.swift; sourceTree = "<group>"; };
 		22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorSettingsUITests.swift; sourceTree = "<group>"; };
 		254021D1AC93E8A414D26241 /* BugNarratorUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugNarratorUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProvider.swift; sourceTree = "<group>"; };
 		277DC17D4084F918920CB8C5 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		28B463E2764267ED731EDB99 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
 		2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
 		2D753EF601F00C09C7FF276C /* TransientToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToast.swift; sourceTree = "<group>"; };
 		2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProvider.swift; sourceTree = "<group>"; };
+		2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarkerTests.swift; sourceTree = "<group>"; };
 		2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBundleExporter.swift; sourceTree = "<group>"; };
+		305726D5E9A576C4C9729670 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
 		3104282993DE974208688237 /* TranscriptQualityFinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFinding.swift; sourceTree = "<group>"; };
 		33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionServiceTests.swift; sourceTree = "<group>"; };
 		33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogDocument.swift; sourceTree = "<group>"; };
-		105A00000000000000000003 /* IssueExtractionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionController.swift; sourceTree = "<group>"; };
-		105A00000000000000000004 /* IssueExtractionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionControllerTests.swift; sourceTree = "<group>"; };
 		34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWorkspaceTests.swift; sourceTree = "<group>"; };
 		3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionControllerTests.swift; sourceTree = "<group>"; };
+		3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
+		38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
 		3B361DA07CDFA2543A36258F /* ExtractedIssue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtractedIssue.swift; sourceTree = "<group>"; };
 		3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceControllerTests.swift; sourceTree = "<group>"; };
+		3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
 		40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLoggerTests.swift; sourceTree = "<group>"; };
 		417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginService.swift; sourceTree = "<group>"; };
 		440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinator.swift; sourceTree = "<group>"; };
 		4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
-		107A00000000000000000003 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
-		107A00000000000000000004 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
-		113A00000000000000000003 /* ExportHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryController.swift; sourceTree = "<group>"; };
-		113A00000000000000000004 /* ExportHistoryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryControllerTests.swift; sourceTree = "<group>"; };
-		109A00000000000000000003 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
-		109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
-		117A00000000000000000003 /* AppErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenter.swift; sourceTree = "<group>"; };
-		117A00000000000000000004 /* AppErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenterTests.swift; sourceTree = "<group>"; };
-		119A00000000000000000003 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
-		119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
-		121A00000000000000000003 /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
-		121A00000000000000000004 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
-		253A00000000000000000002 /* AppSupportLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocationTests.swift; sourceTree = "<group>"; };
-		125A00000000000000000003 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
-		125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
-		127A00000000000000000003 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
-		127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
-		129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilder.swift; sourceTree = "<group>"; };
-		129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
-		189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
-		131A00000000000000000003 /* DebugSessionContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProvider.swift; sourceTree = "<group>"; };
-		131A00000000000000000004 /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
-		137A00000000000000000003 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
-		137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
-		227A00000000000000000003 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
-		227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
-		229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
-		231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
-		235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailureHandlerTests.swift; sourceTree = "<group>"; };
-		123A00000000000000000003 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
-		123A00000000000000000004 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
-		111A00000000000000000003 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
-		111A00000000000000000004 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
+		48DF28E6CC5FB74499C91B74 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
+		4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionControllerTests.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
-		255A00000000000000000002 /* MixedAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorderTests.swift; sourceTree = "<group>"; };
+		51C800B9028E34058B3B1544 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
 		52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
+		52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationStateTests.swift; sourceTree = "<group>"; };
 		54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureService.swift; sourceTree = "<group>"; };
 		553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
 		554387017B49D9CD63967BE3 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotPreviewCache.swift; sourceTree = "<group>"; };
+		58645DF704D4244897938E77 /* TranscriptSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSectionTests.swift; sourceTree = "<group>"; };
 		598E006D3F529E46315F3585 /* HotkeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyAction.swift; sourceTree = "<group>"; };
 		59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutBugNarratorView.swift; sourceTree = "<group>"; };
 		5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogView.swift; sourceTree = "<group>"; };
 		5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshot.swift; sourceTree = "<group>"; };
 		5C5346EDB503C6B05C81C368 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		5D2173ED04BA5467313B6261 /* AppErrorPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenterTests.swift; sourceTree = "<group>"; };
 		5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionResolverTests.swift; sourceTree = "<group>"; };
 		5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServiceContainer.swift; sourceTree = "<group>"; };
 		6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioRecorder.swift; sourceTree = "<group>"; };
+		6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataControllerTests.swift; sourceTree = "<group>"; };
 		60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewWorkspace.swift; sourceTree = "<group>"; };
 		60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocation.swift; sourceTree = "<group>"; };
 		60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapper.swift; sourceTree = "<group>"; };
 		6131EA189B853D1B456A8D26 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironmentTests.swift; sourceTree = "<group>"; };
 		67770387C5BA986EEB40382E /* SessionLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryTests.swift; sourceTree = "<group>"; };
+		68A79F0CD44463306F35C431 /* RecordingAudioSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingAudioSourceTests.swift; sourceTree = "<group>"; };
+		6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryController.swift; sourceTree = "<group>"; };
 		6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSession.swift; sourceTree = "<group>"; };
 		6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProtocols.swift; sourceTree = "<group>"; };
+		6CB4AAA0A02B42A31386D0D7 /* AISetupSectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISetupSectionsView.swift; sourceTree = "<group>"; };
 		6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueScreenshotAnnotationRenderer.swift; sourceTree = "<group>"; };
 		6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcut.swift; sourceTree = "<group>"; };
 		6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoTests.swift; sourceTree = "<group>"; };
 		6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryController.swift; sourceTree = "<group>"; };
 		7322F6B6A58542DEDFC76CCA /* ExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportService.swift; sourceTree = "<group>"; };
 		76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataProtector.swift; sourceTree = "<group>"; };
 		78DB2CC94CABCD51955891BF /* AppStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatus.swift; sourceTree = "<group>"; };
 		78EFF170BAD57E66A7CB20AB /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		792A02D8EE4EBB2A02D4043D /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSectionBuilder.swift; sourceTree = "<group>"; };
+		7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocationTests.swift; sourceTree = "<group>"; };
 		7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporterTests.swift; sourceTree = "<group>"; };
 		800BFCC6407B534886C65D77 /* TranscriptionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClient.swift; sourceTree = "<group>"; };
 		811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionService.swift; sourceTree = "<group>"; };
 		820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabelView.swift; sourceTree = "<group>"; };
+		84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
 		84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionServiceTests.swift; sourceTree = "<group>"; };
 		865C5FE84904ECA5F4379637 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
 		86D135AC919EF9A5E8C21235 /* SessionMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarker.swift; sourceTree = "<group>"; };
 		875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionController.swift; sourceTree = "<group>"; };
+		88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogDocumentTests.swift; sourceTree = "<group>"; };
 		8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUploadPolicy.swift; sourceTree = "<group>"; };
 		8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotAnnotationTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
+		90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
 		92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
 		97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporter.swift; sourceTree = "<group>"; };
 		99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
+		9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapperTests.swift; sourceTree = "<group>"; };
 		9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsService.swift; sourceTree = "<group>"; };
 		9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStore.swift; sourceTree = "<group>"; };
 		9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionServiceTests.swift; sourceTree = "<group>"; };
@@ -345,40 +327,62 @@
 		A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorder.swift; sourceTree = "<group>"; };
 		A8E2942C142197B34696946C /* TranscriptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSection.swift; sourceTree = "<group>"; };
 		A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBundleDirectoryWriter.swift; sourceTree = "<group>"; };
+		ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
 		AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalTelemetryRecorder.swift; sourceTree = "<group>"; };
+		AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshotTests.swift; sourceTree = "<group>"; };
 		AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProviderTests.swift; sourceTree = "<group>"; };
+		B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraftTests.swift; sourceTree = "<group>"; };
 		B09CA463A8DF59221937A2C7 /* TranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptView.swift; sourceTree = "<group>"; };
 		B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
 		B294CC5102A78C8F1D01EEB6 /* BugNarrator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugNarrator.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilder.swift; sourceTree = "<group>"; };
+		B3AE33EE76F55AE456924849 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
+		B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
+		BA49B2B79731E3A62B083174 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
 		BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStoreTests.swift; sourceTree = "<group>"; };
 		BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporter.swift; sourceTree = "<group>"; };
 		BB303E43134D880AB6207D21 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionService.swift; sourceTree = "<group>"; };
 		BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingAudioSource.swift; sourceTree = "<group>"; };
 		C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitorTests.swift; sourceTree = "<group>"; };
+		C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusTests.swift; sourceTree = "<group>"; };
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
 		C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
 		C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsServiceTests.swift; sourceTree = "<group>"; };
 		CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibrary.swift; sourceTree = "<group>"; };
 		CCCB5C9DAEB3066CA8E30234 /* SingleInstanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceController.swift; sourceTree = "<group>"; };
+		D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionController.swift; sourceTree = "<group>"; };
 		D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataProtectorTests.swift; sourceTree = "<group>"; };
+		D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorderTests.swift; sourceTree = "<group>"; };
 		D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorLinks.swift; sourceTree = "<group>"; };
 		D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalTelemetryRecorderTests.swift; sourceTree = "<group>"; };
+		D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
+		D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
 		DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStore.swift; sourceTree = "<group>"; };
 		DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueScreenshotAnnotationPreview.swift; sourceTree = "<group>"; };
 		DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProviderTests.swift; sourceTree = "<group>"; };
+		DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
 		DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorApp.swift; sourceTree = "<group>"; };
+		E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
 		E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
+		E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
 		E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
 		EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionService.swift; sourceTree = "<group>"; };
+		EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFindingTests.swift; sourceTree = "<group>"; };
 		EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
 		EE77CF3D9076FC05278390A6 /* AppPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPresentationState.swift; sourceTree = "<group>"; };
+		EECE1E25C090853C38690595 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
+		EFCA1A4773C2BB41581B37CB /* AppUtilityActionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionController.swift; sourceTree = "<group>"; };
 		F03E1852A3D56F888E98739E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
 		F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitor.swift; sourceTree = "<group>"; };
 		F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClientTests.swift; sourceTree = "<group>"; };
 		F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBundleExporterTests.swift; sourceTree = "<group>"; };
 		F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProvider.swift; sourceTree = "<group>"; };
+		FC68E525601D89A4E993FC89 /* AppErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenter.swift; sourceTree = "<group>"; };
+		FCF1EE5E9EEE1A5D22F7A647 /* HotkeyShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyShortcutTests.swift; sourceTree = "<group>"; };
+		FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryControllerTests.swift; sourceTree = "<group>"; };
 		FED17EDC791F33BADA9E14D8 /* BugNarratorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugNarratorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporterTests.swift; sourceTree = "<group>"; };
 		FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionService.swift; sourceTree = "<group>"; };
@@ -399,76 +403,77 @@
 		2365FC0566C298691506FFDF /* BugNarratorTests */ = {
 			isa = PBXGroup;
 			children = (
-				300F00000000000000000001 /* APIKeyValidationStateTests.swift */,
+				52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */,
 				553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */,
+				5D2173ED04BA5467313B6261 /* AppErrorPresenterTests.swift */,
 				C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */,
-				117A00000000000000000004 /* AppErrorPresenterTests.swift */,
-				300F00000000000000000002 /* AppRuntimeEnvironmentTests.swift */,
+				B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */,
+				64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */,
 				554387017B49D9CD63967BE3 /* AppStateTests.swift */,
-				300F00000000000000000003 /* AppStatusTests.swift */,
-				121A00000000000000000004 /* AppUtilityActionControllerTests.swift */,
-				253A00000000000000000002 /* AppSupportLocationTests.swift */,
-				125A00000000000000000004 /* ApplicationTerminationControllerTests.swift */,
-				300F00000000000000000004 /* ChangelogDocumentTests.swift */,
+				C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */,
+				7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */,
+				F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */,
+				88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
-				131A00000000000000000004 /* DebugSessionContextProviderTests.swift */,
+				ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */,
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
-				300F00000000000000000005 /* ElapsedTimeFormatterTests.swift */,
-				113A00000000000000000004 /* ExportHistoryControllerTests.swift */,
-				229A00000000000000000003 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
-				231A00000000000000000003 /* RetryPostTranscriptionResultHandlerTests.swift */,
+				0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */,
+				FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */,
+				3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
-				300F00000000000000000006 /* HotkeyShortcutTests.swift */,
-				107A00000000000000000004 /* IssueExportControllerTests.swift */,
-				105A00000000000000000004 /* IssueExtractionControllerTests.swift */,
+				FCF1EE5E9EEE1A5D22F7A647 /* HotkeyShortcutTests.swift */,
+				E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */,
+				4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */,
 				33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */,
 				DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */,
 				B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */,
 				C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */,
-				119A00000000000000000004 /* LocalDataDeletionControllerTests.swift */,
+				17E01384A3A5079D5BCBEF1B /* LocalDataDeletionControllerTests.swift */,
 				EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */,
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
-				255A00000000000000000002 /* MixedAudioRecorderTests.swift */,
+				D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */,
+				9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
-				235A00000000000000000003 /* PendingTranscriptionRetryFailureHandlerTests.swift */,
-				109A00000000000000000004 /* PermissionRecoveryControllerTests.swift */,
-				227A00000000000000000004 /* PostTranscriptionPipelineControllerTests.swift */,
+				2064E70346EE9E9D138A9D10 /* PendingTranscriptionRetryFailureHandlerTests.swift */,
+				00F7DD790A65A410DAF9831C /* PermissionRecoveryControllerTests.swift */,
+				84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */,
 				FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */,
 				6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */,
-				300F00000000000000000007 /* RecordingAudioSourceTests.swift */,
-				129A00000000000000000004 /* RecordingStatusMessageBuilderTests.swift */,
+				68A79F0CD44463306F35C431 /* RecordingAudioSourceTests.swift */,
 				3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */,
-				300F00000000000000000008 /* RecordingSessionDraftTests.swift */,
-				189A00000000000000000002 /* RetryTranscriptionStatusPresenterTests.swift */,
+				B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */,
+				51C800B9028E34058B3B1544 /* RecordingStatusMessageBuilderTests.swift */,
+				D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */,
+				D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */,
 				34F0EA33B709CD1A77190E70 /* ReviewWorkspaceTests.swift */,
 				4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */,
 				84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */,
 				8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */,
+				073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */,
 				94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */,
-				127A00000000000000000004 /* ScreenshotCaptureControllerTests.swift */,
 				92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */,
 				20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */,
 				CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */,
 				D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */,
 				E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */,
 				67770387C5BA986EEB40382E /* SessionLibraryTests.swift */,
-				300F00000000000000000009 /* SessionMarkerTests.swift */,
-				300F0000000000000000000A /* SessionScreenshotTests.swift */,
+				2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */,
+				AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
-				111A00000000000000000004 /* SupportDataControllerTests.swift */,
+				6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */,
 				22447E5581818B8003AA49F8 /* TestSupport.swift */,
-				300F0000000000000000000D /* TransientToastTests.swift */,
-				123A00000000000000000004 /* TransientToastControllerTests.swift */,
 				7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */,
-				300F0000000000000000000B /* TranscriptQualityFindingTests.swift */,
-				300F0000000000000000000C /* TranscriptSectionTests.swift */,
 				F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */,
-				137A00000000000000000004 /* TranscriptionSessionBuilderTests.swift */,
 				A31B0939DF668FFC71CD64FD /* TranscriptionRecoveryControllerTests.swift */,
+				DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */,
+				EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */,
 				8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */,
+				58645DF704D4244897938E77 /* TranscriptSectionTests.swift */,
 				BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */,
+				B3AE33EE76F55AE456924849 /* TransientToastControllerTests.swift */,
+				1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */,
 			);
 			path = BugNarratorTests;
 			sourceTree = "<group>";
@@ -528,6 +533,7 @@
 			isa = PBXGroup;
 			children = (
 				59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */,
+				6CB4AAA0A02B42A31386D0D7 /* AISetupSectionsView.swift */,
 				5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */,
 				4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */,
 				DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */,
@@ -546,39 +552,39 @@
 			isa = PBXGroup;
 			children = (
 				99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */,
-				117A00000000000000000003 /* AppErrorPresenter.swift */,
-				121A00000000000000000003 /* AppUtilityActionController.swift */,
-				125A00000000000000000003 /* ApplicationTerminationController.swift */,
+				FC68E525601D89A4E993FC89 /* AppErrorPresenter.swift */,
+				90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */,
+				EFCA1A4773C2BB41581B37CB /* AppUtilityActionController.swift */,
 				C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */,
 				8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */,
 				A663ED1B160E290FCFAC3AED /* ClipboardService.swift */,
 				2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */,
+				70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */,
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
-				113A00000000000000000003 /* ExportHistoryController.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
+				BA49B2B79731E3A62B083174 /* IssueExportController.swift */,
 				46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */,
-				107A00000000000000000003 /* IssueExportController.swift */,
-				105A00000000000000000003 /* IssueExtractionController.swift */,
+				D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
-				119A00000000000000000003 /* LocalDataDeletionController.swift */,
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
+				38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
 				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
-				109A00000000000000000003 /* PermissionRecoveryController.swift */,
-				227A00000000000000000003 /* PostTranscriptionPipelineController.swift */,
+				6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */,
+				E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
+				3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
-				127A00000000000000000003 /* ScreenshotCaptureController.swift */,
 				440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */,
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
 				6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */,
@@ -586,17 +592,17 @@
 				76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */,
 				52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */,
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
-				111A00000000000000000003 /* SupportDataController.swift */,
+				EECE1E25C090853C38690595 /* SupportDataController.swift */,
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
 				BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */,
 				800BFCC6407B534886C65D77 /* TranscriptionClient.swift */,
 				2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */,
-				123A00000000000000000003 /* TransientToastController.swift */,
 				04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */,
 				7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */,
 				9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */,
+				48DF28E6CC5FB74499C91B74 /* TransientToastController.swift */,
 				277DC17D4084F918920CB8C5 /* URLHandler.swift */,
 			);
 			path = Services;
@@ -615,18 +621,18 @@
 				D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */,
 				C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */,
 				33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */,
-				131A00000000000000000003 /* DebugSessionContextProvider.swift */,
+				2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */,
 				4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */,
 				6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */,
 				9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */,
 				17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */,
-				129A00000000000000000003 /* RecordingStatusMessageBuilder.swift */,
+				B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */,
 				002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */,
 				60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */,
 				57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */,
 				CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */,
 				CCCB5C9DAEB3066CA8E30234 /* SingleInstanceController.swift */,
-				137A00000000000000000003 /* TranscriptionSessionBuilder.swift */,
+				305726D5E9A576C4C9729670 /* TranscriptionSessionBuilder.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -774,76 +780,77 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				300B00000000000000000001 /* APIKeyValidationStateTests.swift in Sources */,
+				A0CCAAA3701FF6274B792685 /* APIKeyValidationStateTests.swift in Sources */,
 				A514C06B61A203200CF118A1 /* AppBootstrapTests.swift in Sources */,
+				31D0FF8CFB99E767103A0561 /* AppErrorPresenterTests.swift in Sources */,
 				7094EC90F13C99BA56871010 /* AppErrorTests.swift in Sources */,
-				117A00000000000000000002 /* AppErrorPresenterTests.swift in Sources */,
-				300B00000000000000000002 /* AppRuntimeEnvironmentTests.swift in Sources */,
+				806F6B3953A77B84672AD2DA /* AppRuntimeEnvironmentTests.swift in Sources */,
 				334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */,
-				300B00000000000000000003 /* AppStatusTests.swift in Sources */,
-				121A00000000000000000002 /* AppUtilityActionControllerTests.swift in Sources */,
-				253A00000000000000000001 /* AppSupportLocationTests.swift in Sources */,
-				125A00000000000000000002 /* ApplicationTerminationControllerTests.swift in Sources */,
-				300B00000000000000000004 /* ChangelogDocumentTests.swift in Sources */,
+				31DE75541AFCD7104ED7F09E /* AppStatusTests.swift in Sources */,
+				E1B0000CAD83CD900AA29EAD /* AppSupportLocationTests.swift in Sources */,
+				567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */,
+				AD2549206170CE4F862AD61B /* ApplicationTerminationControllerTests.swift in Sources */,
+				1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,
-				131A00000000000000000002 /* DebugSessionContextProviderTests.swift in Sources */,
+				8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */,
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
-				300B00000000000000000005 /* ElapsedTimeFormatterTests.swift in Sources */,
-				113A00000000000000000002 /* ExportHistoryControllerTests.swift in Sources */,
-				229A00000000000000000001 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
-				231A00000000000000000001 /* RetryPostTranscriptionResultHandlerTests.swift in Sources */,
+				C90F9957B3AC369A5CD49C26 /* ElapsedTimeFormatterTests.swift in Sources */,
+				58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */,
+				A6922E228A52ADAA89226ED4 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
-				300B00000000000000000006 /* HotkeyShortcutTests.swift in Sources */,
-				107A00000000000000000002 /* IssueExportControllerTests.swift in Sources */,
-				105A00000000000000000002 /* IssueExtractionControllerTests.swift in Sources */,
+				DA186645807A441A35F08A44 /* HotkeyShortcutTests.swift in Sources */,
+				09B048166CEEFA50BD278F7D /* IssueExportControllerTests.swift in Sources */,
+				58E53F2092F34D45456CE5DF /* IssueExtractionControllerTests.swift in Sources */,
 				F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */,
 				57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */,
 				6F4442D6646F20C3D3536F67 /* KeychainServiceTests.swift in Sources */,
 				5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */,
-				119A00000000000000000002 /* LocalDataDeletionControllerTests.swift in Sources */,
+				4F09098206B2332C4BE82DCC /* LocalDataDeletionControllerTests.swift in Sources */,
 				0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */,
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
-				255A00000000000000000001 /* MixedAudioRecorderTests.swift in Sources */,
+				C36540B4BE0CB254215654AB /* MixedAudioRecorderTests.swift in Sources */,
+				A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,
-				235A00000000000000000001 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */,
-				109A00000000000000000002 /* PermissionRecoveryControllerTests.swift in Sources */,
-				227A00000000000000000002 /* PostTranscriptionPipelineControllerTests.swift in Sources */,
+				7A05BD7256DB61E5ADA8C818 /* PendingTranscriptionRetryFailureHandlerTests.swift in Sources */,
+				5064BB4B0E4DD7CD0A925F8E /* PermissionRecoveryControllerTests.swift in Sources */,
+				15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */,
 				7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */,
 				8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */,
-				300B00000000000000000007 /* RecordingAudioSourceTests.swift in Sources */,
-				129A00000000000000000002 /* RecordingStatusMessageBuilderTests.swift in Sources */,
+				DB44B00A8FFA358E3239DA48 /* RecordingAudioSourceTests.swift in Sources */,
 				2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */,
-				300B00000000000000000008 /* RecordingSessionDraftTests.swift in Sources */,
-				189A00000000000000000001 /* RetryTranscriptionStatusPresenterTests.swift in Sources */,
+				E7512039897A180D1EC9DF3D /* RecordingSessionDraftTests.swift in Sources */,
+				C739EC09645E2A0D6E7B52CA /* RecordingStatusMessageBuilderTests.swift in Sources */,
+				DABA5D4856C56172E1DFB2FF /* RetryPostTranscriptionResultHandlerTests.swift in Sources */,
+				1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */,
 				634C2CA46D17B6AA571D0771 /* ReviewWorkspaceTests.swift in Sources */,
 				79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */,
 				9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */,
 				28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */,
+				C32D262C1E3A497D0B371C06 /* ScreenshotCaptureControllerTests.swift in Sources */,
 				05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */,
-				127A00000000000000000002 /* ScreenshotCaptureControllerTests.swift in Sources */,
 				52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */,
 				6F0782ACEFF9342CFD3D6D87 /* ScreenshotSelectionServiceTests.swift in Sources */,
 				F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */,
 				8E0DE1B3EABFCECD46EF5ED0 /* SessionDataProtectorTests.swift in Sources */,
 				01CEE47A97CA8B7ED6B6E1B5 /* SessionLibraryControllerTests.swift in Sources */,
 				8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */,
-				300B00000000000000000009 /* SessionMarkerTests.swift in Sources */,
-				300B0000000000000000000A /* SessionScreenshotTests.swift in Sources */,
+				F6A698B3E54CEF73047BC042 /* SessionMarkerTests.swift in Sources */,
+				9619964E0CEE6D5A039340F7 /* SessionScreenshotTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
-				111A00000000000000000002 /* SupportDataControllerTests.swift in Sources */,
+				75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */,
 				5090A54144CACF59295F137C /* TestSupport.swift in Sources */,
-				300B0000000000000000000D /* TransientToastTests.swift in Sources */,
-				123A00000000000000000002 /* TransientToastControllerTests.swift in Sources */,
 				683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */,
-				300B0000000000000000000B /* TranscriptQualityFindingTests.swift in Sources */,
-				300B0000000000000000000C /* TranscriptSectionTests.swift in Sources */,
+				D7D868701BE0B53E59DD6DFD /* TranscriptQualityFindingTests.swift in Sources */,
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
+				A4E7DAB84ECCC217C655A67C /* TranscriptSectionTests.swift in Sources */,
 				38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */,
 				0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */,
-				137A00000000000000000002 /* TranscriptionSessionBuilderTests.swift in Sources */,
 				3CE176593C0130AB6B4A12BA /* TranscriptionRecoveryControllerTests.swift in Sources */,
+				33D0E3F65FCAE14DBC117B40 /* TranscriptionSessionBuilderTests.swift in Sources */,
+				A4732193A022678F45A3BCFC /* TransientToastControllerTests.swift in Sources */,
+				FAF01A932489386F2FEFA1AB /* TransientToastTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -860,19 +867,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				994C5601BD2578CC3A980002 /* AIProviderSettingsController.swift in Sources */,
+				B04FF93EC9D1DE838189B564 /* AISetupSectionsView.swift in Sources */,
 				C4DEF637FA4D2980FA55A9C9 /* APIKeyValidationState.swift in Sources */,
 				7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */,
 				19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */,
 				CB9E1F15D2FB0B7CF38DD5F6 /* AppError.swift in Sources */,
-				117A00000000000000000001 /* AppErrorPresenter.swift in Sources */,
+				D05B48ECBEFAF80A63A7E3CF /* AppErrorPresenter.swift in Sources */,
 				FEFF63FB3DA83F5C8BC659C1 /* AppPresentationState.swift in Sources */,
 				5015987379D4ECB7454899DA /* AppRuntimeEnvironment.swift in Sources */,
 				292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */,
 				9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */,
 				C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */,
-				121A00000000000000000001 /* AppUtilityActionController.swift in Sources */,
-				125A00000000000000000001 /* ApplicationTerminationController.swift in Sources */,
 				EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */,
+				6FFA4F6D7629DDCB2EBAA070 /* AppUtilityActionController.swift in Sources */,
+				C1FDA2B024230D874D06D08B /* ApplicationTerminationController.swift in Sources */,
 				3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */,
 				456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */,
 				FFF767231D9C465D49D307F8 /* AudioUploadPolicy.swift in Sources */,
@@ -882,30 +890,30 @@
 				562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */,
 				77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */,
 				5CB8DACFD986D905D03D0E6A /* ChangelogView.swift in Sources */,
-				131A00000000000000000001 /* DebugSessionContextProvider.swift in Sources */,
 				B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */,
 				040E1F8A34C1C16904AB8370 /* DebugBundleExporter.swift in Sources */,
+				977D86FA0E7E2C16A5B41D4D /* DebugSessionContextProvider.swift in Sources */,
 				4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */,
+				93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */,
 				A73F5969DB4A2C04BC83BF45 /* ExportReceiptStore.swift in Sources */,
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
-				113A00000000000000000001 /* ExportHistoryController.swift in Sources */,
 				9E2FEC30CC71E38CBD59106C /* ExtractedIssue.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,
 				6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */,
 				8CF257839BEA4B0681BEA508 /* HotkeyManager.swift in Sources */,
 				3CDB0E66F370246528266E51 /* HotkeyRecorderView.swift in Sources */,
 				8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */,
+				5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */,
 				474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */,
-				107A00000000000000000001 /* IssueExportController.swift in Sources */,
-				105A00000000000000000001 /* IssueExtractionController.swift in Sources */,
+				EB5DAB7367CC0E4D69D936B6 /* IssueExtractionController.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
 				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
 				099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */,
-				119A00000000000000000001 /* LocalDataDeletionController.swift in Sources */,
 				E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */,
+				525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */,
 				E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */,
 				821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */,
 				4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */,
@@ -914,20 +922,20 @@
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */,
-				109A00000000000000000001 /* PermissionRecoveryController.swift in Sources */,
-				227A00000000000000000001 /* PostTranscriptionPipelineController.swift in Sources */,
+				68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */,
+				B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,
 				EA159F21E891A76BE6A4E825 /* RecordingSessionController.swift in Sources */,
-				129A00000000000000000001 /* RecordingStatusMessageBuilder.swift in Sources */,
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
+				952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,
+				B3FF6A0FB442CAC98A7B9E81 /* ScreenshotCaptureController.swift in Sources */,
 				6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */,
-				127A00000000000000000001 /* ScreenshotCaptureController.swift in Sources */,
 				71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */,
 				CBE08ABB1F52871FE33471BA /* ScreenshotPreviewCache.swift in Sources */,
 				B254C34FC1E013052F77EEA5 /* ScreenshotSelectionService.swift in Sources */,
@@ -941,13 +949,12 @@
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
+				8839D4116A3265DB08430846 /* SupportDataController.swift in Sources */,
 				6470CFDC78DB57C49819E4A9 /* SupportView.swift in Sources */,
-				111A00000000000000000001 /* SupportDataController.swift in Sources */,
 				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,
 				D0754552F75E1CE6B4128800 /* TranscriptExporter.swift in Sources */,
-				137A00000000000000000001 /* TranscriptionSessionBuilder.swift in Sources */,
 				7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */,
 				AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */,
 				6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */,
@@ -958,8 +965,9 @@
 				29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */,
 				33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */,
 				A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */,
+				F715303DE87CE267F3336E39 /* TranscriptionSessionBuilder.swift in Sources */,
 				5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */,
-				123A00000000000000000001 /* TransientToastController.swift in Sources */,
+				67FF2F23B7542897FC6BE68E /* TransientToastController.swift in Sources */,
 				3B4F5CCC16AB9837DD0BD0F4 /* URLHandler.swift in Sources */,
 				B3F726638452CBD7F5A4DC16 /* WindowCoordinator.swift in Sources */,
 			);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [FIX] Blocked recording starts until AI transcription setup is usable, defaulted fresh installs to English transcription hints, and added transcript quality warnings for wrong-script output.
+- [INTERNAL] Split AI setup, transcription defaults, and issue extraction settings into an encapsulated SwiftUI section with UI coverage.
 - [INTERNAL] Added a repository docs audit to keep maintainer docs aligned with the local-first validation path and CI unit-test scope.
 - [INTERNAL] Added a cheap Windows tester release preflight so missing signing secrets fail before reserving a Windows runner.
 - [INTERNAL] Moved Swift/project change detection ahead of the self-hosted macOS CI job so config-only PRs no longer reserve macOS runner slots.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -678,6 +678,20 @@ final class AppState: ObservableObject {
     func startSession() async {
         recordingLogger.info(.sessionStartRequested, "A feedback session start was requested.")
 
+        if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
+            let appError = AppError.transcriptionFailure(compatibilityIssue)
+            errorPresenter.setStatus(.error(compatibilityIssue), error: appError)
+            showSettingsWindow?()
+            return
+        }
+
+        guard settingsStore.hasUsableAIProviderCredential else {
+            let appError = AppError.missingAPIKey
+            errorPresenter.setStatus(.error(appError.userMessage(for: settingsStore.aiProvider)), error: appError)
+            showSettingsWindow?()
+            return
+        }
+
         let outcome = await recordingSessionController.startSession(
             statusPhase: status.phase,
             activityReason: recordingStatusMessages.recordingActivityReason()

--- a/Sources/BugNarrator/Models/TranscriptQualityFinding.swift
+++ b/Sources/BugNarrator/Models/TranscriptQualityFinding.swift
@@ -8,6 +8,7 @@ struct TranscriptQualityFinding: Codable, Equatable, Identifiable, Sendable {
 
     enum Kind: String, Codable, Sendable {
         case repeatedText
+        case unexpectedLanguageScript
         case abruptEnding
         case shortTranscript
     }

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -133,6 +133,7 @@ final class SettingsStore: ObservableObject {
     ]
 
     private static let openAITranscriptionModel = "whisper-1"
+    private static let defaultLanguageHint = "en"
     private static let parakeetTranscriptionModel = "parakeet-tdt-0.6b-v3"
     private static let openAIIssueExtractionModel = "gpt-4.1-mini"
     private static let openAITranscriptionModelChoices = [
@@ -1116,7 +1117,7 @@ final class SettingsStore: ObservableObject {
         preferredModel = stringValue(forKey: Keys.preferredModel) ?? "whisper-1"
         aiProvider = AIProvider(rawValue: stringValue(forKey: Keys.aiProvider) ?? "") ?? .openAI
         openAIBaseURL = stringValue(forKey: Keys.openAIBaseURL) ?? ""
-        languageHint = stringValue(forKey: Keys.languageHint) ?? ""
+        languageHint = stringValue(forKey: Keys.languageHint) ?? Self.defaultLanguageHint
         transcriptionPrompt = stringValue(forKey: Keys.transcriptionPrompt) ?? ""
         issueExtractionModel = stringValue(
             forKey: Keys.issueExtractionModel,

--- a/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
+++ b/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
@@ -5,6 +5,8 @@ struct TranscriptQualityInspector {
         static let minimumUsefulCharacterCount = 12
         static let repeatedPhraseMinimumWords = 4
         static let repeatedPhraseMinimumCount = 6
+        static let unexpectedScriptMinimumScalars = 4
+        static let unexpectedScriptMinimumRatio = 0.04
         static let abruptEndingMinimumWords = 25
     }
 
@@ -44,6 +46,16 @@ struct TranscriptQualityInspector {
             )
         }
 
+        if containsUnexpectedCJKScript(normalized) {
+            findings.append(
+                TranscriptQualityFinding(
+                    kind: .unexpectedLanguageScript,
+                    severity: .warning,
+                    message: "The transcript contains CJK characters. If this was English narration, keep the language hint set to en and retry transcription before relying on it."
+                )
+            )
+        }
+
         if appearsAbruptlyCutOff(normalized) {
             findings.append(
                 TranscriptQualityFinding(
@@ -78,6 +90,38 @@ struct TranscriptQualityInspector {
         }
 
         return nil
+    }
+
+    private func containsUnexpectedCJKScript(_ transcript: String) -> Bool {
+        var cjkScalarCount = 0
+        var letterScalarCount = 0
+
+        for scalar in transcript.unicodeScalars {
+            guard CharacterSet.letters.contains(scalar) else {
+                continue
+            }
+
+            letterScalarCount += 1
+            if Self.isCJKScalar(scalar) {
+                cjkScalarCount += 1
+            }
+        }
+
+        guard cjkScalarCount >= Defaults.unexpectedScriptMinimumScalars,
+              letterScalarCount > 0 else {
+            return false
+        }
+
+        return Double(cjkScalarCount) / Double(letterScalarCount) >= Defaults.unexpectedScriptMinimumRatio
+    }
+
+    private static func isCJKScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+            return true
+        default:
+            return false
+        }
     }
 
     private func appearsAbruptlyCutOff(_ transcript: String) -> Bool {

--- a/Sources/BugNarrator/Views/AISetupSectionsView.swift
+++ b/Sources/BugNarrator/Views/AISetupSectionsView.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+
+struct AISetupSectionsView: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var settingsStore: SettingsStore
+    let secureControlsDisabled: Bool
+
+    var body: some View {
+        GroupBox("AI Provider Setup") {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionIntro(settingsStore.aiProvider.setupDescription)
+
+                labeledField(title: "AI Provider") {
+                    Picker("AI provider", selection: $settingsStore.aiProvider) {
+                        ForEach(AIProvider.allCases) { provider in
+                            Text(provider.displayName)
+                                .tag(provider)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .accessibilityLabel("AI provider")
+                }
+
+                if settingsStore.aiProvider.credentialFieldTitle.isEmpty {
+                    labeledField(title: "Credential") {
+                        Text("No API key required")
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .accessibilityLabel("No AI provider credential required")
+                    }
+                } else {
+                    labeledField(title: settingsStore.aiProvider.credentialFieldTitle) {
+                        CredentialTokenField(
+                            placeholder: "sk-...",
+                            text: apiKeyBinding,
+                            isDisabled: secureControlsDisabled,
+                            accessibilityLabel: settingsStore.aiProvider.credentialFieldTitle
+                        )
+                    }
+                }
+
+                labeledField(title: "API Base URL") {
+                    TextField(settingsStore.aiProvider.baseURLPlaceholder, text: $settingsStore.openAIBaseURL)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(secureControlsDisabled)
+                        .accessibilityLabel("AI provider base URL")
+                }
+
+                Text(settingsStore.aiProvider.baseURLHint)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 12) {
+                    Text(settingsStore.maskedSelectedAIProviderCredential)
+                        .font(.subheadline.monospaced())
+                        .foregroundStyle(settingsStore.hasSelectedAIProviderCredential ? .primary : .secondary)
+
+                    Spacer()
+
+                    Button(apiKeyActionTitle) {
+                        Task {
+                            await appState.validateAPIKey()
+                        }
+                    }
+                    .disabled(
+                        secureControlsDisabled ||
+                        (!settingsStore.hasSelectedAIProviderCredential &&
+                            settingsStore.aiProvider.requiresAPIKey &&
+                            settingsStore.selectedAIProviderCredentialPersistenceState != .keychainLocked) ||
+                        appState.apiKeyValidationState == .validating
+                    )
+
+                    Button("Remove Key", role: .destructive) {
+                        appState.removeAPIKey()
+                    }
+                    .disabled(secureControlsDisabled || !settingsStore.hasSelectedAIProviderCredential)
+                }
+
+                if let message = appState.apiKeyValidationState.message {
+                    Text(message)
+                        .font(.footnote)
+                        .foregroundStyle(appState.apiKeyValidationState.isFailure ? .red : .green)
+                }
+
+                if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
+                    Text(compatibilityIssue)
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                }
+
+                Text(settingsStore.selectedAIProviderCredentialStorageDescription)
+                    .font(.footnote)
+                    .foregroundStyle(
+                        settingsStore.selectedAIProviderCredentialPersistenceState == .sessionOnly ||
+                        settingsStore.selectedAIProviderCredentialPersistenceState == .keychainLocked ||
+                        settingsStore.selectedAIProviderCredentialPersistenceState == .pendingSave
+                            ? .orange
+                            : .secondary
+                    )
+
+                Text("BugNarrator stores the provider credential in your macOS Keychain when available and never bundles it with the app or source code.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("AI Provider Setup section")
+
+        GroupBox("Transcription Defaults") {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionIntro("Choose the default transcription model and language hints BugNarrator sends to the selected provider.")
+
+                labeledField(title: "Model") {
+                    modelSelection(
+                        choices: settingsStore.transcriptionModelChoices,
+                        selection: transcriptionModelSelection,
+                        customText: $settingsStore.preferredModel,
+                        placeholder: settingsStore.transcriptionModelPlaceholder,
+                        accessibilityLabel: "Transcription model"
+                    )
+                }
+
+                labeledField(title: "Language Hint") {
+                    TextField("For English narration, keep en", text: $settingsStore.languageHint)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel("Transcription language hint")
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Prompt")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    TextEditor(text: $settingsStore.transcriptionPrompt)
+                        .font(.body)
+                        .frame(height: 110)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(.quaternary, lineWidth: 1)
+                        )
+                        .accessibilityLabel("Transcription prompt")
+                }
+
+                Text("Fresh installs default the language hint to en to reduce wrong-language transcript hallucinations. Clear it only when recording non-English narration.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityIdentifier("Transcription Defaults section")
+
+        GroupBox("Issue Extraction") {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionIntro("Configure how BugNarrator turns finished transcripts into reviewable draft issues.")
+
+                labeledField(title: "Extraction Model") {
+                    if settingsStore.supportsIssueExtraction {
+                        modelSelection(
+                            choices: settingsStore.issueExtractionModelChoices,
+                            selection: issueExtractionModelSelection,
+                            customText: $settingsStore.issueExtractionModel,
+                            placeholder: settingsStore.issueExtractionModelPlaceholder,
+                            accessibilityLabel: "Issue extraction model"
+                        )
+                    } else {
+                        Text("Not available for Local (Parakeet)")
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .accessibilityLabel("Issue extraction model not available for Local Parakeet")
+                    }
+                }
+
+                Toggle("Run issue extraction automatically after transcription", isOn: autoExtractIssuesBinding)
+
+                Text(issueExtractionHelpText)
+                    .font(.footnote)
+                    .foregroundStyle(settingsStore.supportsIssueExtraction ? Color.secondary : Color.orange)
+            }
+        }
+        .accessibilityIdentifier("Issue Extraction section")
+    }
+
+    private var apiKeyBinding: Binding<String> {
+        Binding(
+            get: { settingsStore.apiKey },
+            set: { settingsStore.apiKey = $0 }
+        )
+    }
+
+    private var transcriptionModelSelection: Binding<String> {
+        Binding(
+            get: {
+                let model = settingsStore.preferredModelValue
+                let choices = settingsStore.transcriptionModelChoices
+                guard !choices.isEmpty else { return model }
+
+                return choices.contains(where: { $0.id == model })
+                    ? model
+                    : choices[0].id
+            },
+            set: { selectedModel in
+                settingsStore.preferredModel = selectedModel
+            }
+        )
+    }
+
+    private var issueExtractionModelSelection: Binding<String> {
+        Binding(
+            get: {
+                let model = settingsStore.issueExtractionModelValue
+                let choices = settingsStore.issueExtractionModelChoices
+                guard !choices.isEmpty else { return model }
+
+                return choices.contains(where: { $0.id == model })
+                    ? model
+                    : choices[0].id
+            },
+            set: { selectedModel in
+                settingsStore.issueExtractionModel = selectedModel
+            }
+        )
+    }
+
+    private var autoExtractIssuesBinding: Binding<Bool> {
+        Binding(
+            get: { settingsStore.autoExtractIssues },
+            set: { shouldAutoExtract in
+                guard settingsStore.supportsIssueExtraction || !shouldAutoExtract else { return }
+                settingsStore.autoExtractIssues = shouldAutoExtract
+            }
+        )
+    }
+
+    private var issueExtractionHelpText: String {
+        if settingsStore.supportsIssueExtraction {
+            return "Issue extraction creates draft bugs, UX issues, enhancements, and follow-ups from the transcript. Review the results before exporting them."
+        }
+
+        return "Local Parakeet handles transcription only. Choose OpenAI or a compatible provider when you want automatic issue extraction."
+    }
+
+    private var apiKeyActionTitle: String {
+        if appState.apiKeyValidationState == .validating {
+            return "Validating..."
+        }
+
+        return settingsStore.selectedAIProviderCredentialPersistenceState == .keychainLocked &&
+            !settingsStore.hasSelectedAIProviderCredential
+            ? "Unlock Credential"
+            : (
+                settingsStore.selectedAIProviderCredentialPersistenceState == .pendingSave
+                    ? "Save & \(settingsStore.aiProvider.validationActionTitle)"
+                    : settingsStore.aiProvider.validationActionTitle
+            )
+    }
+
+    @ViewBuilder
+    private func modelSelection(
+        choices: [AIModelChoice],
+        selection: Binding<String>,
+        customText: Binding<String>,
+        placeholder: String,
+        accessibilityLabel: String
+    ) -> some View {
+        if choices.isEmpty {
+            TextField(placeholder, text: customText)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel(accessibilityLabel)
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                Picker(accessibilityLabel, selection: selection) {
+                    ForEach(choices) { choice in
+                        Text("\(choice.title) (\(choice.id))")
+                            .tag(choice.id)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityIdentifier(accessibilityLabel)
+
+                if let selectedChoice = choices.first(where: { $0.id == selection.wrappedValue }) {
+                    Text("\(selectedChoice.id) - \(selectedChoice.detail)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func labeledField<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack(alignment: .top) {
+            Text(title)
+                .frame(width: 170, alignment: .leading)
+            content()
+        }
+    }
+
+    private func sectionIntro(_ text: String) -> some View {
+        Text(text)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+    }
+}

--- a/Sources/BugNarrator/Views/RecordingControlPanelView.swift
+++ b/Sources/BugNarrator/Views/RecordingControlPanelView.swift
@@ -162,6 +162,14 @@ struct RecordingControlPanelView: View {
     }
 
     private var footerMessage: String {
+        if appState.status.phase != .recording && appState.needsAPIKeySetup {
+            let provider = appState.settingsStore.aiProvider
+            if provider.requiresAPIKey {
+                return "Add and validate your \(provider.displayName) API key before recording so the session can be transcribed."
+            }
+            return "Finish \(provider.displayName) setup before recording so the session can be transcribed."
+        }
+
         if appState.status.phase == .recording && appState.needsAPIKeySetup {
             let provider = appState.settingsStore.aiProvider
             if provider.requiresAPIKey {
@@ -176,7 +184,7 @@ struct RecordingControlPanelView: View {
     private var canStartSession: Bool {
         switch appState.status.phase {
         case .idle, .success, .error:
-            return true
+            return !appState.needsAPIKeySetup
         case .recording, .transcribing:
             return false
         }

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -34,103 +34,11 @@ struct SettingsView: View {
                     }
                 }
 
-                GroupBox("AI Provider Setup") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro(settingsStore.aiProvider.setupDescription)
-
-                        labeledField(title: "AI Provider") {
-                            Picker("AI provider", selection: $settingsStore.aiProvider) {
-                                ForEach(AIProvider.allCases) { provider in
-                                    Text(provider.displayName)
-                                        .tag(provider)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .accessibilityLabel("AI provider")
-                        }
-
-                        if settingsStore.aiProvider.credentialFieldTitle.isEmpty {
-                            labeledField(title: "Credential") {
-                                Text("No API key required")
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .accessibilityLabel("No AI provider credential required")
-                            }
-                        } else {
-                            labeledField(title: settingsStore.aiProvider.credentialFieldTitle) {
-                                CredentialTokenField(
-                                    placeholder: "sk-...",
-                                    text: apiKeyBinding,
-                                    isDisabled: secureControlsDisabled,
-                                    accessibilityLabel: settingsStore.aiProvider.credentialFieldTitle
-                                )
-                            }
-                        }
-
-                        labeledField(title: "API Base URL") {
-                            TextField(settingsStore.aiProvider.baseURLPlaceholder, text: $settingsStore.openAIBaseURL)
-                                .textFieldStyle(.roundedBorder)
-                                .disabled(secureControlsDisabled)
-                                .accessibilityLabel("AI provider base URL")
-                        }
-
-                        Text(settingsStore.aiProvider.baseURLHint)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        HStack(spacing: 12) {
-                            Text(settingsStore.maskedSelectedAIProviderCredential)
-                                .font(.subheadline.monospaced())
-                                .foregroundStyle(settingsStore.hasSelectedAIProviderCredential ? .primary : .secondary)
-
-                            Spacer()
-
-                            Button(apiKeyActionTitle) {
-                                Task {
-                                    await appState.validateAPIKey()
-                                }
-                            }
-                            .disabled(
-                                secureControlsDisabled ||
-                                (!settingsStore.hasSelectedAIProviderCredential &&
-                                    settingsStore.aiProvider.requiresAPIKey &&
-                                    settingsStore.selectedAIProviderCredentialPersistenceState != .keychainLocked) ||
-                                appState.apiKeyValidationState == .validating
-                            )
-
-                            Button("Remove Key", role: .destructive) {
-                                appState.removeAPIKey()
-                            }
-                            .disabled(secureControlsDisabled || !settingsStore.hasSelectedAIProviderCredential)
-                        }
-
-                        if let message = appState.apiKeyValidationState.message {
-                            Text(message)
-                                .font(.footnote)
-                                .foregroundStyle(appState.apiKeyValidationState.isFailure ? .red : .green)
-                        }
-
-                        if let compatibilityIssue = settingsStore.aiProviderCompatibilityIssue {
-                            Text(compatibilityIssue)
-                                .font(.footnote)
-                                .foregroundStyle(.orange)
-                        }
-
-                        Text(settingsStore.selectedAIProviderCredentialStorageDescription)
-                            .font(.footnote)
-                            .foregroundStyle(
-                                settingsStore.selectedAIProviderCredentialPersistenceState == .sessionOnly ||
-                                settingsStore.selectedAIProviderCredentialPersistenceState == .keychainLocked ||
-                                settingsStore.selectedAIProviderCredentialPersistenceState == .pendingSave
-                                    ? .orange
-                                    : .secondary
-                            )
-
-                        Text("BugNarrator stores the provider credential in your macOS Keychain when available and never bundles it with the app or source code.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                AISetupSectionsView(
+                    appState: appState,
+                    settingsStore: settingsStore,
+                    secureControlsDisabled: secureControlsDisabled
+                )
 
                 GroupBox("Recording Audio") {
                     VStack(alignment: .leading, spacing: 12) {
@@ -171,75 +79,6 @@ struct SettingsView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
-                    }
-                }
-
-                GroupBox("Transcription Defaults") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Choose the default transcription model and optional hints BugNarrator sends to the selected provider.")
-
-                        labeledField(title: "Model") {
-                            modelSelection(
-                                choices: settingsStore.transcriptionModelChoices,
-                                selection: transcriptionModelSelection,
-                                customText: $settingsStore.preferredModel,
-                                placeholder: settingsStore.transcriptionModelPlaceholder,
-                                accessibilityLabel: "Transcription model"
-                            )
-                        }
-
-                        labeledField(title: "Language Hint") {
-                            TextField("Optional, for example en", text: $settingsStore.languageHint)
-                                .textFieldStyle(.roundedBorder)
-                                .accessibilityLabel("Transcription language hint")
-                        }
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("Prompt")
-                                .frame(maxWidth: .infinity, alignment: .leading)
-
-                            TextEditor(text: $settingsStore.transcriptionPrompt)
-                                .font(.body)
-                                .frame(height: 110)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                        .stroke(.quaternary, lineWidth: 1)
-                                )
-                                .accessibilityLabel("Transcription prompt")
-                        }
-
-                        Text("Transcription uses the selected provider endpoint. Keep prompt guidance short and use the language hint only when it improves recognition.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                GroupBox("Issue Extraction") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Configure how BugNarrator turns finished transcripts into reviewable draft issues.")
-
-                        labeledField(title: "Extraction Model") {
-                            if settingsStore.supportsIssueExtraction {
-                                modelSelection(
-                                    choices: settingsStore.issueExtractionModelChoices,
-                                    selection: issueExtractionModelSelection,
-                                    customText: $settingsStore.issueExtractionModel,
-                                    placeholder: settingsStore.issueExtractionModelPlaceholder,
-                                    accessibilityLabel: "Issue extraction model"
-                                )
-                            } else {
-                                Text("Not available for Local (Parakeet)")
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .accessibilityLabel("Issue extraction model not available for Local Parakeet")
-                            }
-                        }
-
-                        Toggle("Run issue extraction automatically after transcription", isOn: autoExtractIssuesBinding)
-
-                        Text(issueExtractionHelpText)
-                            .font(.footnote)
-                            .foregroundStyle(settingsStore.supportsIssueExtraction ? Color.secondary : Color.orange)
                     }
                 }
 
@@ -734,65 +573,6 @@ struct SettingsView: View {
         appState.status.phase == .recording || appState.status.phase == .transcribing
     }
 
-    private var apiKeyBinding: Binding<String> {
-        Binding(
-            get: { settingsStore.apiKey },
-            set: { settingsStore.apiKey = $0 }
-        )
-    }
-
-    private var transcriptionModelSelection: Binding<String> {
-        Binding(
-            get: {
-                let model = settingsStore.preferredModelValue
-                let choices = settingsStore.transcriptionModelChoices
-                guard !choices.isEmpty else { return model }
-
-                return choices.contains(where: { $0.id == model })
-                    ? model
-                    : choices[0].id
-            },
-            set: { selectedModel in
-                settingsStore.preferredModel = selectedModel
-            }
-        )
-    }
-
-    private var issueExtractionModelSelection: Binding<String> {
-        Binding(
-            get: {
-                let model = settingsStore.issueExtractionModelValue
-                let choices = settingsStore.issueExtractionModelChoices
-                guard !choices.isEmpty else { return model }
-
-                return choices.contains(where: { $0.id == model })
-                    ? model
-                    : choices[0].id
-            },
-            set: { selectedModel in
-                settingsStore.issueExtractionModel = selectedModel
-            }
-        )
-    }
-
-    private var autoExtractIssuesBinding: Binding<Bool> {
-        Binding(
-            get: { settingsStore.autoExtractIssues },
-            set: { shouldAutoExtract in
-                guard settingsStore.supportsIssueExtraction || !shouldAutoExtract else { return }
-                settingsStore.autoExtractIssues = shouldAutoExtract
-            }
-        )
-    }
-
-    private var issueExtractionHelpText: String {
-        if settingsStore.supportsIssueExtraction {
-            return "Issue extraction creates draft bugs, UX issues, enhancements, and follow-ups from the transcript. Review the results before exporting them."
-        }
-
-        return "Local Parakeet handles transcription only. Choose OpenAI or a compatible provider when you want automatic issue extraction."
-    }
-
     private var availableRecordingAudioSources: [RecordingAudioSource] {
         settingsStore.systemAudioCaptureEnabled
             ? RecordingAudioSource.allCases
@@ -877,21 +657,6 @@ struct SettingsView: View {
         }
 
         return settingsStore.jiraProjectDiscoveryIsReady ? .ready : .needsSetup
-    }
-
-    private var apiKeyActionTitle: String {
-        if appState.apiKeyValidationState == .validating {
-            return "Validating..."
-        }
-
-        return settingsStore.selectedAIProviderCredentialPersistenceState == .keychainLocked &&
-            !settingsStore.hasSelectedAIProviderCredential
-            ? "Unlock Credential"
-            : (
-                settingsStore.selectedAIProviderCredentialPersistenceState == .pendingSave
-                    ? "Save & \(settingsStore.aiProvider.validationActionTitle)"
-                    : settingsStore.aiProvider.validationActionTitle
-            )
     }
 
     private var gitHubValidationActionTitle: String {
@@ -1020,40 +785,6 @@ struct SettingsView: View {
             HotkeyRecorderView(actionTitle: action.title, shortcut: shortcut)
         }
         .accessibilityElement(children: .contain)
-    }
-
-    @ViewBuilder
-    private func modelSelection(
-        choices: [AIModelChoice],
-        selection: Binding<String>,
-        customText: Binding<String>,
-        placeholder: String,
-        accessibilityLabel: String
-    ) -> some View {
-        if choices.isEmpty {
-            TextField(placeholder, text: customText)
-                .textFieldStyle(.roundedBorder)
-                .accessibilityLabel(accessibilityLabel)
-        } else {
-            VStack(alignment: .leading, spacing: 4) {
-                Picker(accessibilityLabel, selection: selection) {
-                    ForEach(choices) { choice in
-                        Text("\(choice.title) (\(choice.id))")
-                            .tag(choice.id)
-                    }
-                }
-                .pickerStyle(.menu)
-                .labelsHidden()
-                .accessibilityLabel(accessibilityLabel)
-                .accessibilityIdentifier(accessibilityLabel)
-
-                if let selectedChoice = choices.first(where: { $0.id == selection.wrappedValue }) {
-                    Text("\(selectedChoice.id) - \(selectedChoice.detail)")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
     }
 
     @ViewBuilder

--- a/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
+++ b/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
@@ -85,6 +85,8 @@ struct TranscriptQualityFindingsView: View {
         switch finding.kind {
         case .repeatedText:
             return "repeat"
+        case .unexpectedLanguageScript:
+            return "globe.asia.australia"
         case .abruptEnding:
             return "text.badge.exclamationmark"
         case .shortTranscript:

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -26,7 +26,7 @@ final class AppStateTests: XCTestCase {
     }
 
     func testRecordingControlsStartFlowShowsPanelAndStartsSession() async {
-        let harness = AppStateHarness(apiKey: "")
+        let harness = AppStateHarness()
         defer { harness.cleanup() }
 
         var didOpenRecordingControls = false
@@ -96,7 +96,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.exportHistory, [receipt])
     }
 
-    func testStartSessionWithoutAPIKeyStillStartsRecordingAndShowsTranscriptionGuidance() async {
+    func testStartSessionWithoutAPIKeyBlocksRecordingAndOpensSettings() async {
         let harness = AppStateHarness(apiKey: "")
         defer { harness.cleanup() }
 
@@ -107,13 +107,36 @@ final class AppStateTests: XCTestCase {
 
         await harness.appState.startSession()
 
-        XCTAssertEqual(harness.appState.status.phase, .recording)
+        XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertEqual(
             harness.appState.status.detail,
-            "Recording in progress. Finish the AI provider setup in Settings before stopping to transcribe this session."
+            "BugNarrator requires your own OpenAI API key for transcription and issue extraction. Add it in Settings, then retry transcription."
         )
-        XCTAssertEqual(harness.audioRecorder.startCallCount, 1)
-        XCTAssertFalse(didOpenSettings)
+        XCTAssertEqual(harness.appState.currentError, .missingAPIKey)
+        XCTAssertEqual(harness.audioRecorder.startCallCount, 0)
+        XCTAssertTrue(didOpenSettings)
+    }
+
+    func testStartSessionWithProviderCompatibilityIssueBlocksRecordingAndOpensSettings() async {
+        let harness = AppStateHarness()
+        defer { harness.cleanup() }
+
+        harness.settingsStore.aiProvider = .localCompatible
+        harness.settingsStore.preferredModel = "whisper-1"
+        var didOpenSettings = false
+        harness.appState.showSettingsWindow = {
+            didOpenSettings = true
+        }
+
+        await harness.appState.startSession()
+
+        XCTAssertEqual(harness.appState.status.phase, .error)
+        XCTAssertEqual(
+            harness.appState.status.detail,
+            "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider."
+        )
+        XCTAssertEqual(harness.audioRecorder.startCallCount, 0)
+        XCTAssertTrue(didOpenSettings)
     }
 
     func testAppStateRegistersDistinctRecordingHotkeys() {
@@ -708,9 +731,10 @@ final class AppStateTests: XCTestCase {
         let recordedAudio = try harness.makeRecordedAudio(fileName: "parakeet-setup-on-stop")
         harness.audioRecorder.stopResults = [.success(recordedAudio)]
         harness.settingsStore.aiProvider = .parakeetLocal
-        harness.settingsStore.autoExtractIssues = true
+        harness.settingsStore.autoExtractIssues = false
 
         await harness.appState.startSession()
+        harness.settingsStore.autoExtractIssues = true
         await harness.appState.stopSession()
 
         XCTAssertEqual(harness.appState.status.phase, .error)

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -23,9 +23,27 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.stopRecordingHotkeyShortcut, .disabled)
         XCTAssertEqual(store.screenshotHotkeyShortcut, .disabled)
         XCTAssertEqual(store.jiraIssueType, "")
+        XCTAssertEqual(store.languageHint, "en")
+        XCTAssertEqual(store.transcriptionRequest.languageHint, "en")
         XCTAssertFalse(store.systemAudioCaptureEnabled)
         XCTAssertEqual(store.recordingAudioSource, .microphone)
         XCTAssertFalse(store.hasAcceptedSystemAudioRecordingConsent)
+    }
+
+    func testClearedLanguageHintPersistsAsNoLanguageHint() {
+        let suiteName = "BugNarrator-SettingsClearedLanguageHintTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let firstStore = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        XCTAssertEqual(firstStore.languageHint, "en")
+        firstStore.languageHint = ""
+
+        let secondStore = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        XCTAssertEqual(secondStore.languageHint, "")
+        XCTAssertNil(secondStore.transcriptionRequest.languageHint)
     }
 
     func testSettingsPersistAcrossReloads() {

--- a/Tests/BugNarratorTests/TranscriptQualityFindingTests.swift
+++ b/Tests/BugNarratorTests/TranscriptQualityFindingTests.swift
@@ -14,9 +14,9 @@ final class TranscriptQualityFindingTests: XCTestCase {
 
     func testFindingCodableRoundTripPreservesSeverityAndKind() throws {
         let finding = TranscriptQualityFinding(
-            kind: .repeatedText,
+            kind: .unexpectedLanguageScript,
             severity: .error,
-            message: "Repeated transcript detected."
+            message: "Unexpected script detected."
         )
 
         let data = try JSONEncoder().encode(finding)

--- a/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
+++ b/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
@@ -11,6 +11,16 @@ final class TranscriptQualityInspectorTests: XCTestCase {
         XCTAssertEqual(findings.first?.severity, .warning)
     }
 
+    func testFindsUnexpectedCJKScriptForLikelyEnglishTranscript() {
+        let transcript = """
+        The tester opened the command center and clicked refresh. 然后系统显示错误。The expected setup panel did not appear.
+        """
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertTrue(findings.contains { $0.kind == .unexpectedLanguageScript })
+    }
+
     func testFindsAbruptEndingForLongTranscript() {
         let transcript = """
         This customer call covered setup reliability, settings validation, tracker exports, transcript review,

--- a/Tests/BugNarratorTests/TranscriptionClientTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionClientTests.swift
@@ -126,6 +126,33 @@ final class TranscriptionClientTests: XCTestCase {
         XCTAssertEqual(result.qualityFindings.map(\.kind), [.repeatedText])
     }
 
+    func testTranscribeSurfacesUnexpectedLanguageScriptFinding() async throws {
+        let fileURL = try makeAudioFile(named: "wrong-language-transcript", contents: "audio-data")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let transcript = "The tester clicked refresh and the setup view failed. 然后系统显示错误。"
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = try JSONSerialization.data(
+                withJSONObject: [
+                    "text": transcript,
+                    "segments": []
+                ]
+            )
+            return (response, data)
+        }
+
+        let client = TranscriptionClient(session: makeMockURLSession())
+        let result = try await client.transcribe(
+            fileURL: fileURL,
+            apiKey: "fixture-openai-key",
+            request: TranscriptionRequest(model: "whisper-1", languageHint: "en", prompt: nil)
+        )
+
+        XCTAssertEqual(result.text, transcript)
+        XCTAssertTrue(result.qualityFindings.contains { $0.kind == .unexpectedLanguageScript })
+    }
+
     func testTranscribeMapsAPIErrorResponse() async throws {
         let fileURL = try makeAudioFile(named: "api-error", contents: "audio-data")
         defer { try? FileManager.default.removeItem(at: fileURL) }

--- a/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
+++ b/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
@@ -78,6 +78,10 @@ final class BugNarratorSettingsUITests: XCTestCase {
         waitForSettingsLayout()
         XCTAssertTrue(settingsWindow.scrollViews.firstMatch.exists)
 
+        XCTAssertTrue(app.descendants(matching: .any)["AI Provider Setup section"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["Transcription Defaults section"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.descendants(matching: .any)["Issue Extraction section"].waitForExistence(timeout: 5))
+
         let openAIKeyField = app.textFields["OpenAI API Key"]
         XCTAssertTrue(waitForSettingsElement(openAIKeyField, in: settingsWindow))
         replaceText(in: openAIKeyField, with: "sk-ui-test")


### PR DESCRIPTION
## Summary
- Split AI provider setup, transcription defaults, and issue extraction controls into an encapsulated settings section with UI coverage.
- Block recording starts when the selected AI provider setup is missing or incompatible, and surface Settings immediately instead of creating retryable recordings that cannot transcribe.
- Default fresh installs to an English transcription language hint and flag repeated or unexpected CJK-script transcript output as quality warnings.

Closes #330

## Validation
- git diff --check
- ./scripts/validate.sh origin/main
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination 'platform=macOS' -only-testing:BugNarratorUITests/BugNarratorSettingsUITests/testSettingsDialogCoversControlsFieldsButtonsAndScrollContainer CODE_SIGNING_ALLOWED=NO test\n\nNote: local xcodebuild emits a CoreSimulator out-of-date warning on this Mac, but macOS unit and UI tests completed successfully.