### PR TITLE
Add debug WAV-first microphone capture

### DIFF
--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -21,11 +21,47 @@ extension AVAudioRecorder: AudioRecorderEngine {}
 
 typealias AudioRecorderEngineFactory = (URL, [String: Any]) throws -> any AudioRecorderEngine
 
+enum AudioRecorderCaptureFormat: Equatable {
+    case aacM4A
+    case wavPCM
+
+    var fileExtension: String {
+        switch self {
+        case .aacM4A:
+            return "m4a"
+        case .wavPCM:
+            return "wav"
+        }
+    }
+
+    var recordingSettings: [String: Any] {
+        switch self {
+        case .aacM4A:
+            return [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: 44_100,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+            ]
+        case .wavPCM:
+            return [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: 44_100,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsBigEndianKey: false
+            ]
+        }
+    }
+}
+
 @MainActor
 final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, AudioRecording {
     private let recordingLogger = DiagnosticsLogger(category: .recording)
     private let permissionAccess: any MicrophonePermissionAccessing
     private let recoveryDirectoryURL: URL
+    private let captureFormat: AudioRecorderCaptureFormat
     private let finalizationTimeoutNanoseconds: UInt64
     private let makeRecorder: AudioRecorderEngineFactory
 
@@ -40,6 +76,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     init(
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
             .appendingPathComponent("RecoveredRecordings", isDirectory: true),
+        captureFormat: AudioRecorderCaptureFormat = .aacM4A,
         finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000,
         makeRecorder: @escaping AudioRecorderEngineFactory = { url, settings in
             try AVAudioRecorder(url: url, settings: settings)
@@ -47,6 +84,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     ) {
         self.permissionAccess = SystemMicrophonePermissionAccess()
         self.recoveryDirectoryURL = recoveryDirectoryURL
+        self.captureFormat = captureFormat
         self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
         self.makeRecorder = makeRecorder
     }
@@ -55,6 +93,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         permissionAccess: any MicrophonePermissionAccessing,
         recoveryDirectoryURL: URL = AppSupportLocation.appDirectory()
             .appendingPathComponent("RecoveredRecordings", isDirectory: true),
+        captureFormat: AudioRecorderCaptureFormat = .aacM4A,
         finalizationTimeoutNanoseconds: UInt64 = 10_000_000_000,
         makeRecorder: @escaping AudioRecorderEngineFactory = { url, settings in
             try AVAudioRecorder(url: url, settings: settings)
@@ -62,6 +101,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
     ) {
         self.permissionAccess = permissionAccess
         self.recoveryDirectoryURL = recoveryDirectoryURL
+        self.captureFormat = captureFormat
         self.finalizationTimeoutNanoseconds = finalizationTimeoutNanoseconds
         self.makeRecorder = makeRecorder
     }
@@ -77,7 +117,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
 
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-Preflight-\(UUID().uuidString)")
-            .appendingPathExtension("m4a")
+            .appendingPathExtension(captureFormat.fileExtension)
 
         do {
             let recorder = try makeRecorder(fileURL, recordingSettings)
@@ -102,7 +142,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
 
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-ActivationProbe-\(UUID().uuidString)")
-            .appendingPathExtension("m4a")
+            .appendingPathExtension(captureFormat.fileExtension)
 
         do {
             let recorder = try makeRecorder(fileURL, recordingSettings)
@@ -426,15 +466,10 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
 
         return recoveryDirectoryURL
             .appendingPathComponent("\(timestamp)-recording-\(UUID().uuidString)")
-            .appendingPathExtension("m4a")
+            .appendingPathExtension(captureFormat.fileExtension)
     }
 
     private var recordingSettings: [String: Any] {
-        [
-            AVFormatIDKey: kAudioFormatMPEG4AAC,
-            AVSampleRateKey: 44_100,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
-        ]
+        captureFormat.recordingSettings
     }
 }

--- a/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
@@ -11,11 +11,14 @@ final class RoutingAudioRecorder: AudioRecording {
 
     init(
         settingsStore: SettingsStore,
-        microphoneRecorder: any AudioRecording = AudioRecorder(),
+        microphoneRecorder: (any AudioRecording)? = nil,
         systemAudioRecorder: any AudioRecording = SystemAudioRecorder(),
         microphoneAndSystemAudioRecorder: (any AudioRecording)? = nil
     ) {
         self.settingsStore = settingsStore
+        let microphoneRecorder = microphoneRecorder ?? AudioRecorder(
+            captureFormat: settingsStore.debugMode ? .wavPCM : .aacM4A
+        )
         self.microphoneRecorder = microphoneRecorder
         self.systemAudioRecorder = systemAudioRecorder
         self.microphoneAndSystemAudioRecorder = microphoneAndSystemAudioRecorder ?? MixedAudioRecorder(

--- a/Tests/BugNarratorTests/AudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/AudioRecorderTests.swift
@@ -76,6 +76,21 @@ final class AudioRecorderTests: XCTestCase {
         let fileURL = try XCTUnwrap(harness.recordingFileURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
+
+    func testWavCaptureFormatUsesPCMRecoveryArtifact() async throws {
+        let harness = try AudioRecorderHarness(
+            captureFormat: .wavPCM,
+            timeoutNanoseconds: 500_000_000
+        )
+        defer { harness.cleanup() }
+
+        try await harness.recorder.startRecording()
+
+        let fileURL = try XCTUnwrap(harness.recordingFileURL)
+        XCTAssertEqual(fileURL.pathExtension, "wav")
+        XCTAssertEqual(harness.recorderFactory.recordingSettings?[AVFormatIDKey] as? AudioFormatID, kAudioFormatLinearPCM)
+        XCTAssertEqual(harness.recorderFactory.recordingSettings?[AVLinearPCMBitDepthKey] as? Int, 16)
+    }
 }
 
 @MainActor
@@ -99,7 +114,10 @@ private final class AudioRecorderHarness {
         recorderFactory.recordingFileURL
     }
 
-    init(timeoutNanoseconds: UInt64) throws {
+    init(
+        captureFormat: AudioRecorderCaptureFormat = .aacM4A,
+        timeoutNanoseconds: UInt64
+    ) throws {
         rootDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioRecorderTests-\(UUID().uuidString)", isDirectory: true)
         recoveryDirectoryURL = rootDirectoryURL.appendingPathComponent("RecoveredRecordings", isDirectory: true)
@@ -110,9 +128,10 @@ private final class AudioRecorderHarness {
         recorder = AudioRecorder(
             permissionAccess: StaticMicrophonePermissionAccess(),
             recoveryDirectoryURL: recoveryDirectoryURL,
+            captureFormat: captureFormat,
             finalizationTimeoutNanoseconds: timeoutNanoseconds
-        ) { url, _ in
-            factory.makeRecorder(for: url)
+        ) { url, settings in
+            factory.makeRecorder(for: url, settings: settings)
         }
     }
 
@@ -126,6 +145,7 @@ private final class AudioRecorderEngineFactorySpy {
     private let recoveryDirectoryURL: URL
     private(set) var engines: [FakeAudioRecorderEngine] = []
     private(set) var recordingFileURL: URL?
+    private(set) var recordingSettings: [String: Any]?
     var nextEngineRecordResult = true
     var writePlaceholderFileForNextEngine = false
 
@@ -137,7 +157,7 @@ private final class AudioRecorderEngineFactorySpy {
         self.recoveryDirectoryURL = recoveryDirectoryURL
     }
 
-    func makeRecorder(for url: URL) -> FakeAudioRecorderEngine {
+    func makeRecorder(for url: URL, settings: [String: Any]) -> FakeAudioRecorderEngine {
         let isRecordingArtifact = url.standardizedFileURL.path.hasPrefix(recoveryDirectoryURL.standardizedFileURL.path)
         let recordResult = isRecordingArtifact ? nextEngineRecordResult : true
 
@@ -154,6 +174,7 @@ private final class AudioRecorderEngineFactorySpy {
 
         if isRecordingArtifact {
             recordingFileURL = url
+            recordingSettings = settings
         }
 
         return engine


### PR DESCRIPTION
## Summary
- add an explicit microphone capture format selector with existing AAC as the default
- route debug-mode microphone capture through PCM WAV recovery artifacts for comparison
- cover WAV filename/settings selection in AudioRecorder tests

Closes #354

## Scope note
The repo no longer has unexpected-quit recovered-recording import; this implements the executable feature-flagged WAV-first capture path without changing production default behavior.

## Validation
- scripts/swift-parse-check.sh
- scripts/validate.sh
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AudioRecorderTests