### PR TITLE
refactor: extract shared annotated-screenshot gathering (#397 step 1)

### DIFF
--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -593,34 +593,12 @@ actor GitHubExportProvider {
     }
 
     private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
-        let screenshots = session.screenshots(for: issue).filter {
-            !issue.screenshotAnnotations(for: $0.id).isEmpty
-        }
-
-        guard !screenshots.isEmpty else {
-            return []
-        }
-
-        let annotationDirectoryURL = session.artifactsDirectoryURL?.appendingPathComponent(
-            "annotated-exports",
-            isDirectory: true
-        )
-
-        return try screenshots.map { screenshot in
-            let renderedAsset = try annotationDirectoryURL.flatMap {
-                try annotationRenderer.writeAnnotatedScreenshot(
-                    for: issue,
-                    screenshot: screenshot,
-                    to: $0
-                )
-            }
-            let summaries = issue.screenshotAnnotations(for: screenshot.id).map(\.exportDescription).joined(separator: "; ")
-
-            if let renderedAsset {
-                return "- \(renderedAsset.fileName) from `\(screenshot.fileName)` (`\(screenshot.timeLabel)`) — \(summaries)"
+        try annotationRenderer.annotatedScreenshotExports(for: issue, session: session).map { export in
+            if let renderedFileName = export.renderedFileName {
+                return "- \(renderedFileName) from `\(export.screenshotFileName)` (`\(export.timeLabel)`) — \(export.summaries)"
             }
 
-            return "- \(screenshot.fileName) (`\(screenshot.timeLabel)`) — \(summaries)"
+            return "- \(export.screenshotFileName) (`\(export.timeLabel)`) — \(export.summaries)"
         }
     }
 

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -886,34 +886,12 @@ actor JiraExportProvider {
     }
 
     private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
-        let screenshots = session.screenshots(for: issue).filter {
-            !issue.screenshotAnnotations(for: $0.id).isEmpty
-        }
-
-        guard !screenshots.isEmpty else {
-            return []
-        }
-
-        let annotationDirectoryURL = session.artifactsDirectoryURL?.appendingPathComponent(
-            "annotated-exports",
-            isDirectory: true
-        )
-
-        return try screenshots.map { screenshot in
-            let renderedAsset = try annotationDirectoryURL.flatMap {
-                try annotationRenderer.writeAnnotatedScreenshot(
-                    for: issue,
-                    screenshot: screenshot,
-                    to: $0
-                )
-            }
-            let summaries = issue.screenshotAnnotations(for: screenshot.id).map(\.exportDescription).joined(separator: "; ")
-
-            if let renderedAsset {
-                return "\(renderedAsset.fileName) from \(screenshot.fileName) (\(screenshot.timeLabel)) - \(summaries)"
+        try annotationRenderer.annotatedScreenshotExports(for: issue, session: session).map { export in
+            if let renderedFileName = export.renderedFileName {
+                return "\(renderedFileName) from \(export.screenshotFileName) (\(export.timeLabel)) - \(export.summaries)"
             }
 
-            return "\(screenshot.fileName) (\(screenshot.timeLabel)) - \(summaries)"
+            return "\(export.screenshotFileName) (\(export.timeLabel)) - \(export.summaries)"
         }
     }
 

--- a/Sources/BugNarrator/Utilities/IssueScreenshotAnnotationRenderer.swift
+++ b/Sources/BugNarrator/Utilities/IssueScreenshotAnnotationRenderer.swift
@@ -11,11 +11,65 @@ struct RenderedIssueScreenshotAsset: Equatable {
     }
 }
 
+/// One annotated screenshot resolved for export: the rendered asset's file
+/// name (nil when no annotated asset could be written), plus the source
+/// screenshot's file name, time label, and the joined annotation summaries.
+/// Tracker providers format these fields into their own line syntax.
+struct AnnotatedScreenshotExport: Equatable {
+    let renderedFileName: String?
+    let screenshotFileName: String
+    let timeLabel: String
+    let summaries: String
+}
+
 struct IssueScreenshotAnnotationRenderer {
     private let fileManager: FileManager
 
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
+    }
+
+    /// Gathers the annotated screenshots for an issue, rendering each annotated
+    /// asset into the session's `annotated-exports` directory, and returns the
+    /// per-screenshot fields tracker providers need to build export lines. The
+    /// gathering/rendering logic is shared; each provider applies its own line
+    /// formatting to the returned values.
+    func annotatedScreenshotExports(
+        for issue: ExtractedIssue,
+        session: TranscriptSession
+    ) throws -> [AnnotatedScreenshotExport] {
+        let screenshots = session.screenshots(for: issue).filter {
+            !issue.screenshotAnnotations(for: $0.id).isEmpty
+        }
+
+        guard !screenshots.isEmpty else {
+            return []
+        }
+
+        let annotationDirectoryURL = session.artifactsDirectoryURL?.appendingPathComponent(
+            "annotated-exports",
+            isDirectory: true
+        )
+
+        return try screenshots.map { screenshot in
+            let renderedAsset = try annotationDirectoryURL.flatMap {
+                try writeAnnotatedScreenshot(
+                    for: issue,
+                    screenshot: screenshot,
+                    to: $0
+                )
+            }
+            let summaries = issue.screenshotAnnotations(for: screenshot.id)
+                .map(\.exportDescription)
+                .joined(separator: "; ")
+
+            return AnnotatedScreenshotExport(
+                renderedFileName: renderedAsset?.fileName,
+                screenshotFileName: screenshot.fileName,
+                timeLabel: screenshot.timeLabel,
+                summaries: summaries
+            )
+        }
     }
 
     func writeAnnotatedScreenshot(

--- a/Tests/BugNarratorTests/ScreenshotAnnotationTests.swift
+++ b/Tests/BugNarratorTests/ScreenshotAnnotationTests.swift
@@ -55,6 +55,60 @@ final class ScreenshotAnnotationTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: asset?.fileURL.path ?? ""))
         XCTAssertTrue(asset?.fileName.contains("annotated") == true)
     }
