### PR TITLE
fix: signal saved OpenAI key in Settings credential field

### DIFF
--- a/Sources/BugNarrator/Views/AISetupSectionsView.swift
+++ b/Sources/BugNarrator/Views/AISetupSectionsView.swift
@@ -31,7 +31,7 @@ struct AISetupSectionsView: View {
                 } else {
                     labeledField(title: settingsStore.aiProvider.credentialFieldTitle) {
                         CredentialTokenField(
-                            placeholder: "sk-...",
+                            placeholder: aiProviderCredentialPlaceholder,
                             text: apiKeyBinding,
                             isDisabled: secureControlsDisabled,
                             accessibilityLabel: settingsStore.aiProvider.credentialFieldTitle
@@ -182,6 +182,17 @@ struct AISetupSectionsView: View {
             get: { settingsStore.apiKey },
             set: { settingsStore.apiKey = $0 }
         )
+    }
+
+    private var aiProviderCredentialPlaceholder: String {
+        switch settingsStore.selectedAIProviderCredentialPersistenceState {
+        case .keychain:
+            return "Stored in Keychain — type to replace"
+        case .keychainLocked:
+            return "Stored in Keychain — unlock to use"
+        case .empty, .sessionOnly, .pendingSave:
+            return "sk-..."
+        }
     }
 
     private var transcriptionModelSelection: Binding<String> {


### PR DESCRIPTION
## Summary
- Settings → AI Provider Setup showed an empty "sk-..." placeholder in the OpenAI API key field even when a key was already saved in the Keychain, making the UI look identical to a fresh install while the Setup Status badge correctly reported "Ready".
- The actual secret is intentionally not loaded into memory from the Keychain (retrieval requires user interaction), so the field has no value to render — but the placeholder can carry the signal.
- Switch the placeholder to reflect persistence state:
  - `.keychain` → **"Stored in Keychain — type to replace"**
  - `.keychainLocked` → **"Stored in Keychain — unlock to use"**
  - otherwise → **"sk-..."** (unchanged)
- No behavior change beyond the placeholder text; no secret material is exposed; GitHub/Jira credential fields are unaffected (they round-trip their values into memory and already render masked).

## Files changed
- `Sources/BugNarrator/Views/AISetupSectionsView.swift` — replace literal placeholder with computed `aiProviderCredentialPlaceholder`.

## Test plan
- [x] `xcodebuild -scheme BugNarrator -only-testing:BugNarratorTests test` → **559/559 pass**
- [x] `./scripts/validate.sh` → **PASS** (semgrep, swift-parse, effort-leak, repo-docs, local-transcription syntax)
- [ ] Manual: open Settings with an existing Keychain-saved OpenAI key, verify the placeholder reads "Stored in Keychain — type to replace"
- [ ] Manual: remove the key, verify the placeholder reverts to "sk-..."
- [ ] Manual: with a Touch-ID-locked Keychain entry, verify the "unlock to use" placeholder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)