### PR TITLE
Stabilize recording finalization and transcription retries

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		01CEE47A97CA8B7ED6B6E1B5 /* SessionLibraryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */; };
 		040E1F8A34C1C16904AB8370 /* DebugBundleExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */; };
 		05491334A5AA806307646EE5 /* ScreenshotCaptureServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */; };
+		BF32AD0E75C44346BDF33002 /* AudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF32AD0E75C44346BDF33001 /* AudioRecorderTests.swift */; };
 		05FAED3D483F3C16AEFFB7A5 /* TranscriptSectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */; };
 		0952565F78B2C3C544A8B4FC /* MenuBarStatusPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */; };
 		099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */; };
@@ -212,6 +213,7 @@
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
 		073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
+		BF32AD0E75C44346BDF33001 /* AudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderTests.swift; sourceTree = "<group>"; };
 		0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingControlPanelView.swift; sourceTree = "<group>"; };
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
@@ -413,6 +415,7 @@
 				C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */,
 				7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */,
 				F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */,
+				BF32AD0E75C44346BDF33001 /* AudioRecorderTests.swift */,
 				88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */,
 				F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */,
 				ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */,
@@ -789,6 +792,7 @@
 				31DE75541AFCD7104ED7F09E /* AppStatusTests.swift in Sources */,
 				E1B0000CAD83CD900AA29EAD /* AppSupportLocationTests.swift in Sources */,
 				567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */,
+				BF32AD0E75C44346BDF33002 /* AudioRecorderTests.swift in Sources */,
 				AD2549206170CE4F862AD61B /* ApplicationTerminationControllerTests.swift in Sources */,
 				1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */,
 				5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */,

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -721,7 +721,7 @@ final class AppState: ObservableObject {
                     from: recordingSession,
                     recordedAudio: recordedAudio,
                     request: request,
-                    failureReason: .missingAPIKey
+                    failureReason: .providerSetup
                 )
                 return
             }
@@ -978,7 +978,7 @@ final class AppState: ObservableObject {
 
         do {
             guard settingsStore.aiProviderCompatibilityIssue == nil else {
-                throw AppError.missingAPIKey
+                throw AppError.transcriptionFailure("Finish the AI provider setup in Settings, then retry transcription from this session.")
             }
 
             guard let apiKey = settingsStore.aiProviderCredentialForUserInitiatedAccess() else {

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -4,6 +4,12 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
     case missingAPIKey
     case invalidAPIKey
     case revokedAPIKey
+    case networkTimeout
+    case networkFailure
+    case rateLimited
+    case providerRejected
+    case transcriptionFailure
+    case emptyTranscript
     case crashRecovery
 
     init?(appError: AppError) {
@@ -14,6 +20,16 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
             self = .invalidAPIKey
         case .revokedAPIKey:
             self = .revokedAPIKey
+        case .networkTimeout:
+            self = .networkTimeout
+        case .networkFailure:
+            self = .networkFailure
+        case .rateLimited:
+            self = .rateLimited
+        case .openAIRequestRejected:
+            self = .providerRejected
+        case .emptyTranscript:
+            self = .emptyTranscript
         default:
             return nil
         }
@@ -36,6 +52,18 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
                 return "Recording saved locally. Add a new \(provider.displayName) API key in Settings, then retry transcription from this session."
             }
             return "Recording saved locally. Open Settings, refresh the \(provider.displayName) configuration, then retry transcription from this session."
+        case .networkTimeout:
+            return "Recording saved locally. The \(provider.displayName) request timed out, so retry transcription from this session when the connection is stable."
+        case .networkFailure:
+            return "Recording saved locally. BugNarrator could not reach \(provider.displayName), so retry transcription from this session when the connection is available."
+        case .rateLimited:
+            return "Recording saved locally. \(provider.displayName) rate limited the request, so wait a moment and retry transcription from this session."
+        case .providerRejected:
+            return "Recording saved locally. \(provider.displayName) rejected the transcription request, so review settings or retry from this session."
+        case .transcriptionFailure:
+            return "Recording saved locally. Transcription failed, so retry transcription from this session."
+        case .emptyTranscript:
+            return "Recording saved locally. Transcription returned empty text, so retry transcription from this session."
         case .crashRecovery:
             return "This older unexpected-quit recovery item is no longer supported. Delete it and start a new recording."
         }
@@ -53,6 +81,18 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
             return .invalidAPIKey
         case .revokedAPIKey:
             return .revokedAPIKey
+        case .networkTimeout:
+            return .networkTimeout
+        case .networkFailure:
+            return .networkFailure
+        case .rateLimited:
+            return .rateLimited(retryAfter: nil)
+        case .providerRejected:
+            return .openAIRequestRejected("The preserved recording is waiting for transcription retry.")
+        case .transcriptionFailure:
+            return .transcriptionFailure("The preserved recording is waiting for transcription retry.")
+        case .emptyTranscript:
+            return .emptyTranscript
         case .crashRecovery:
             return .transcriptionFailure("Unexpected-quit recording recovery is no longer supported.")
         }

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum PendingTranscriptionFailureReason: String, Codable, Equatable {
     case missingAPIKey
+    case providerSetup
     case invalidAPIKey
     case revokedAPIKey
     case networkTimeout
@@ -35,13 +36,15 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
         }
     }
 
