### PR TITLE
Avoid main actor blocking on recorder stop

### DIFF
--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -230,7 +230,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         }
 
         if !preserveFile {
-            try? FileManager.default.removeItem(at: fileURL)
+            await Self.removeItemIfPresent(at: fileURL)
         }
     }
 
@@ -254,23 +254,28 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
             return
         }
 
-        do {
-            try validateRecordedAudioFile(at: pendingStopResult.fileURL)
-        } catch {
-            recordingLogger.error("recording_validation_failed", (error as? AppError)?.userMessage ?? error.localizedDescription)
-            stopContinuation?.resume(throwing: error)
-            return
-        }
+        Task { [recordingLogger] in
+            do {
+                try await Self.validateRecordedAudioFile(at: pendingStopResult.fileURL)
+            } catch {
+                recordingLogger.error(
+                    "recording_validation_failed",
+                    (error as? AppError)?.userMessage ?? error.localizedDescription
+                )
+                stopContinuation?.resume(throwing: error)
+                return
+            }
 
-        recordingLogger.info(
-            "recording_stopped",
-            "Audio recording finished successfully.",
-            metadata: [
-                "file_name": pendingStopResult.fileURL.lastPathComponent,
-                "duration_seconds": String(format: "%.2f", pendingStopResult.duration)
-            ]
-        )
-        stopContinuation?.resume(returning: pendingStopResult)
+            recordingLogger.info(
+                "recording_stopped",
+                "Audio recording finished successfully.",
+                metadata: [
+                    "file_name": pendingStopResult.fileURL.lastPathComponent,
+                    "duration_seconds": String(format: "%.2f", pendingStopResult.duration)
+                ]
+            )
+            stopContinuation?.resume(returning: pendingStopResult)
+        }
     }
 
     func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: (any Error)?) {
@@ -359,7 +364,19 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         }
     }
 
-    private func validateRecordedAudioFile(at url: URL) throws {
+    private static func removeItemIfPresent(at url: URL) async {
+        await Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: url)
+        }.value
+    }
+
+    private static func validateRecordedAudioFile(at url: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try validateRecordedAudioFileSynchronously(at: url)
+        }.value
+    }
+
+    private nonisolated static func validateRecordedAudioFileSynchronously(at url: URL) throws {
         let attributes: [FileAttributeKey: Any]
 
         do {

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -121,11 +121,11 @@ final class SystemAudioRecorder: AudioRecording {
         )
 
         tapSession.invalidate()
-        ioQueue.sync { }
-        try activeWriter.close()
+        await ioQueue.drain()
+        try await Self.closeWriter(activeWriter)
         cleanupActiveState()
 
-        try validateRecordedAudioFile(at: currentFileURL)
+        try await Self.validateRecordedAudioFile(at: currentFileURL)
 
         recordingLogger.info(
             "system_audio_recording_stopped",
@@ -142,15 +142,17 @@ final class SystemAudioRecorder: AudioRecording {
     func cancelRecording(preserveFile: Bool) async {
         let fileURL = currentFileURL
         tapSession?.invalidate()
-        ioQueue.sync { }
-        try? activeWriter?.close()
+        await ioQueue.drain()
+        if let activeWriter {
+            try? await Self.closeWriter(activeWriter)
+        }
         cleanupActiveState()
 
         guard !preserveFile, let fileURL else {
             return
         }
 
-        try? FileManager.default.removeItem(at: fileURL)
+        await Self.removeItemIfPresent(at: fileURL)
     }
 
     private func cleanupActiveState() {
@@ -160,7 +162,25 @@ final class SystemAudioRecorder: AudioRecording {
         recordingStartedAt = nil
     }
 
-    private func validateRecordedAudioFile(at url: URL) throws {
+    private static func closeWriter(_ writer: SystemAudioFileWriter) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try writer.close()
+        }.value
+    }
+
+    private static func removeItemIfPresent(at url: URL) async {
+        await Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: url)
+        }.value
+    }
+
+    private static func validateRecordedAudioFile(at url: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try validateRecordedAudioFileSynchronously(at: url)
+        }.value
+    }
+
+    private nonisolated static func validateRecordedAudioFileSynchronously(at url: URL) throws {
         let attributes: [FileAttributeKey: Any]
 
         do {
@@ -398,6 +418,16 @@ private final class SystemAudioFileWriter: @unchecked Sendable {
 
         if let writeError {
             throw AppError.recordingFailure("System audio could not be written. \(writeError.localizedDescription)")
+        }
+    }
+}
+
+private extension DispatchQueue {
+    func drain() async {
+        await withCheckedContinuation { continuation in
+            async {
+                continuation.resume()
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #350\n\n## Summary\n- replace synchronous system-audio IO queue drains with an async DispatchQueue drain helper\n- move system-audio writer close, audio validation, and cancellation file removal onto detached background work\n- move microphone recording validation and cancellation cleanup off the main actor while preserving stop/cancel semantics\n\n## Validation\n- scripts/validate.sh\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AudioRecorderTests\n\nNote: plain xcodebuild is not usable on this machine while xcode-select points at CommandLineTools; the explicit DEVELOPER_DIR path uses the installed Xcode.app.