### PR TITLE
test: cover GitHub export pending-receipt reconciliation path

### DIFF
--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -352,6 +352,82 @@ final class GitHubExportProviderTests: XCTestCase {
             XCTAssertTrue(message.contains("Validation Failed"))
         }
     }
+
+    func testExportReconcilesPendingReceiptInsteadOfCreatingDuplicate() async throws {
+        let issue = ExtractedIssue(
+            title: "Login button is disabled",
+            category: .bug,
+            summary: "The login button never enables after valid input.",
+            evidenceExcerpt: "The login button stayed disabled after I entered a valid email.",
+            timestamp: nil
+        )
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 30,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+        let configuration = GitHubExportConfiguration(
+            token: "fixture-github-token",
+            owner: "acme",
+            repository: "bugnarrator",
+            labels: []
+        )
+
+        // A prior attempt left a pending receipt for this issue's fingerprint.
+        let fingerprint = TrackerExportFingerprint.make(
+            destination: .github,
+            targetIdentity: configuration.targetIdentity,
+            sessionID: session.id,
+            issueID: issue.id
+        )
+        let receiptStore = StubExportReceiptStore()
+        await receiptStore.seedPending(
+            fingerprint: fingerprint,
+            sourceIssueID: issue.id,
+            destination: .github,
+            targetIdentity: configuration.targetIdentity
+        )
+        let provider = GitHubExportProvider(session: makeMockURLSession(), receiptStore: receiptStore)
+
+        let marker = TrackerExportFingerprint.marker(for: fingerprint)
+        MockURLProtocol.requestHandler = { request in
+            // Reconciliation must locate the existing issue via a search GET and
+            // never POST a duplicate create request.
+            XCTAssertEqual(request.httpMethod, "GET")
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = Data(
+                #"{"items":[{"number":77,"title":"Login button stuck disabled","body":"Tracked \#(marker)","html_url":"https://github.com/acme/bugnarrator/issues/77"}]}"#.utf8
+            )
+            return (response, data)
+        }
+
+        let results = try await provider.export(
+            issues: [issue],
+            session: session,
+            configuration: configuration
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.remoteIdentifier, "#77")
+        XCTAssertEqual(
+            results.first?.remoteURL,
+            URL(string: "https://github.com/acme/bugnarrator/issues/77")
+        )
+
+        // The pending receipt was reconciled to succeeded exactly once.
+        let succeededCalls = await receiptStore.markSucceededCalls
+        XCTAssertEqual(succeededCalls.count, 1)
+        XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "#77")
+    }
 }
 
 private struct GitHubIssueRequestPayload: Decodable {

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -932,6 +932,84 @@ func makeMockURLSession() -> URLSession {
     return URLSession(configuration: configuration)
 }
 
+/// In-memory `ExportReceiptStoring` for tests that need to drive the receipt
+/// lifecycle — e.g. seeding a `.pending` receipt to exercise the reconcile
+/// path — without the file-backed production store. Records `markSucceeded`
+/// calls so a test can assert reconciliation occurred.
+actor StubExportReceiptStore: ExportReceiptStoring {
+    private(set) var receipts: [String: ExportReceipt] = [:]
+    private(set) var markSucceededCalls: [(fingerprint: String, remoteIdentifier: String)] = []
+
+    func seedPending(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        destination: ExportDestination,
+        targetIdentity: String
+    ) {
+        receipts[fingerprint] = ExportReceipt(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            destination: destination,
+            targetIdentity: targetIdentity,
+            state: .pending,
+            remoteIdentifier: nil,
+            remoteURL: nil,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func receipt(for fingerprint: String) async -> ExportReceipt? {
+        receipts[fingerprint]
+    }
+
+    func allReceipts() async -> [ExportReceipt] {
+        Array(receipts.values)
+    }
+
+    func markPending(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        destination: ExportDestination,
+        targetIdentity: String
+    ) async throws {
+        receipts[fingerprint] = ExportReceipt(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            destination: destination,
+            targetIdentity: targetIdentity,
+            state: .pending,
+            remoteIdentifier: nil,
+            remoteURL: nil,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func markSucceeded(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        destination: ExportDestination,
+        targetIdentity: String,
+        remoteIdentifier: String,
+        remoteURL: URL?
+    ) async throws {
+        markSucceededCalls.append((fingerprint, remoteIdentifier))
+        receipts[fingerprint] = ExportReceipt(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            destination: destination,
+            targetIdentity: targetIdentity,
+            state: .succeeded,
+            remoteIdentifier: remoteIdentifier,
+            remoteURL: remoteURL,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    func clearReceipt(for fingerprint: String) async throws {
+        receipts.removeValue(forKey: fingerprint)
+    }
+}
+
 func requestBodyData(from request: URLRequest) throws -> Data {
     if let httpBody = request.httpBody {
         return httpBody


### PR DESCRIPTION
## Summary

The export **reconcile** path — where a prior attempt left a `.pending` receipt and a retry locates the already-created issue via a fingerprint search instead of POSTing a duplicate — had **no test** on either provider. The existing provider tests inject only a mock `URLSession` and fall back to the real file-backed receipt store, so they can't drive a pending-receipt scenario.

- Added a reusable in-memory `StubExportReceiptStore` to `TestSupport.swift` (conforms to `ExportReceiptStoring`, seedable with a pending receipt, records `markSucceeded` calls).
- Added `testExportReconcilesPendingReceiptInsteadOfCreatingDuplicate` to the GitHub suite: seeds a pending receipt for the issue's computed fingerprint, drives `export(...)`, and asserts it reconciles via a **search GET** — returning the existing issue (`#77`, with its `html_url`) and marking the receipt succeeded — while asserting **no create POST** is ever issued.

Pure test addition — **no production code change**. Closes the coverage gap I flagged on #397, and de-risks any future shared-coordinator extraction of this exact logic.

## Test plan

- [x] `xcodebuild … test -only-testing:BugNarratorTests/GitHubExportProviderTests` → **9 tests, 0 failures** (8 prior + the new reconcile test). Full app+test compile succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)