-    func recoveryMessage(for provider: AIProvider) -> String {
+    func retryMessage(for provider: AIProvider) -> String {
         switch self {
         case .missingAPIKey:
             if provider.requiresAPIKey {
                 return "Recording saved locally. Add your \(provider.displayName) API key in Settings, then retry transcription from this session."
             }
             return "Recording saved locally. Open Settings, confirm the \(provider.displayName) server setup, then retry transcription from this session."
+        case .providerSetup:
+            return "Recording saved locally. Finish the \(provider.displayName) setup in Settings, then retry transcription from this session."
         case .invalidAPIKey:
             if provider.requiresAPIKey {
                 return "Recording saved locally. Replace the rejected \(provider.displayName) API key in Settings, then retry transcription from this session."
@@ -69,14 +72,20 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
         }
     }
 
+    func recoveryMessage(for provider: AIProvider) -> String {
+        retryMessage(for: provider)
+    }
+
     var recoveryMessage: String {
-        recoveryMessage(for: .openAI)
+        retryMessage(for: .openAI)
     }
 
     var appError: AppError {
         switch self {
         case .missingAPIKey:
             return .missingAPIKey
+        case .providerSetup:
+            return .transcriptionFailure("The preserved recording is waiting for AI provider setup.")
         case .invalidAPIKey:
             return .invalidAPIKey
         case .revokedAPIKey:
@@ -258,7 +267,7 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
 
     func preview(for provider: AIProvider) -> String {
         if let pendingTranscription {
-            return pendingTranscription.failureReason.recoveryMessage(for: provider)
+            return pendingTranscription.failureReason.retryMessage(for: provider)
         }
 
         return Self.previewText(from: transcript)
@@ -298,11 +307,19 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
     }
 
     func transcriptionRecoveryMessage(for provider: AIProvider) -> String? {
-        pendingTranscription?.failureReason.recoveryMessage(for: provider)
+        transcriptionRetryMessage(for: provider)
     }
 
     var transcriptionRecoveryMessage: String? {
-        transcriptionRecoveryMessage(for: .openAI)
+        transcriptionRetryMessage
+    }
+
+    func transcriptionRetryMessage(for provider: AIProvider) -> String? {
+        pendingTranscription?.failureReason.retryMessage(for: provider)
+    }
+
+    var transcriptionRetryMessage: String? {
+        transcriptionRetryMessage(for: .openAI)
     }
 
     var summaryText: String {
@@ -373,9 +390,9 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
             lines.append("Prompt: \(prompt)")
         }
 
-        if let transcriptionRecoveryMessage {
+        if let transcriptionRetryMessage {
             lines.append("Transcription Status: Pending retry")
-            lines.append("Recovery: \(transcriptionRecoveryMessage)")
+            lines.append("Retry: \(transcriptionRetryMessage)")
         }
 
         if !markers.isEmpty {
@@ -435,9 +452,9 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
             lines.append("- Prompt: \(prompt)")
         }
 
-        if let transcriptionRecoveryMessage {
+        if let transcriptionRetryMessage {
             lines.append("- Transcription Status: Pending retry")
-            lines.append("- Recovery: \(transcriptionRecoveryMessage)")
+            lines.append("- Retry: \(transcriptionRetryMessage)")
         }
 
         lines.append("")

--- a/Sources/BugNarrator/Services/ApplicationTerminationController.swift
+++ b/Sources/BugNarrator/Services/ApplicationTerminationController.swift
@@ -59,19 +59,32 @@ final class ApplicationTerminationController {
     }
 
     func applicationShouldTerminate() -> NSApplication.TerminateReply {
-        guard statusPhase() == .recording,
-              let activeRecordingSession = activeRecordingSession() else {
+        let phase = statusPhase()
+        guard let activeRecordingSession = activeRecordingSession(),
+              phase == .recording || phase == .transcribing else {
             return .terminateNow
         }
 
+        let isTranscribing = phase == .transcribing
         recordingLogger.warning(
-            "termination_blocked_while_recording",
-            "BugNarrator blocked an app termination request while a recording session was still active.",
+            isTranscribing ? "termination_blocked_while_transcribing" : "termination_blocked_while_recording",
+            isTranscribing
+                ? "BugNarrator blocked an app termination request while a stopped recording was still being transcribed."
+                : "BugNarrator blocked an app termination request while a recording session was still active.",
             metadata: ["session_id": activeRecordingSession.sessionID.uuidString]
         )
-        cancelPendingScreenshotSelection("Quit was requested while recording, so pending screenshot selection was cancelled.")
+        cancelPendingScreenshotSelection(
+            isTranscribing
+                ? "Quit was requested while transcription was finishing, so pending screenshot selection was cancelled."
+                : "Quit was requested while recording, so pending screenshot selection was cancelled."
+        )
         showRecordingControls()
-        showToast("Stop recording before quitting BugNarrator.", .informational)
+        showToast(
+            isTranscribing
+                ? "Wait for transcription to finish saving before quitting BugNarrator."
+                : "Stop recording before quitting BugNarrator.",
+            .informational
+        )
         return .terminateCancel
     }
 

--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -12,6 +12,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let permissionAccess: any MicrophonePermissionAccessing
     private let recoveryDirectoryURL: URL
+    private let finalizationTimeoutNanoseconds: UInt64
 
     private var recorder: AVAudioRecorder?
     private var currentFileURL: URL?
@@ -19,22 +20,27 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     private var cancelContinuation: CheckedContinuation<Void, Never>?
     private var pendingStopResult: RecordedAudio?
     private var isCancelling = false
+    private var finalizationTimeoutTask: Task<Void, Never>?
 
     init(
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
-            .appendingPathComponent("RecoveredRecordings", isDirectory: true)
+            .appendingPathComponent("RecoveredRecordings", isDirectory: true),
+        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000
     ) {
         self.permissionAccess = SystemMicrophonePermissionAccess()
         self.recoveryDirectoryURL = recoveryDirectoryURL
+        self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
     }
 
     init(
         permissionAccess: any MicrophonePermissionAccessing,
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
-            .appendingPathComponent("RecoveredRecordings", isDirectory: true)
+            .appendingPathComponent("RecoveredRecordings", isDirectory: true),
+        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000
     ) {
         self.permissionAccess = permissionAccess
         self.recoveryDirectoryURL = recoveryDirectoryURL
+        self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
     }
 
     var currentDuration: TimeInterval {
@@ -171,6 +177,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         return try await withCheckedThrowingContinuation { continuation in
             stopContinuation = continuation
             pendingStopResult = RecordedAudio(fileURL: currentFileURL, duration: recorder.currentTime)
+            scheduleStopTimeout(fileName: currentFileURL.lastPathComponent)
             recorder.stop()
         }
     }
@@ -193,6 +200,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
 
         await withCheckedContinuation { continuation in
             cancelContinuation = continuation
+            scheduleCancelTimeout(fileName: currentFileURL.lastPathComponent)
             recorder.stop()
         }
 
@@ -265,6 +273,8 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     }
 
     private func cleanup() {
+        finalizationTimeoutTask?.cancel()
+        finalizationTimeoutTask = nil
         recorder?.delegate = nil
         recorder = nil
         currentFileURL = nil
@@ -272,6 +282,56 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         cancelContinuation = nil
         pendingStopResult = nil
         isCancelling = false
+    }
+
+    private func scheduleStopTimeout(fileName: String) {
+        finalizationTimeoutTask?.cancel()
+        finalizationTimeoutTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(nanoseconds: finalizationTimeoutNanoseconds)
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled, let stopContinuation else {
+                return
+            }
+
+            recordingLogger.error(
+                "recording_finalize_timeout",
+                "The recorded audio file did not finish finalizing before the timeout.",
+                metadata: ["file_name": fileName]
+            )
+            cleanup()
+            stopContinuation.resume(
+                throwing: AppError.recordingFailure("The recorded audio file did not finish finalizing before the timeout.")
+            )
+        }
+    }
+
+    private func scheduleCancelTimeout(fileName: String) {
+        finalizationTimeoutTask?.cancel()
+        finalizationTimeoutTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await Task.sleep(nanoseconds: finalizationTimeoutNanoseconds)
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled, let cancelContinuation else {
+                return
+            }
+
+            recordingLogger.warning(
+                "recording_cancel_timeout",
+                "Audio recording cancellation did not receive a final delegate callback before the timeout.",
+                metadata: ["file_name": fileName]
+            )
+            cleanup()
+            cancelContinuation.resume()
+        }
     }
 
     private func validateRecordedAudioFile(at url: URL) throws {

--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -347,6 +347,17 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         guard fileSize > 0 else {
             throw AppError.recordingFailure("The recorded audio file was empty.")
         }
+
+        do {
+            let audioFile = try AVAudioFile(forReading: url)
+            guard audioFile.fileFormat.sampleRate > 0, audioFile.length > 0 else {
+                throw AppError.recordingFailure("The recorded audio file did not contain playable audio.")
+            }
+        } catch let error as AppError {
+            throw error
+        } catch {
+            throw AppError.recordingFailure("The recorded audio file could not be read.")
+        }
     }
 
     private var permissionBlockedError: AppError? {

--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -8,13 +8,28 @@ struct RecordedAudio {
 }
 
 @MainActor
+protocol AudioRecorderEngine: AnyObject {
+    var delegate: (any AVAudioRecorderDelegate)? { get set }
+    var currentTime: TimeInterval { get }
+
+    func prepareToRecord() -> Bool
+    func record() -> Bool
+    func stop()
+}
+
+extension AVAudioRecorder: AudioRecorderEngine {}
+
+typealias AudioRecorderEngineFactory = (URL, [String: Any]) throws -> any AudioRecorderEngine
+
+@MainActor
 final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, AudioRecording {
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let permissionAccess: any MicrophonePermissionAccessing
     private let recoveryDirectoryURL: URL
     private let finalizationTimeoutNanoseconds: UInt64
+    private let makeRecorder: AudioRecorderEngineFactory
 
-    private var recorder: AVAudioRecorder?
+    private var recorder: (any AudioRecorderEngine)?
     private var currentFileURL: URL?
     private var stopContinuation: CheckedContinuation<RecordedAudio, Error>?
     private var cancelContinuation: CheckedContinuation<Void, Never>?
@@ -25,22 +40,30 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     init(
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
             .appendingPathComponent("RecoveredRecordings", isDirectory: true),
-        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000
+        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000,
+        makeRecorder: @escaping AudioRecorderEngineFactory = { url, settings in
+            try AVAudioRecorder(url: url, settings: settings)
+        }
     ) {
         self.permissionAccess = SystemMicrophonePermissionAccess()
         self.recoveryDirectoryURL = recoveryDirectoryURL
         self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
+        self.makeRecorder = makeRecorder
     }
 
     init(
         permissionAccess: any MicrophonePermissionAccessing,
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
             .appendingPathComponent("RecoveredRecordings", isDirectory: true),
-        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000
+        finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000,
+        makeRecorder: @escaping AudioRecorderEngineFactory = { url, settings in
+            try AVAudioRecorder(url: url, settings: settings)
+        }
     ) {
         self.permissionAccess = permissionAccess
         self.recoveryDirectoryURL = recoveryDirectoryURL
         self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
+        self.makeRecorder = makeRecorder
     }
 
     var currentDuration: TimeInterval {
@@ -57,7 +80,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
             .appendingPathExtension("m4a")
 
         do {
-            let recorder = try AVAudioRecorder(url: fileURL, settings: recordingSettings)
+            let recorder = try makeRecorder(fileURL, recordingSettings)
             let prepared = recorder.prepareToRecord()
             try? FileManager.default.removeItem(at: fileURL)
 
@@ -82,7 +105,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
             .appendingPathExtension("m4a")
 
         do {
-            let recorder = try AVAudioRecorder(url: fileURL, settings: recordingSettings)
+            let recorder = try makeRecorder(fileURL, recordingSettings)
             guard recorder.prepareToRecord() else {
                 return resolvedMicrophoneAccessError(
                     defaultMessage: "Check that an input device is connected and available, then try again."
@@ -127,7 +150,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
 
         do {
             try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
-            let recorder = try AVAudioRecorder(url: fileURL, settings: recordingSettings)
+            let recorder = try makeRecorder(fileURL, recordingSettings)
             recorder.delegate = self
             guard recorder.prepareToRecord() else {
                 throw resolvedMicrophoneAccessError(

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -9,6 +9,7 @@ final class MixedAudioRecorder: AudioRecording {
     private let outputDirectoryURL: URL
 
     private var isRecording = false
+    private var isStopping = false
 
     init(
         microphoneRecorder: any AudioRecording,
@@ -73,33 +74,19 @@ final class MixedAudioRecorder: AudioRecording {
     }
 
     func stopRecording() async throws -> RecordedAudio {
-        guard isRecording else {
+        guard isRecording, !isStopping else {
             throw AppError.recordingFailure("There is no active recording.")
         }
 
-        isRecording = false
-
-        var systemResult: Result<RecordedAudio, Error>?
-        var microphoneResult: Result<RecordedAudio, Error>?
-
-        do {
-            systemResult = .success(try await systemAudioRecorder.stopRecording())
-        } catch {
-            systemResult = .failure(error)
+        isStopping = true
+        defer {
+            isStopping = false
+            isRecording = false
         }
 
-        do {
-            microphoneResult = .success(try await microphoneRecorder.stopRecording())
-        } catch {
-            microphoneResult = .failure(error)
-        }
-
-        guard let systemResult else {
-            throw AppError.recordingFailure("System audio recording was unavailable.")
-        }
-        guard let microphoneResult else {
-            throw AppError.recordingFailure("Microphone recording was unavailable.")
-        }
+        async let systemStopResult = stopSystemAudioRecorder()
+        async let microphoneStopResult = stopMicrophoneRecorder()
+        let (systemResult, microphoneResult) = await (systemStopResult, microphoneStopResult)
 
         switch (systemResult, microphoneResult) {
         case (.failure, .success(let microphoneAudio)):
@@ -136,6 +123,22 @@ final class MixedAudioRecorder: AudioRecording {
         return mixedAudio
     }
 
+    private func stopSystemAudioRecorder() async -> Result<RecordedAudio, Error> {
+        do {
+            return .success(try await systemAudioRecorder.stopRecording())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func stopMicrophoneRecorder() async -> Result<RecordedAudio, Error> {
+        do {
+            return .success(try await microphoneRecorder.stopRecording())
+        } catch {
+            return .failure(error)
+        }
+    }
+
     private func removeSourceAudioFiles(_ sourceURLs: [URL], preserving outputURL: URL) {
         let preservedURL = outputURL.standardizedFileURL
         for sourceURL in sourceURLs where sourceURL.standardizedFileURL != preservedURL {
@@ -144,7 +147,7 @@ final class MixedAudioRecorder: AudioRecording {
     }
 
     func cancelRecording(preserveFile: Bool) async {
-        guard isRecording else {
+        guard isRecording, !isStopping else {
             return
         }
 

--- a/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
@@ -19,8 +19,8 @@ final class RoutingAudioRecorder: AudioRecording {
         self.microphoneRecorder = microphoneRecorder
         self.systemAudioRecorder = systemAudioRecorder
         self.microphoneAndSystemAudioRecorder = microphoneAndSystemAudioRecorder ?? MixedAudioRecorder(
-            microphoneRecorder: AudioRecorder(),
-            systemAudioRecorder: SystemAudioRecorder()
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder
         )
     }
 

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -173,6 +173,17 @@ final class SystemAudioRecorder: AudioRecording {
         guard fileSize > 0 else {
             throw AppError.recordingFailure("The recorded system audio file was empty.")
         }
+
+        do {
+            let audioFile = try AVAudioFile(forReading: url)
+            guard audioFile.fileFormat.sampleRate > 0, audioFile.length > 0 else {
+                throw AppError.recordingFailure("The recorded system audio file did not contain playable audio.")
+            }
+        } catch let error as AppError {
+            throw error
+        } catch {
+            throw AppError.recordingFailure("The recorded system audio file could not be read.")
+        }
     }
 
     private func makeRecoverableRecordingURL() -> URL {

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -220,6 +220,13 @@ private final class SystemAudioTapSession {
             return audioFormat
         }
 
+        var preparedSuccessfully = false
+        defer {
+            if !preparedSuccessfully {
+                invalidate()
+            }
+        }
+
         let excludedProcesses = (try? Self.currentProcessObjectIDs()) ?? []
         let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: excludedProcesses)
         tapDescription.uuid = UUID()
@@ -271,6 +278,7 @@ private final class SystemAudioTapSession {
         }
 
         audioFormat = format
+        preparedSuccessfully = true
         return format
     }
 
@@ -278,6 +286,13 @@ private final class SystemAudioTapSession {
     func start(on queue: DispatchQueue, writer: SystemAudioFileWriter) throws {
         guard aggregateDeviceID != AudioObjectID(kAudioObjectUnknown) else {
             throw AppError.systemAudioUnavailable("The system audio device was not prepared.")
+        }
+
+        var startedSuccessfully = false
+        defer {
+            if !startedSuccessfully {
+                invalidate()
+            }
         }
 
         var status = AudioDeviceCreateIOProcIDWithBlock(
@@ -295,6 +310,7 @@ private final class SystemAudioTapSession {
         guard status == noErr else {
             throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio refused to start system audio capture with status \(status)."))
         }
+        startedSuccessfully = true
     }
 
     func invalidate() {

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -43,8 +43,13 @@ final class SystemAudioRecorder: AudioRecording {
 
         do {
             let probe = SystemAudioTapSession()
-            _ = try probe.prepare()
-            probe.invalidate()
+            do {
+                _ = try probe.prepare()
+                probe.invalidate()
+            } catch {
+                probe.invalidate()
+                throw error
+            }
             return nil
         } catch let error as AppError {
             return error
@@ -68,14 +73,17 @@ final class SystemAudioRecorder: AudioRecording {
             throw AppError.systemAudioUnavailable("System audio capture requires macOS 14.2 or later.")
         }
 
+        let session = SystemAudioTapSession()
+        var writer: SystemAudioFileWriter?
+
         do {
             try FileManager.default.createDirectory(at: recoveryDirectoryURL, withIntermediateDirectories: true)
-            let session = SystemAudioTapSession()
             let format = try session.prepare()
             let fileURL = makeRecoverableRecordingURL()
-            let writer = try SystemAudioFileWriter(fileURL: fileURL, format: format)
+            let preparedWriter = try SystemAudioFileWriter(fileURL: fileURL, format: format)
+            writer = preparedWriter
 
-            try session.start(on: ioQueue, writer: writer)
+            try session.start(on: ioQueue, writer: preparedWriter)
 
             tapSession = session
             activeWriter = writer
@@ -88,9 +96,13 @@ final class SystemAudioRecorder: AudioRecording {
                 metadata: ["file_name": fileURL.lastPathComponent]
             )
         } catch let error as AppError {
+            session.invalidate()
+            try? writer?.close()
             recordingLogger.error("system_audio_recording_start_failed", error.userMessage)
             throw error
         } catch {
+            session.invalidate()
+            try? writer?.close()
             recordingLogger.error("system_audio_recording_start_failed", error.localizedDescription)
             throw AppError.systemAudioUnavailable(systemAudioRecoveryMessage(details: error.localizedDescription))
         }
@@ -108,9 +120,9 @@ final class SystemAudioRecorder: AudioRecording {
             metadata: ["file_name": currentFileURL.lastPathComponent]
         )
 
-        activeWriter.close()
-        ioQueue.sync { }
         tapSession.invalidate()
+        ioQueue.sync { }
+        try activeWriter.close()
         cleanupActiveState()
 
         try validateRecordedAudioFile(at: currentFileURL)
@@ -129,9 +141,9 @@ final class SystemAudioRecorder: AudioRecording {
 
     func cancelRecording(preserveFile: Bool) async {
         let fileURL = currentFileURL
-        activeWriter?.close()
-        ioQueue.sync { }
         tapSession?.invalidate()
+        ioQueue.sync { }
+        try? activeWriter?.close()
         cleanupActiveState()
 
         guard !preserveFile, let fileURL else {
@@ -320,6 +332,7 @@ private final class SystemAudioFileWriter: @unchecked Sendable {
     private let lock = NSLock()
     private let format: AVAudioFormat
     private var file: AVAudioFile?
+    private var writeError: Error?
 
     init(fileURL: URL, format: AVAudioFormat) throws {
         self.format = format
@@ -342,13 +355,23 @@ private final class SystemAudioFileWriter: @unchecked Sendable {
             return
         }
 
-        try? file.write(from: buffer)
+        do {
+            try file.write(from: buffer)
+        } catch {
+            writeError = error
+        }
     }
 
-    func close() {
+    func close() throws {
         lock.lock()
+        let writeError = writeError
         file = nil
+        self.writeError = nil
         lock.unlock()
+
+        if let writeError {
+            throw AppError.recordingFailure("System audio could not be written. \(writeError.localizedDescription)")
+        }
     }
 }
 

--- a/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoveryController.swift
@@ -122,7 +122,7 @@ final class RetryableSessionPreservationPresenter {
         errorPresenter.logAppError(appError, context: "preserve_retryable_session", operation: .transcription)
         errorPresenter.setStatus(
             .error(
-                retryableSession.transcriptionRecoveryMessage(for: currentProvider)
+                retryableSession.transcriptionRetryMessage(for: currentProvider)
                     ?? appError.userMessage(for: currentProvider)
             ),
             error: appError
@@ -251,7 +251,7 @@ final class TranscriptionRecoveryController: ObservableObject {
             return .failure(
                 .transcriptionFailure(aiProviderCompatibilityIssue),
                 opensSettings: true,
-                statusMessage: aiProviderCompatibilityIssue
+                statusMessage: session.transcriptionRetryMessage(for: provider) ?? aiProviderCompatibilityIssue
             )
         }
 
@@ -259,7 +259,7 @@ final class TranscriptionRecoveryController: ObservableObject {
             return .failure(
                 .missingAPIKey,
                 opensSettings: true,
-                statusMessage: session.transcriptionRecoveryMessage(for: provider)
+                statusMessage: session.transcriptionRetryMessage(for: provider)
                     ?? AppError.missingAPIKey.userMessage(for: provider)
             )
         }
@@ -313,7 +313,7 @@ final class TranscriptionRecoveryController: ObservableObject {
         } catch {
             transcriptionLogger.error(
                 "transcription_retry_state_persist_failed",
-                "Retry attempt count could not be saved durably; recovery state is in memory only.",
+                "Retry attempt count could not be saved durably; pending transcription state is in memory only.",
                 metadata: [
                     "session_id": session.id.uuidString,
                     "failure_reason": failureReason.rawValue,
@@ -333,7 +333,7 @@ final class TranscriptionRecoveryController: ObservableObject {
             session: session,
             appError: failureReason.appError,
             statusMessage: (
-                session.transcriptionRecoveryMessage(for: provider)
+                session.transcriptionRetryMessage(for: provider)
                     ?? failureReason.appError.userMessage(for: provider)
             ) + attemptMessage
         )

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -213,7 +213,13 @@ actor DiagnosticsLogStore {
     }
 
     static func defaultStorageURL(fileManager: FileManager) -> URL {
-        AppSupportLocation.appDirectory(fileManager: fileManager)
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return fileManager.temporaryDirectory
+                .appendingPathComponent("BugNarratorTestDiagnostics", isDirectory: true)
+                .appendingPathComponent("recent-log-\(ProcessInfo.processInfo.processIdentifier).json")
+        }
+
+        return AppSupportLocation.appDirectory(fileManager: fileManager)
             .appendingPathComponent("Diagnostics", isDirectory: true)
             .appendingPathComponent("recent-log.json")
     }

--- a/Sources/BugNarrator/Utilities/ReviewWorkspace.swift
+++ b/Sources/BugNarrator/Utilities/ReviewWorkspace.swift
@@ -45,7 +45,7 @@ enum ReviewWorkspace {
                     timestamp: 0,
                     kind: .transcript,
                     title: "Transcription Pending",
-                    text: session.transcriptionRecoveryMessage(for: provider)
+                    text: session.transcriptionRetryMessage(for: provider)
                         ?? "Retry transcription after restoring the provider setup.",
                     secondaryText: "The finished audio was preserved with this session.",
                     index: nil,

--- a/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
+++ b/Sources/BugNarrator/Utilities/TranscriptionSessionBuilder.swift
@@ -9,7 +9,7 @@ enum PostTranscriptionPipelineMode: Equatable {
         case .finishedRecording:
             return "Saving the finished session locally..."
         case .retry:
-            return "Saving the recovered session locally..."
+            return "Saving the retried session locally..."
         }
     }
 

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -101,7 +101,7 @@ struct SettingsView: View {
                             .font(.footnote)
                             .foregroundStyle(.secondary)
 
-                        Text("Completed recordings are always saved to the local session library as soon as you stop. BugNarrator keeps the session even if the app quits before you review it.")
+                        Text("When transcription cannot finish after a recording stops, BugNarrator saves the recording locally as a pending session so you can retry transcription.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
 

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -696,7 +696,7 @@ struct TranscriptView: View {
             if session.requiresTranscriptionRetry {
                 HStack(alignment: .center, spacing: 10) {
                     Label(
-                        session.transcriptionRecoveryMessage(for: appState.settingsStore.aiProvider) ?? defaultRetryRecoveryMessage,
+                        session.transcriptionRetryMessage(for: appState.settingsStore.aiProvider) ?? defaultRetryRecoveryMessage,
                         systemImage: "arrow.clockwise.circle"
                     )
                     .font(.footnote)

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -741,10 +741,10 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertEqual(
             harness.appState.status.detail,
-            "Recording saved locally. Open Settings, confirm the Local (Parakeet) server setup, then retry transcription from this session."
+            "Recording saved locally. Finish the Local (Parakeet) setup in Settings, then retry transcription from this session."
         )
         XCTAssertTrue(harness.appState.needsAPIKeySetup)
-        XCTAssertEqual(harness.transcriptStore.sessions.first?.pendingTranscription?.failureReason, .missingAPIKey)
+        XCTAssertEqual(harness.transcriptStore.sessions.first?.pendingTranscription?.failureReason, .providerSetup)
     }
 
     func testStopSessionWithRejectedAPIKeyPreservesRetryableSession() async throws {

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -539,7 +539,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.status.detail, "Session saved. Transcript copied to the clipboard.")
     }
 
-    func testTranscriptionFailureTransitionsToErrorAndDeletesTemporaryAudioFile() async throws {
+    func testTransientTranscriptionFailurePreservesRetryableSession() async throws {
         let harness = AppStateHarness()
         defer { harness.cleanup() }
 
@@ -551,8 +551,9 @@ final class AppStateTests: XCTestCase {
         await harness.appState.stopSession()
 
         XCTAssertEqual(harness.appState.status.phase, .error)
-        XCTAssertEqual(harness.appState.status.detail, AppError.networkTimeout.userMessage)
-        XCTAssertEqual(harness.transcriptStore.sessions.count, 0)
+        let session = try XCTUnwrap(harness.transcriptStore.sessions.first)
+        XCTAssertEqual(session.pendingTranscription?.failureReason, .networkTimeout)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: try XCTUnwrap(session.pendingTranscriptionAudioURL).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
         XCTAssertNil(harness.appState.activeRecordingSession)
     }

--- a/Tests/BugNarratorTests/ApplicationTerminationControllerTests.swift
+++ b/Tests/BugNarratorTests/ApplicationTerminationControllerTests.swift
@@ -29,6 +29,20 @@ final class ApplicationTerminationControllerTests: XCTestCase {
         XCTAssertEqual(harness.toasts.map(\.style), [.informational])
     }
 
+    func testApplicationShouldTerminateCancelsQuitWhileTranscribing() {
+        let harness = ApplicationTerminationControllerHarness()
+        harness.statusPhase = .transcribing
+        harness.activeRecordingSession = harness.makeRecordingSession()
+
+        let reply = harness.controller.applicationShouldTerminate()
+
+        XCTAssertEqual(reply, .terminateCancel)
+        XCTAssertEqual(harness.cancelReasons, ["Quit was requested while transcription was finishing, so pending screenshot selection was cancelled."])
+        XCTAssertEqual(harness.recordingControlsShownCount, 1)
+        XCTAssertEqual(harness.toasts.map(\.message), ["Wait for transcription to finish saving before quitting BugNarrator."])
+        XCTAssertEqual(harness.toasts.map(\.style), [.informational])
+    }
+
     func testRequestApplicationTerminationInvokesInjectedTerminateOnlyWhenAllowed() {
         let allowedHarness = ApplicationTerminationControllerHarness()
 

--- a/Tests/BugNarratorTests/AudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/AudioRecorderTests.swift
@@ -1,0 +1,158 @@
+import AVFoundation
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class AudioRecorderTests: XCTestCase {
+    func testStopRecordingTimesOutWhenRecorderNeverFinalizes() async throws {
+        let harness = try AudioRecorderHarness(timeoutNanoseconds: 1_000_000)
+        defer { harness.cleanup() }
+
+        try await harness.recorder.startRecording()
+
+        do {
+            _ = try await harness.recorder.stopRecording()
+            XCTFail("Expected stop recording to time out.")
+        } catch {
+            XCTAssertEqual(
+                error as? AppError,
+                .recordingFailure("The recorded audio file did not finish finalizing before the timeout.")
+            )
+        }
+    }
+
+    func testCancelRecordingTimesOutWhenRecorderNeverFinalizes() async throws {
+        let harness = try AudioRecorderHarness(timeoutNanoseconds: 1_000_000)
+        defer { harness.cleanup() }
+
+        try await harness.recorder.startRecording()
+        await harness.recorder.cancelRecording(preserveFile: true)
+
+        XCTAssertEqual(harness.recordingEngine?.stopCallCount, 1)
+    }
+
+    func testStopRecordingRejectsCorruptFinalizedAudio() async throws {
+        let harness = try AudioRecorderHarness(timeoutNanoseconds: 500_000_000)
+        defer { harness.cleanup() }
+
+        try await harness.recorder.startRecording()
+        let stopTask = Task {
+            try await harness.recorder.stopRecording()
+        }
+
+        await waitUntil {
+            harness.recordingEngine?.stopCallCount == 1
+        }
+
+        let fileURL = try XCTUnwrap(harness.recordingFileURL)
+        try Data("not playable audio".utf8).write(to: fileURL)
+        let callbackRecorder = try AVAudioRecorder(url: fileURL, settings: harness.callbackRecorderSettings)
+        harness.recorder.audioRecorderDidFinishRecording(callbackRecorder, successfully: true)
+
+        do {
+            _ = try await stopTask.value
+            XCTFail("Expected corrupt audio validation to fail.")
+        } catch {
+            XCTAssertEqual(error as? AppError, .recordingFailure("The recorded audio file could not be read."))
+        }
+    }
+}
+
+@MainActor
+private final class AudioRecorderHarness {
+    let rootDirectoryURL: URL
+    let recoveryDirectoryURL: URL
+    let recorder: AudioRecorder
+    let recorderFactory: AudioRecorderEngineFactorySpy
+    let callbackRecorderSettings: [String: Any] = [
+        AVFormatIDKey: kAudioFormatMPEG4AAC,
+        AVSampleRateKey: 44_100,
+        AVNumberOfChannelsKey: 1,
+        AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+    ]
+
+    var recordingEngine: FakeAudioRecorderEngine? {
+        recorderFactory.recordingEngine
+    }
+
+    var recordingFileURL: URL? {
+        recorderFactory.recordingFileURL
+    }
+
+    init(timeoutNanoseconds: UInt64) throws {
+        rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioRecorderTests-\(UUID().uuidString)", isDirectory: true)
+        recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        let factory = AudioRecorderEngineFactorySpy(recoveryDirectoryURL: recoveryDirectoryURL)
+        recorderFactory = factory
+
+        recorder = AudioRecorder(
+            permissionAccess: StaticMicrophonePermissionAccess(),
+            recoveryDirectoryURL: recoveryDirectoryURL,
+            finalizationTimeoutNanoseconds: timeoutNanoseconds
+        ) { url, _ in
+            factory.makeRecorder(for: url)
+        }
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootDirectoryURL)
+    }
+}
+
+@MainActor
+private final class AudioRecorderEngineFactorySpy {
+    private let recoveryDirectoryURL: URL
+    private(set) var engines: [FakeAudioRecorderEngine] = []
+    private(set) var recordingFileURL: URL?
+
+    var recordingEngine: FakeAudioRecorderEngine? {
+        engines.last
+    }
+
+    init(recoveryDirectoryURL: URL) {
+        self.recoveryDirectoryURL = recoveryDirectoryURL
+    }
+
+    func makeRecorder(for url: URL) -> FakeAudioRecorderEngine {
+        let engine = FakeAudioRecorderEngine()
+        engines.append(engine)
+
+        if url.standardizedFileURL.path.hasPrefix(recoveryDirectoryURL.standardizedFileURL.path) {
+            recordingFileURL = url
+        }
+
+        return engine
+    }
+}
+
+@MainActor
+private final class FakeAudioRecorderEngine: AudioRecorderEngine {
+    weak var delegate: (any AVAudioRecorderDelegate)?
+    var currentTime: TimeInterval = 3
+    private(set) var stopCallCount = 0
+
+    func prepareToRecord() -> Bool {
+        true
+    }
+
+    func record() -> Bool {
+        true
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+}
+
+@MainActor
+private final class StaticMicrophonePermissionAccess: MicrophonePermissionAccessing {
+    func currentPermissionState() -> MicrophonePermissionState {
+        .authorized
+    }
+
+    func requestPermissionIfNeeded() async -> MicrophonePermissionState {
+        .authorized
+    }
+}

--- a/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
+++ b/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
@@ -2,6 +2,13 @@ import XCTest
 @testable import BugNarrator
 
 final class DiagnosticsLoggerTests: XCTestCase {
+    func testDefaultDiagnosticsStoreUsesTemporaryPathDuringUnitTests() {
+        let storageURL = DiagnosticsLogStore.defaultStorageURL(fileManager: .default)
+
+        XCTAssertTrue(storageURL.path.contains(FileManager.default.temporaryDirectory.path))
+        XCTAssertTrue(storageURL.lastPathComponent.hasPrefix("recent-log-"))
+    }
+
     func testFreeformRedactionSanitizesKnownTokenPatterns() {
         let sanitized = DiagnosticsRedactor.sanitizeFreeformText(
             """

--- a/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/MixedAudioRecorderTests.swift
@@ -140,6 +140,42 @@ final class MixedAudioRecorderTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
     }
 
+    func testStopRecordingStartsBothSourceStopsBeforeEitherCompletes() async throws {
+        let rootDirectoryURL = temporaryDirectoryURL()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let microphoneURL = rootDirectoryURL.appendingPathComponent("microphone.wav")
+        let systemAudioURL = rootDirectoryURL.appendingPathComponent("system.wav")
+        try writeSilentAudioFile(to: microphoneURL)
+        try writeSilentAudioFile(to: systemAudioURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.suspendStop = true
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.suspendStop = true
+        let recorder = MixedAudioRecorder(
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder,
+            outputDirectoryURL: rootDirectoryURL
+        )
+
+        try await recorder.startRecording()
+        let stopTask = Task {
+            try await recorder.stopRecording()
+        }
+
+        await waitForStopCalls(microphoneRecorder: microphoneRecorder, systemAudioRecorder: systemAudioRecorder)
+
+        XCTAssertEqual(microphoneRecorder.stopCallCount, 1)
+        XCTAssertEqual(systemAudioRecorder.stopCallCount, 1)
+
+        microphoneRecorder.resumeStop(with: .success(RecordedAudio(fileURL: microphoneURL, duration: 0.1)))
+        systemAudioRecorder.resumeStop(with: .success(RecordedAudio(fileURL: systemAudioURL, duration: 0.1)))
+
+        let mixedAudio = try await stopTask.value
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedAudio.fileURL.path))
+    }
+
     private func temporaryDirectoryURL() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
@@ -152,5 +188,26 @@ final class MixedAudioRecorderTests: XCTestCase {
         let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_410))
         buffer.frameLength = 4_410
         try file.write(from: buffer)
+    }
+
+    private func waitForStopCalls(
+        microphoneRecorder: MockAudioRecorder,
+        systemAudioRecorder: MockAudioRecorder,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0..<20 {
+            if microphoneRecorder.stopCallCount == 1, systemAudioRecorder.stopCallCount == 1 {
+                return
+            }
+
+            await Task.yield()
+        }
+
+        XCTFail(
+            "Expected both mixed recorder sources to begin stopping.",
+            file: file,
+            line: line
+        )
     }
 }

--- a/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
+++ b/Tests/BugNarratorTests/RecordingStatusMessageBuilderTests.swift
@@ -185,7 +185,7 @@ final class RecordingStatusMessageBuilderTests: XCTestCase {
         )
         XCTAssertEqual(
             providerWithIssueExtraction.transcriptionSavingProgressMessage(mode: .retry),
-            "Step 2 of 3: Saving the recovered session locally..."
+            "Step 2 of 3: Saving the retried session locally..."
         )
         XCTAssertEqual(
             providerWithIssueExtraction.transcriptionIssueExtractionProgressMessage(),
@@ -212,7 +212,7 @@ final class RecordingStatusMessageBuilderTests: XCTestCase {
         harness.presenter.presentSavingProgress(mode: .retry)
         XCTAssertEqual(
             harness.status(),
-            .transcribing("Step 2 of 3: Saving the recovered session locally...")
+            .transcribing("Step 2 of 3: Saving the retried session locally...")
         )
 
         harness.presenter.presentIssueExtractionProgress()

--- a/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
@@ -95,6 +95,51 @@ final class RoutingAudioRecorderTests: XCTestCase {
         XCTAssertEqual(mixedRecorder.stopCallCount, 1)
     }
 
+    func testDefaultMixedRecorderUsesInjectedSourceRecorders() async throws {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .microphoneAndSystemAudio
+        store.hasAcceptedSystemAudioRecordingConsent = true
+
+        let rootDirectoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+
+        let microphoneURL = rootDirectoryURL.appendingPathComponent("microphone.wav")
+        let systemAudioURL = rootDirectoryURL.appendingPathComponent("system.wav")
+        try Data("not real audio".utf8).write(to: microphoneURL)
+        try Data("not real audio".utf8).write(to: systemAudioURL)
+
+        let microphoneRecorder = MockAudioRecorder()
+        microphoneRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: microphoneURL, duration: 0.1))
+        ]
+        let systemAudioRecorder = MockAudioRecorder()
+        systemAudioRecorder.requiresMicrophonePermission = false
+        systemAudioRecorder.stopResults = [
+            .success(RecordedAudio(fileURL: systemAudioURL, duration: 0.1))
+        ]
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: microphoneRecorder,
+            systemAudioRecorder: systemAudioRecorder
+        )
+
+        try await router.startRecording()
+        do {
+            _ = try await router.stopRecording()
+            XCTFail("Expected mixed stop to fail while proving the injected source recorders were used.")
+        } catch {
+            // Expected: the injected recorders returned intentionally invalid audio files.
+        }
+
+        XCTAssertEqual(microphoneRecorder.startCallCount, 1)
+        XCTAssertEqual(microphoneRecorder.stopCallCount, 1)
+        XCTAssertEqual(systemAudioRecorder.startCallCount, 1)
+        XCTAssertEqual(systemAudioRecorder.stopCallCount, 1)
+    }
+
     private func makeSettingsStore() -> (SettingsStore, UserDefaults, String) {
         let suiteName = "BugNarrator-RoutingAudioRecorderTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/BugNarratorTests/SessionLibraryTests.swift
+++ b/Tests/BugNarratorTests/SessionLibraryTests.swift
@@ -374,6 +374,43 @@ final class SessionLibraryTests: XCTestCase {
         XCTAssertFalse(preview.hasSuffix(" "))
     }
 
+    func testPendingTranscriptionRetryMessagesSeparateProviderSetupFromCredentialsAndLegacyRecovery() {
+        XCTAssertEqual(
+            PendingTranscriptionFailureReason.missingAPIKey.retryMessage(for: .openAI),
+            "Recording saved locally. Add your OpenAI API key in Settings, then retry transcription from this session."
+        )
+        XCTAssertEqual(
+            PendingTranscriptionFailureReason.providerSetup.retryMessage(for: .parakeetLocal),
+            "Recording saved locally. Finish the Local (Parakeet) setup in Settings, then retry transcription from this session."
+        )
+        XCTAssertEqual(
+            PendingTranscriptionFailureReason.invalidAPIKey.retryMessage(for: .openAI),
+            "Recording saved locally. Replace the rejected OpenAI API key in Settings, then retry transcription from this session."
+        )
+        XCTAssertEqual(
+            PendingTranscriptionFailureReason.crashRecovery.retryMessage(for: .openAI),
+            "This older unexpected-quit recovery item is no longer supported. Delete it and start a new recording."
+        )
+    }
+
+    func testPendingTranscriptionExportsUseRetryLabelInsteadOfRecoveryLabel() {
+        let session = makeSession(
+            transcript: "",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            summary: "",
+            pendingTranscription: PendingTranscription(
+                audioFileName: "recording.m4a",
+                failureReason: .providerSetup,
+                preservedAt: Date(timeIntervalSince1970: 1_700_000_010)
+            )
+        )
+
+        XCTAssertTrue(session.plainTextContent.contains("Retry: Recording saved locally. Finish the OpenAI setup in Settings, then retry transcription from this session."))
+        XCTAssertFalse(session.plainTextContent.contains("Recovery:"))
+        XCTAssertTrue(session.markdownContent.contains("- Retry: Recording saved locally. Finish the OpenAI setup in Settings, then retry transcription from this session."))
+        XCTAssertFalse(session.markdownContent.contains("- Recovery:"))
+    }
+
     private func makeCalendar() -> Calendar {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!

--- a/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionRecoveryControllerTests.swift
@@ -50,6 +50,34 @@ final class TranscriptionRecoveryControllerTests: XCTestCase {
         XCTAssertEqual(statusMessage, session.transcriptionRecoveryMessage)
     }
 
+    func testRetryContextWithProviderSetupIssueReturnsRetryMessage() throws {
+        let harness = try TranscriptionRecoveryControllerHarness()
+        defer { harness.cleanup() }
+
+        let session = try harness.addPendingSession(failureReason: .providerSetup)
+
+        let resolution = harness.controller.retryContext(
+            for: session.id,
+            isRecording: false,
+            provider: .parakeetLocal,
+            hasUsableAIProviderCredential: true,
+            aiProviderCompatibilityIssue: "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider."
+        )
+
+        guard case .failure(let appError, let opensSettings, let statusMessage) = resolution else {
+            return XCTFail("Expected provider setup failure.")
+        }
+        XCTAssertEqual(
+            appError,
+            .transcriptionFailure("Choose a local transcription model instead of whisper-1 for the Local-Compatible provider.")
+        )
+        XCTAssertTrue(opensSettings)
+        XCTAssertEqual(
+            statusMessage,
+            "Recording saved locally. Finish the Local (Parakeet) setup in Settings, then retry transcription from this session."
+        )
+    }
+
     func testRetryContextRejectsLegacyCrashRecoverySessions() throws {
         let harness = try TranscriptionRecoveryControllerHarness()
         defer { harness.cleanup() }


### PR DESCRIPTION
## Summary
- Bound microphone stop/cancel finalization and validate audio artifacts are playable before transcription.
- Harden system audio and mixed recording finalization paths, including partial Core Audio tap cleanup and concurrent mixed-source stops.
- Preserve retryable transcription failures as pending transcription retries, separate that terminology from crash recovery, and block quit during active recording/transcription.
- Add concrete audio recorder tests and isolate default diagnostics storage for unit tests.

## Local validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test` - passed, 543 tests, 0 failures.

Closes #332
Closes #333
Closes #334
Closes #335
Closes #336
Closes #337
Closes #338
Closes #339
Closes #340
Closes #341
Closes #342