+
+    func testAnnotatedScreenshotExportsGathersOnlyAnnotatedScreenshots() throws {
+        let annotatedURL = makeScreenshotFileURL(named: "exports-annotated.png")
+        let annotatedScreenshot = SessionScreenshot(elapsedTime: 12, filePath: annotatedURL.path)
+        let plainURL = makeScreenshotFileURL(named: "exports-plain.png")
+        let plainScreenshot = SessionScreenshot(elapsedTime: 20, filePath: plainURL.path)
+        let issue = ExtractedIssue(
+            title: "Submit button does not respond",
+            category: .bug,
+            summary: "The highlighted submit button does not respond.",
+            evidenceExcerpt: "The submit button never reacts to clicks.",
+            timestamp: 12,
+            relatedScreenshotIDs: [annotatedScreenshot.id, plainScreenshot.id],
+            screenshotAnnotations: [
+                IssueScreenshotAnnotation(
+                    screenshotID: annotatedScreenshot.id,
+                    label: "Submit button",
+                    x: 0.42,
+                    y: 0.56,
+                    width: 0.22,
+                    height: 0.16
+                )
+            ]
+        )
+        let artifactsDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 30,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            screenshots: [annotatedScreenshot, plainScreenshot],
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue]),
+            artifactsDirectoryPath: artifactsDirectory.path
+        )
+
+        let exports = try IssueScreenshotAnnotationRenderer()
+            .annotatedScreenshotExports(for: issue, session: session)
+
+        // The screenshot without annotations is filtered out.
+        XCTAssertEqual(exports.count, 1)
+        let export = try XCTUnwrap(exports.first)
+        XCTAssertEqual(export.screenshotFileName, annotatedScreenshot.fileName)
+        XCTAssertEqual(export.timeLabel, annotatedScreenshot.timeLabel)
+        // Summaries are joined exactly as the providers render them.
+        let expectedSummaries = issue.screenshotAnnotations(for: annotatedScreenshot.id)
+            .map(\.exportDescription)
+            .joined(separator: "; ")
+        XCTAssertEqual(export.summaries, expectedSummaries)
+        // An annotated asset was rendered into the artifacts directory.
+        XCTAssertEqual(export.renderedFileName?.contains("annotated"), true)
+    }
 }
 
 private func makeScreenshotFileURL(named fileName: String) -> URL {


### PR DESCRIPTION
Part of #397 (extract shared tracker-export logic) — **step 1 of the staged plan**, the lowest-risk slice.

## Summary

`JiraExportProvider` and `GitHubExportProvider` had an identical `annotatedScreenshotLines` body — filter the issue's annotated screenshots, render each annotated asset into the session's `annotated-exports` dir, join the annotation summaries — differing only in the final per-line string format (Jira: plain hyphen; GitHub: Markdown list item with backticks + em-dash).

- Moved the shared gathering/rendering into `IssueScreenshotAnnotationRenderer.annotatedScreenshotExports(for:session:)` → `[AnnotatedScreenshotExport]` (`renderedFileName`, `screenshotFileName`, `timeLabel`, `summaries`).
- Each provider's `annotatedScreenshotLines` is now a thin `.map` applying its own format — **byte-identical output preserved** on both sides (verified line-by-line against the originals).
- The exact line format was previously **unpinned by any test**. Added a characterization test on the shared method (filters unannotated screenshots, joins summaries identically to production, renders the annotated asset) — this guards both this extraction and the larger coordinator work to come in #397.

## Test plan

- [x] `xcodebuild … build` → **BUILD SUCCEEDED**
- [x] `JiraExportProviderTests` (13) + `GitHubExportProviderTests` (8) pass **unchanged**
- [x] `ScreenshotAnnotationTests` (3, incl. new `testAnnotatedScreenshotExportsGathersOnlyAnnotatedScreenshots`) pass
- [x] Manual line-by-line diff confirms each provider's emitted strings are unchanged (hyphen vs backtick/em-dash literals preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)