### PR TITLE
Harden recording startup and AI setup checks

### DIFF
--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -174,9 +174,11 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
                 metadata: ["file_name": fileURL.lastPathComponent]
             )
         } catch let error as AppError {
+            try? FileManager.default.removeItem(at: fileURL)
             recordingLogger.error("recording_start_failed", error.userMessage)
             throw error
         } catch {
+            try? FileManager.default.removeItem(at: fileURL)
             recordingLogger.error("recording_start_failed", "Audio recording could not be started.")
             throw AppError.recordingFailure(error.localizedDescription)
         }

--- a/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
+++ b/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
@@ -4,8 +4,13 @@ struct TranscriptQualityInspector {
     private enum Defaults {
         static let minimumUsefulCharacterCount = 12
         static let repeatedPhraseMinimumWords = 4
-        static let repeatedPhraseMinimumCount = 6
+        static let repeatedPhraseMinimumCount = 4
+        static let consecutiveRepeatedPhraseMinimumWords = 2
+        static let consecutiveRepeatedPhraseMinimumCount = 4
+        static let consecutiveRepeatedPhraseMaximumWords = 8
         static let unexpectedScriptMinimumScalars = 4
+        static let unexpectedScriptMinimumScalarsInLikelyEnglish = 2
+        static let likelyEnglishMinimumLatinScalars = 20
         static let unexpectedScriptMinimumRatio = 0.04
         static let abruptEndingMinimumWords = 25
     }
@@ -75,6 +80,10 @@ struct TranscriptQualityInspector {
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
 
+        if let consecutivePhrase = consecutiveRepeatedPhrase(in: words) {
+            return consecutivePhrase
+        }
+
         guard words.count >= Defaults.repeatedPhraseMinimumWords * Defaults.repeatedPhraseMinimumCount else {
             return nil
         }
@@ -92,9 +101,44 @@ struct TranscriptQualityInspector {
         return nil
     }
 
+    private func consecutiveRepeatedPhrase(in words: [String]) -> String? {
+        guard words.count >= Defaults.consecutiveRepeatedPhraseMinimumWords * Defaults.consecutiveRepeatedPhraseMinimumCount else {
+            return nil
+        }
+
+        let maximumWindowSize = min(Defaults.consecutiveRepeatedPhraseMaximumWords, words.count / Defaults.consecutiveRepeatedPhraseMinimumCount)
+        guard maximumWindowSize >= Defaults.consecutiveRepeatedPhraseMinimumWords else {
+            return nil
+        }
+
+        for windowSize in Defaults.consecutiveRepeatedPhraseMinimumWords...maximumWindowSize {
+            var index = 0
+            while index + windowSize * Defaults.consecutiveRepeatedPhraseMinimumCount <= words.count {
+                let phrase = Array(words[index..<(index + windowSize)])
+                var repetitionCount = 1
+                var nextIndex = index + windowSize
+
+                while nextIndex + windowSize <= words.count,
+                      Array(words[nextIndex..<(nextIndex + windowSize)]) == phrase {
+                    repetitionCount += 1
+                    nextIndex += windowSize
+                }
+
+                if repetitionCount >= Defaults.consecutiveRepeatedPhraseMinimumCount {
+                    return phrase.joined(separator: " ")
+                }
+
+                index += 1
+            }
+        }
+
+        return nil
+    }
+
     private func containsUnexpectedCJKScript(_ transcript: String) -> Bool {
         var cjkScalarCount = 0
         var letterScalarCount = 0
+        var latinScalarCount = 0
 
         for scalar in transcript.unicodeScalars {
             guard CharacterSet.letters.contains(scalar) else {
@@ -104,11 +148,21 @@ struct TranscriptQualityInspector {
             letterScalarCount += 1
             if Self.isCJKScalar(scalar) {
                 cjkScalarCount += 1
+            } else if Self.isLatinScalar(scalar) {
+                latinScalarCount += 1
             }
         }
 
-        guard cjkScalarCount >= Defaults.unexpectedScriptMinimumScalars,
-              letterScalarCount > 0 else {
+        guard letterScalarCount > 0 else {
+            return false
+        }
+
+        if latinScalarCount >= Defaults.likelyEnglishMinimumLatinScalars,
+           cjkScalarCount >= Defaults.unexpectedScriptMinimumScalarsInLikelyEnglish {
+            return true
+        }
+
+        guard cjkScalarCount >= Defaults.unexpectedScriptMinimumScalars else {
             return false
         }
 
@@ -118,6 +172,15 @@ struct TranscriptQualityInspector {
     private static func isCJKScalar(_ scalar: UnicodeScalar) -> Bool {
         switch scalar.value {
         case 0x3400...0x4DBF, 0x4E00...0x9FFF, 0xF900...0xFAFF:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isLatinScalar(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x0041...0x005A, 0x0061...0x007A, 0x00C0...0x024F:
             return true
         default:
             return false

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -842,6 +842,45 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(harness.appState.apiKeyValidationState, .failure(AppError.missingAPIKey.userMessage))
     }
 
+    func testValidateOpenAICompatibleProviderBlocksMissingBaseURLBeforeNetworkCall() async {
+        let harness = AppStateHarness(apiKey: "enterprise-token")
+        defer { harness.cleanup() }
+
+        harness.settingsStore.aiProvider = .openAICompatible
+
+        await harness.appState.validateAPIKey()
+
+        XCTAssertEqual(
+            harness.appState.apiKeyValidationState,
+            .failure("Choose a non-default API base URL for the OpenAI-Compatible provider.")
+        )
+        let validationCallCount = await harness.transcriptionClient.validationCallCount
+        XCTAssertEqual(validationCallCount, 0)
+    }
+
+    func testValidateLocalCompatibleProviderUsesEmptyCredentialAndLocalBaseURLWhenSetupIsReady() async {
+        let harness = AppStateHarness(apiKey: "")
+        defer { harness.cleanup() }
+
+        harness.settingsStore.aiProvider = .localCompatible
+        harness.settingsStore.openAIBaseURL = "http://localhost:1234/v1"
+        harness.settingsStore.preferredModel = "whisper-large-v3"
+        harness.settingsStore.issueExtractionModel = "llama3.1:8b"
+
+        await harness.appState.validateAPIKey()
+
+        XCTAssertEqual(
+            harness.appState.apiKeyValidationState,
+            .success("The local-compatible provider accepted this configuration.")
+        )
+        let validationCallCount = await harness.transcriptionClient.validationCallCount
+        let validationKeys = await harness.transcriptionClient.requestedValidationAPIKeys
+        let validationBaseURLs = await harness.transcriptionClient.requestedValidationBaseURLs
+        XCTAssertEqual(validationCallCount, 1)
+        XCTAssertEqual(validationKeys, [""])
+        XCTAssertEqual(validationBaseURLs.map(\.absoluteString), ["http://localhost:1234/v1"])
+    }
+
     func testValidateGitHubConfigurationUpdatesValidationStateOnSuccess() async {
         let harness = AppStateHarness()
         defer { harness.cleanup() }

--- a/Tests/BugNarratorTests/AudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/AudioRecorderTests.swift
@@ -56,6 +56,26 @@ final class AudioRecorderTests: XCTestCase {
             XCTAssertEqual(error as? AppError, .recordingFailure("The recorded audio file could not be read."))
         }
     }
+
+    func testStartRecordingRemovesPreparedFileWhenRecorderRejectsStart() async throws {
+        let harness = try AudioRecorderHarness(timeoutNanoseconds: 500_000_000)
+        defer { harness.cleanup() }
+        harness.recorderFactory.nextEngineRecordResult = false
+        harness.recorderFactory.writePlaceholderFileForNextEngine = true
+
+        do {
+            try await harness.recorder.startRecording()
+            XCTFail("Expected start recording to fail.")
+        } catch {
+            XCTAssertEqual(
+                error as? AppError,
+                .microphoneUnavailable("Check that an input device is connected and available, then try again.")
+            )
+        }
+
+        let fileURL = try XCTUnwrap(harness.recordingFileURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
 }
 
 @MainActor
@@ -106,6 +126,8 @@ private final class AudioRecorderEngineFactorySpy {
     private let recoveryDirectoryURL: URL
     private(set) var engines: [FakeAudioRecorderEngine] = []
     private(set) var recordingFileURL: URL?
+    var nextEngineRecordResult = true
+    var writePlaceholderFileForNextEngine = false
 
     var recordingEngine: FakeAudioRecorderEngine? {
         engines.last
@@ -116,10 +138,21 @@ private final class AudioRecorderEngineFactorySpy {
     }
 
     func makeRecorder(for url: URL) -> FakeAudioRecorderEngine {
-        let engine = FakeAudioRecorderEngine()
+        let isRecordingArtifact = url.standardizedFileURL.path.hasPrefix(recoveryDirectoryURL.standardizedFileURL.path)
+        let recordResult = isRecordingArtifact ? nextEngineRecordResult : true
+
+        if isRecordingArtifact, writePlaceholderFileForNextEngine {
+            try? Data("partial recorder artifact".utf8).write(to: url)
+            writePlaceholderFileForNextEngine = false
+        }
+
+        let engine = FakeAudioRecorderEngine(recordResult: recordResult)
+        if isRecordingArtifact {
+            nextEngineRecordResult = true
+        }
         engines.append(engine)
 
-        if url.standardizedFileURL.path.hasPrefix(recoveryDirectoryURL.standardizedFileURL.path) {
+        if isRecordingArtifact {
             recordingFileURL = url
         }
 
@@ -132,13 +165,18 @@ private final class FakeAudioRecorderEngine: AudioRecorderEngine {
     weak var delegate: (any AVAudioRecorderDelegate)?
     var currentTime: TimeInterval = 3
     private(set) var stopCallCount = 0
+    private let recordResult: Bool
+
+    init(recordResult: Bool = true) {
+        self.recordResult = recordResult
+    }
 
     func prepareToRecord() -> Bool {
         true
     }
 
     func record() -> Bool {
-        true
+        recordResult
     }
 
     func stop() {

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -118,6 +118,8 @@ actor MockTranscriptionClient: TranscriptionServing {
     private(set) var requestedFileURLs: [URL] = []
     private(set) var requestedModels: [String] = []
     private(set) var validationCallCount = 0
+    private(set) var requestedValidationAPIKeys: [String] = []
+    private(set) var requestedValidationBaseURLs: [URL] = []
 
     func enqueue(_ result: Result<TranscriptionResult, Error>) {
         queuedResults.append(result)
@@ -141,6 +143,8 @@ actor MockTranscriptionClient: TranscriptionServing {
 
     func validateAPIKey(_ apiKey: String, apiBaseURL: URL) async throws {
         validationCallCount += 1
+        requestedValidationAPIKeys.append(apiKey)
+        requestedValidationBaseURLs.append(apiBaseURL)
 
         if validationResults.isEmpty {
             return

--- a/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
+++ b/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class TranscriptQualityInspectorTests: XCTestCase {
     func testFindsRepeatedTextLoop() {
-        let transcript = Array(repeating: "show you how it works", count: 6).joined(separator: " ")
+        let transcript = Array(repeating: "show you how it works", count: 4).joined(separator: " ")
 
         let findings = TranscriptQualityInspector().findings(for: transcript)
 
@@ -11,9 +11,19 @@ final class TranscriptQualityInspectorTests: XCTestCase {
         XCTAssertEqual(findings.first?.severity, .warning)
     }
 
+    func testFindsAdjacentShortRepeatedTextLoop() {
+        let transcript = """
+        The tester clicked refresh and the app crashed. please wait please wait please wait please wait before moving on.
+        """
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertTrue(findings.contains { $0.kind == .repeatedText })
+    }
+
     func testFindsUnexpectedCJKScriptForLikelyEnglishTranscript() {
         let transcript = """
-        The tester opened the command center and clicked refresh. 然后系统显示错误。The expected setup panel did not appear.
+        The tester opened the command center and clicked refresh. 然后 the expected setup panel did not appear.
         """
 
         let findings = TranscriptQualityInspector().findings(for: transcript)


### PR DESCRIPTION
## Summary
- Remove partially prepared microphone recording files when recorder startup fails after preflight.
- Strengthen transcript quality detection for adjacent repeated phrases and short CJK snippets in otherwise English transcripts.
- Add AI setup validation coverage for OpenAI-compatible provider blocking and local-compatible provider validation.

## Local validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests/TranscriptQualityInspectorTests -only-testing:BugNarratorTests/AppStateTests/testValidateOpenAICompatibleProviderBlocksMissingBaseURLBeforeNetworkCall -only-testing:BugNarratorTests/AppStateTests/testValidateLocalCompatibleProviderUsesEmptyCredentialAndLocalBaseURLWhenSetupIsReady CODE_SIGNING_ALLOWED=NO test` - passed, 7 tests.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests/AudioRecorderTests CODE_SIGNING_ALLOWED=NO test` - passed, 4 tests.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test` - passed, 547 tests, 0 failures.

Closes #344