### PR TITLE
refactor: consolidate GitHub request header construction

### DIFF
--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -291,12 +291,12 @@ actor GitHubExportProvider {
     ) throws -> URLRequest {
         let endpoint = issueEndpoint(configuration: configuration)
 
-        var request = URLRequest(url: endpoint)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(configuration.token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            token: configuration.token,
+            includesJSONContentType: true
+        )
         request.httpBody = try JSONEncoder().encode(
             GitHubIssueRequest(
                 title: issue.title,
@@ -314,12 +314,12 @@ actor GitHubExportProvider {
     private func makeRepositoryValidationRequest(
         configuration: GitHubExportConfiguration
     ) throws -> URLRequest {
-        var request = URLRequest(url: repositoryEndpoint(configuration: configuration))
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(configuration.token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+        return authenticatedRequest(
+            url: repositoryEndpoint(configuration: configuration),
+            httpMethod: "GET",
+            token: configuration.token,
+            includesJSONContentType: false
+        )
     }
 
     private func makeRepositoryListRequest(
@@ -334,12 +334,12 @@ actor GitHubExportProvider {
             .init(name: "page", value: "\(page)")
         ]
 
-        var request = URLRequest(url: try url(from: components))
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: token,
+            includesJSONContentType: false
+        )
     }
 
     private func makeSearchRequest(
@@ -354,12 +354,12 @@ actor GitHubExportProvider {
             URLQueryItem(name: "per_page", value: "5")
         ]
 
-        var request = URLRequest(url: try url(from: components))
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(configuration.token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: configuration.token,
+            includesJSONContentType: false
+        )
     }
 
     private func makeExportFingerprintSearchRequest(
@@ -373,12 +373,12 @@ actor GitHubExportProvider {
             URLQueryItem(name: "per_page", value: "1")
         ]
 
-        var request = URLRequest(url: try url(from: components))
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(configuration.token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: configuration.token,
+            includesJSONContentType: false
+        )
     }
 
     private func makeIssueBody(
@@ -683,6 +683,26 @@ actor GitHubExportProvider {
         }
 
         return url
+    }
+
+    /// Produces a GitHub REST request with the shared Bearer auth, Accept, and
+    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
+    /// that carry a JSON body.
+    private func authenticatedRequest(
+        url: URL,
+        httpMethod: String,
+        token: String,
+        includesJSONContentType: Bool
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        if includesJSONContentType {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        return request
     }
 
     private func repositoryEndpoint(configuration: GitHubExportConfiguration) -> URL {


### PR DESCRIPTION
## Summary

Follow-up to #394, applying the same pattern to `GitHubExportProvider.swift`. The five GitHub REST request builders each repeated identical Bearer-auth / Accept / Content-Type / User-Agent header boilerplate. Extracted a private `authenticatedRequest(url:httpMethod:token:includesJSONContentType:)` helper so the header contract has a single source of truth.

### Scope note

Pure de-duplication. Unlike the Jira side, the GitHub builders **already** routed query-string URLs through the existing `url(from:)` throwing helper, so there were no URL force-unwraps to remove here. No behavior change — hence `chore:trivial`, no CHANGELOG entry.

## Test plan

- [x] `xcodebuild … build` → **BUILD SUCCEEDED**
- [x] `xcodebuild … test -only-testing:BugNarratorTests/GitHubExportProviderTests` → **8 tests, 0 failures**. `testMakeURLRequestIncludesAuthorizationAndIssueBody` and `testValidateConfigurationChecksRepositoryAccess` pin the exact `Authorization: Bearer …` / `User-Agent: BugNarrator` header values now produced by the helper; `testFindOpenIssues…` and `testFetchRepositories…` exercise the GET search/list builders.
- [x] `grep` confirms each header string now appears exactly once (inside the helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)