### PR TITLE
refactor: consolidate Jira request construction and remove URL force-unwraps

### DIFF
--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -216,7 +216,7 @@ actor JiraExportProvider {
         var projects: [JiraProjectOption] = []
 
         while true {
-            let request = makeProjectSearchRequest(configuration: configuration, startAt: startAt)
+            let request = try makeProjectSearchRequest(configuration: configuration, startAt: startAt)
             let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
@@ -333,12 +333,13 @@ actor JiraExportProvider {
         exportFingerprint: String? = nil
     ) throws -> URLRequest {
         let endpoint = configuration.baseURL.appending(path: "rest/api/3/issue")
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue("Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: true
+        )
         request.httpBody = try JSONEncoder().encode(
             JiraIssueRequest(
                 fields: .init(
@@ -359,87 +360,71 @@ actor JiraExportProvider {
     private func makeProjectSearchRequest(
         configuration: JiraConnectionConfiguration,
         startAt: Int
-    ) -> URLRequest {
-        var components = URLComponents(
-            url: configuration.baseURL.appending(path: "rest/api/3/project/search"),
-            resolvingAgainstBaseURL: false
-        )!
-        components.queryItems = [
-            .init(name: "startAt", value: "\(startAt)"),
-            .init(name: "maxResults", value: "50")
-        ]
-
-        var request = URLRequest(url: components.url!)
-        request.httpMethod = "GET"
-        request.setValue(
-            "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-            forHTTPHeaderField: "Authorization"
+    ) throws -> URLRequest {
+        let url = try jiraRequestURL(
+            baseURL: configuration.baseURL,
+            path: "rest/api/3/project/search",
+            queryItems: [
+                .init(name: "startAt", value: "\(startAt)"),
+                .init(name: "maxResults", value: "50")
+            ]
         )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+
+        return authenticatedRequest(
+            url: url,
+            httpMethod: "GET",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: false
+        )
     }
 
     private func makeProjectIssueTypesRequest(
         configuration: JiraConnectionConfiguration,
         projectKey: String,
         projectID: String?
-    ) -> URLRequest {
+    ) throws -> URLRequest {
+        let url: URL
         if let normalizedProjectID = projectID?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
-            var components = URLComponents(
-                url: configuration.baseURL.appending(path: "rest/api/3/issuetype/project"),
-                resolvingAgainstBaseURL: false
-            )!
-            components.queryItems = [
-                .init(name: "projectId", value: normalizedProjectID)
-            ]
-
-            var request = URLRequest(url: components.url!)
-            request.httpMethod = "GET"
-            request.setValue(
-                "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-                forHTTPHeaderField: "Authorization"
+            url = try jiraRequestURL(
+                baseURL: configuration.baseURL,
+                path: "rest/api/3/issuetype/project",
+                queryItems: [.init(name: "projectId", value: normalizedProjectID)]
             )
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-            request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-            return request
+        } else {
+            url = configuration.baseURL.appending(path: "rest/api/3/project/\(projectKey)")
         }
 
-        let url = configuration.baseURL.appending(path: "rest/api/3/project/\(projectKey)")
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue(
-            "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-            forHTTPHeaderField: "Authorization"
+        return authenticatedRequest(
+            url: url,
+            httpMethod: "GET",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: false
         )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
     }
 
     private func makeCreateFieldMetadataRequest(
         configuration: JiraConnectionConfiguration,
         projectKey: String,
         issueTypeID: String
-    ) -> URLRequest {
-        var components = URLComponents(
-            url: configuration.baseURL.appending(path: "rest/api/3/issue/createmeta/\(projectKey)/issuetypes/\(issueTypeID)"),
-            resolvingAgainstBaseURL: false
-        )!
-        components.queryItems = [
-            .init(name: "startAt", value: "0"),
-            .init(name: "maxResults", value: "100")
-        ]
-
-        var request = URLRequest(url: components.url!)
-        request.httpMethod = "GET"
-        request.setValue(
-            "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-            forHTTPHeaderField: "Authorization"
+    ) throws -> URLRequest {
+        let url = try jiraRequestURL(
+            baseURL: configuration.baseURL,
+            path: "rest/api/3/issue/createmeta/\(projectKey)/issuetypes/\(issueTypeID)",
+            queryItems: [
+                .init(name: "startAt", value: "0"),
+                .init(name: "maxResults", value: "100")
+            ]
         )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+
+        return authenticatedRequest(
+            url: url,
+            httpMethod: "GET",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: false
+        )
     }
 
     private func fetchCreateIssueTypesPayload(
@@ -447,7 +432,7 @@ actor JiraExportProvider {
         projectID: String?,
         configuration: JiraConnectionConfiguration
     ) async throws -> JiraCreateMetaIssueTypesResponse {
-        let request = makeProjectIssueTypesRequest(
+        let request = try makeProjectIssueTypesRequest(
             configuration: configuration,
             projectKey: projectKey,
             projectID: projectID
@@ -484,7 +469,7 @@ actor JiraExportProvider {
         issueTypeID: String,
         configuration: JiraConnectionConfiguration
     ) async throws -> [JiraCreateFieldMetadata] {
-        let request = makeCreateFieldMetadataRequest(
+        let request = try makeCreateFieldMetadataRequest(
             configuration: configuration,
             projectKey: projectKey,
             issueTypeID: issueTypeID
@@ -544,15 +529,13 @@ actor JiraExportProvider {
         configuration: JiraExportConfiguration
     ) throws -> URLRequest {
         let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue(
-            "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-            forHTTPHeaderField: "Authorization"
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: true
         )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
         request.httpBody = try JSONEncoder().encode(
             JiraSearchRequest(
                 jql: searchJQL(for: issue, projectKey: configuration.projectKey),
@@ -568,15 +551,13 @@ actor JiraExportProvider {
         configuration: JiraExportConfiguration
     ) throws -> URLRequest {
         let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue(
-            "Basic \(basicAuthValue(email: configuration.email, apiToken: configuration.apiToken))",
-            forHTTPHeaderField: "Authorization"
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: true
         )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
         request.httpBody = try JSONEncoder().encode(
             JiraSearchRequest(
                 jql: #"project = \#(configuration.projectKey) AND description ~ "\"\#(TrackerExportFingerprint.marker(for: fingerprint))\"" ORDER BY created DESC"#,
@@ -590,6 +571,60 @@ actor JiraExportProvider {
     private func basicAuthValue(email: String, apiToken: String) -> String {
         let rawValue = "\(email):\(apiToken)"
         return Data(rawValue.utf8).base64EncodedString()
+    }
+
+    /// Builds a Jira request URL from the configured base URL, appending the
+    /// given path and optional query items. Throws a typed export error instead
+    /// of trapping when the base URL cannot be expressed as URL components.
+    private func jiraRequestURL(
+        baseURL: URL,
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) throws -> URL {
+        guard var components = URLComponents(
+            url: baseURL.appending(path: path),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw AppError.exportFailure(
+                "Could not build a Jira request URL from the configured base URL."
+            )
+        }
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw AppError.exportFailure(
+                "Could not build a Jira request URL from the configured base URL."
+            )
+        }
+
+        return url
+    }
+
+    /// Produces a Jira REST request with the shared Basic auth, Accept, and
+    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
+    /// that carry a JSON body.
+    private func authenticatedRequest(
+        url: URL,
+        httpMethod: String,
+        email: String,
+        apiToken: String,
+        includesJSONContentType: Bool
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        request.setValue(
+            "Basic \(basicAuthValue(email: email, apiToken: apiToken))",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if includesJSONContentType {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        return request
     }
 
     private func existingExportResult(


### PR DESCRIPTION
## Summary

Technical-debt cleanup in `JiraExportProvider.swift`. The seven Jira REST request builders each repeated identical Basic-auth / Accept / Content-Type / User-Agent header boilerplate (7× the auth header alone), and three of them force-unwrapped `URLComponents(url:resolvingAgainstBaseURL:)!` and `components.url!` while assembling query-string GET requests.

### Changes

- **New `authenticatedRequest(url:httpMethod:email:apiToken:includesJSONContentType:)`** — applies the shared headers in one place. Single source of truth for the Jira auth/header contract.
- **New `jiraRequestURL(baseURL:path:queryItems:)`** — builds the request URL and throws a typed `AppError.exportFailure` instead of trapping if URL components can't be formed. The three affected builders (`makeProjectSearchRequest`, `makeProjectIssueTypesRequest`, `makeCreateFieldMetadataRequest`) become `throws`; their callers already run inside `async throws` contexts, so the call-site change is a one-word `try`.

### Honesty note on scope

The Jira base URL is validated upstream in `SettingsStore.jiraBaseURLValue` (host required, scheme defaulted to `https`), so the removed `!` force-unwraps were **not a reachable crash in practice**. This is defensive hardening + de-duplication, not a user-facing bug fix — hence no CHANGELOG entry.

## Test plan

- [x] `xcodebuild … build` → **BUILD SUCCEEDED**
- [x] `xcodebuild … test -only-testing:BugNarratorTests/JiraExportProviderTests` → **13 tests, 0 failures**. This suite already exercises every rewritten builder: `testMakeURLRequestIncludesBasicAuthAndProjectFields` pins the exact header values through the new helper; `fetchProjects` / `fetchIssueTypes` / `validateConfiguration` exercise the three now-throwing GET builders.
- [x] `grep` confirms zero remaining force-unwraps and a single inline copy of the auth/User-Agent headers (inside the helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)