### PR TITLE
Improve transcript quality detection

### DIFF
--- a/Sources/BugNarrator/Models/TranscriptQualityFinding.swift
+++ b/Sources/BugNarrator/Models/TranscriptQualityFinding.swift
@@ -8,6 +8,7 @@ struct TranscriptQualityFinding: Codable, Equatable, Identifiable, Sendable {
 
     enum Kind: String, Codable, Sendable {
         case repeatedText
+        case boilerplateText
         case unexpectedLanguageScript
         case abruptEnding
         case shortTranscript

--- a/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
+++ b/Sources/BugNarrator/Services/TranscriptQualityInspector.swift
@@ -5,6 +5,7 @@ struct TranscriptQualityInspector {
         static let minimumUsefulCharacterCount = 12
         static let repeatedPhraseMinimumWords = 4
         static let repeatedPhraseMinimumCount = 4
+        static let repeatedSingleWordMinimumCount = 6
         static let consecutiveRepeatedPhraseMinimumWords = 2
         static let consecutiveRepeatedPhraseMinimumCount = 4
         static let consecutiveRepeatedPhraseMaximumWords = 8
@@ -13,6 +14,8 @@ struct TranscriptQualityInspector {
         static let likelyEnglishMinimumLatinScalars = 20
         static let unexpectedScriptMinimumRatio = 0.04
         static let abruptEndingMinimumWords = 25
+        static let boilerplateMinimumLatinScalars = 8
+        static let boilerplateMaximumUsefulWords = 18
     }
 
     func findings(for transcript: String) -> [TranscriptQualityFinding] {
@@ -51,6 +54,16 @@ struct TranscriptQualityInspector {
             )
         }
 
+        if let boilerplatePhrase = boilerplateHallucination(in: normalized) {
+            findings.append(
+                TranscriptQualityFinding(
+                    kind: .boilerplateText,
+                    severity: .warning,
+                    message: "The transcript contains likely transcription boilerplate near \"\(boilerplatePhrase)\". Confirm the recording captured tester narration before relying on it."
+                )
+            )
+        }
+
         if containsUnexpectedCJKScript(normalized) {
             findings.append(
                 TranscriptQualityFinding(
@@ -80,6 +93,10 @@ struct TranscriptQualityInspector {
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .filter { !$0.isEmpty }
 
+        if let repeatedWord = repeatedSingleWord(in: words) {
+            return repeatedWord
+        }
+
         if let consecutivePhrase = consecutiveRepeatedPhrase(in: words) {
             return consecutivePhrase
         }
@@ -95,6 +112,29 @@ struct TranscriptQualityInspector {
             counts[phrase, default: 0] += 1
             if counts[phrase, default: 0] >= Defaults.repeatedPhraseMinimumCount {
                 return phrase
+            }
+        }
+
+        return nil
+    }
+
+    private func repeatedSingleWord(in words: [String]) -> String? {
+        guard words.count >= Defaults.repeatedSingleWordMinimumCount else {
+            return nil
+        }
+
+        var currentWord: String?
+        var currentCount = 0
+        for word in words {
+            if word == currentWord {
+                currentCount += 1
+            } else {
+                currentWord = word
+                currentCount = 1
+            }
+
+            if currentCount >= Defaults.repeatedSingleWordMinimumCount {
+                return word
             }
         }
 
@@ -186,6 +226,90 @@ struct TranscriptQualityInspector {
             return false
         }
     }
+
+    private func boilerplateHallucination(in transcript: String) -> String? {
+        let normalized = transcript
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased()
+
+        let boilerplatePhrases = [
+            "thanks for watching",
+            "thank you for watching",
+            "like and subscribe",
+            "dont forget to subscribe",
+            "don't forget to subscribe",
+            "please subscribe",
+            "this is the end",
+            "subtitles by",
+            "transcribed by",
+            "captions by"
+        ]
+
+        if let matchedPhrase = boilerplatePhrases.first(where: { normalized.contains($0) }) {
+            return matchedPhrase
+        }
+
+        guard likelyLowInformationBoilerplate(transcript) else {
+            return nil
+        }
+
+        return "low-information transcript"
+    }
+
+    private func likelyLowInformationBoilerplate(_ transcript: String) -> Bool {
+        var latinScalarCount = 0
+        var cjkScalarCount = 0
+        for scalar in transcript.unicodeScalars where CharacterSet.letters.contains(scalar) {
+            if Self.isLatinScalar(scalar) {
+                latinScalarCount += 1
+            } else if Self.isCJKScalar(scalar) {
+                cjkScalarCount += 1
+            }
+        }
+
+        guard latinScalarCount >= Defaults.boilerplateMinimumLatinScalars,
+              cjkScalarCount == 0 else {
+            return false
+        }
+
+        let words = transcript
+            .lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+
+        guard !words.isEmpty,
+              words.count <= Defaults.boilerplateMaximumUsefulWords else {
+            return false
+        }
+
+        let usefulWords = words.filter { !Self.boilerplateStopWords.contains($0) }
+        return usefulWords.isEmpty
+    }
+
+    private static let boilerplateStopWords: Set<String> = [
+        "a",
+        "an",
+        "and",
+        "are",
+        "end",
+        "for",
+        "from",
+        "i",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "so",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "we",
+        "you"
+    ]
 
     private func appearsAbruptlyCutOff(_ transcript: String) -> Bool {
         let words = transcript.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }

--- a/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
+++ b/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
@@ -85,6 +85,8 @@ struct TranscriptQualityFindingsView: View {
         switch finding.kind {
         case .repeatedText:
             return "repeat"
+        case .boilerplateText:
+            return "text.quote"
         case .unexpectedLanguageScript:
             return "globe.asia.australia"
         case .abruptEnding:

--- a/Tests/BugNarratorTests/TranscriptQualityFindingTests.swift
+++ b/Tests/BugNarratorTests/TranscriptQualityFindingTests.swift
@@ -14,9 +14,9 @@ final class TranscriptQualityFindingTests: XCTestCase {
 
     func testFindingCodableRoundTripPreservesSeverityAndKind() throws {
         let finding = TranscriptQualityFinding(
-            kind: .unexpectedLanguageScript,
+            kind: .boilerplateText,
             severity: .error,
-            message: "Unexpected script detected."
+            message: "Likely boilerplate detected."
         )
 
         let data = try JSONEncoder().encode(finding)

--- a/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
+++ b/Tests/BugNarratorTests/TranscriptQualityInspectorTests.swift
@@ -21,6 +21,38 @@ final class TranscriptQualityInspectorTests: XCTestCase {
         XCTAssertTrue(findings.contains { $0.kind == .repeatedText })
     }
 
+    func testFindsSingleWordRepeatedTextLoop() {
+        let transcript = "The recorder returned you you you you you you after the tester stopped talking."
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertTrue(findings.contains { $0.kind == .repeatedText })
+    }
+
+    func testFindsLikelyBoilerplateHallucination() {
+        let transcript = "Thanks for watching. Please subscribe."
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertTrue(findings.contains { $0.kind == .boilerplateText })
+    }
+
+    func testFindsLowInformationBoilerplateTranscript() {
+        let transcript = "This is the end of the"
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertTrue(findings.contains { $0.kind == .boilerplateText })
+    }
+
+    func testDoesNotFlagNormalShortNarrationAsBoilerplate() {
+        let transcript = "Clicked refresh and the command center crashed."
+
+        let findings = TranscriptQualityInspector().findings(for: transcript)
+
+        XCTAssertFalse(findings.contains { $0.kind == .boilerplateText })
+    }
+
     func testFindsUnexpectedCJKScriptForLikelyEnglishTranscript() {
         let transcript = """
         The tester opened the command center and clicked refresh. 然后 the expected setup panel did not appear.

--- a/Tests/BugNarratorTests/TranscriptionClientTests.swift
+++ b/Tests/BugNarratorTests/TranscriptionClientTests.swift
@@ -153,6 +153,33 @@ final class TranscriptionClientTests: XCTestCase {
         XCTAssertTrue(result.qualityFindings.contains { $0.kind == .unexpectedLanguageScript })
     }
 
+    func testTranscribeSurfacesBoilerplateTranscriptQualityFinding() async throws {
+        let fileURL = try makeAudioFile(named: "boilerplate-transcript", contents: "audio-data")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let transcript = "Thank you for watching. Please subscribe."
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = try JSONSerialization.data(
+                withJSONObject: [
+                    "text": transcript,
+                    "segments": []
+                ]
+            )
+            return (response, data)
+        }
+
+        let client = TranscriptionClient(session: makeMockURLSession())
+        let result = try await client.transcribe(
+            fileURL: fileURL,
+            apiKey: "fixture-openai-key",
+            request: TranscriptionRequest(model: "whisper-1", languageHint: "en", prompt: nil)
+        )
+
+        XCTAssertEqual(result.text, transcript)
+        XCTAssertTrue(result.qualityFindings.contains { $0.kind == .boilerplateText })
+    }
+
     func testTranscribeMapsAPIErrorResponse() async throws {
         let fileURL = try makeAudioFile(named: "api-error", contents: "audio-data")
         defer { try? FileManager.default.removeItem(at: fileURL) }


### PR DESCRIPTION
## Summary
- Detect single-word transcript repetition loops such as repeated filler tokens.
- Add a distinct boilerplate transcript quality finding for likely STT hallucinations such as "thanks for watching", subscribe/outro text, subtitles/captions credits, and low-information endings.
- Surface the new finding in transcript quality UI and verify it flows through transcription client results.

## Local validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests/TranscriptQualityInspectorTests -only-testing:BugNarratorTests/TranscriptQualityFindingTests CODE_SIGNING_ALLOWED=NO test` - passed, 11 tests.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests/TranscriptionClientTests/testTranscribeSurfacesBoilerplateTranscriptQualityFinding CODE_SIGNING_ALLOWED=NO test` - passed, 1 test.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test` - passed, 552 tests, 0 failures.

Closes #346