### PR TITLE
Harden Parakeet local setup

### DIFF
--- a/local-transcription/setup.sh
+++ b/local-transcription/setup.sh
@@ -17,13 +17,35 @@ if ! command -v ffmpeg >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "error: python3 is required." >&2
+PYTHON="${PYTHON:-}"
+if [[ -z "$PYTHON" ]]; then
+    for candidate in python3.12 python3.11 python3; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            PYTHON="$(command -v "$candidate")"
+            break
+        fi
+    done
+fi
+
+if [[ -z "$PYTHON" ]]; then
+    echo "error: python3.12, python3.11, or python3 is required." >&2
     exit 1
 fi
 
+PYTHON_VERSION="$("$PYTHON" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+case "$PYTHON_VERSION" in
+    3.11|3.12) ;;
+    *)
+        echo "error: Parakeet local transcription requires Python 3.11 or 3.12; found $PYTHON_VERSION at $PYTHON." >&2
+        echo "       Install with: brew install python@3.12" >&2
+        echo "       Or rerun with: PYTHON=/opt/homebrew/bin/python3.12 $0" >&2
+        exit 1
+        ;;
+esac
+
+echo "Using Python $PYTHON_VERSION at $PYTHON..."
 echo "Creating virtual environment at $VENV_DIR..."
-python3 -m venv "$VENV_DIR"
+"$PYTHON" -m venv "$VENV_DIR"
 
 echo "Installing dependencies..."
 "$VENV_DIR/bin/python" -m pip install --upgrade pip --quiet
@@ -39,6 +61,6 @@ echo "Or preload the model at startup (recommended):"
 echo "  $VENV_DIR/bin/python $SCRIPT_DIR/server.py --preload"
 echo ""
 echo "Then configure BugNarrator:"
-echo "  Provider: Local-Compatible"
+echo "  Provider: Local (Parakeet)"
 echo "  Base URL: http://localhost:8422"
 echo "  API Key:  (leave blank)"


### PR DESCRIPTION
## Summary
- prefer Python 3.12/3.11 for the Parakeet local transcription venv instead of the machine default python3
- fail clearly when an unsupported Python version is selected
- update setup output to point users at the Local (Parakeet) provider

## Validation
- local-transcription/venv/bin/python -m unittest discover -s local-transcription -p 'test_*.py'
- scripts/validate.sh
- generated WAV smoke transcribed successfully through http://127.0.0.1:8422/v1/audio/transcriptions