### PR TITLE
Fix OpenAI credential setup state (#402)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -1040,7 +1040,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -1063,7 +1063,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 36;
+				CURRENT_PROJECT_VERSION = 37;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1072,7 +1072,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [FIX] Refreshed menu-bar AI setup state when the saved OpenAI credential changes, so Settings and the menu no longer disagree about a usable key.
 - [FIX] Blocked recording starts until AI transcription setup is usable, defaulted fresh installs to English transcription hints, and added transcript quality warnings for wrong-script output.
 - [INTERNAL] Split AI setup, transcription defaults, and issue extraction settings into an encapsulated SwiftUI section with UI coverage.
 - [INTERNAL] Added a repository docs audit to keep maintainer docs aligned with the local-first validation path and CI unit-test scope.

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -529,6 +529,7 @@ final class AppState: ObservableObject {
 
         objectChangeForwarder.forward(
             [
+                settingsStore.objectWillChange,
                 trackerIntegration.objectWillChange,
                 aiProviderSettings.objectWillChange,
                 presentationState.objectWillChange,

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -25,6 +25,24 @@ final class AppStateTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(appStateChangeCount, 2)
     }
 
+    func testSettingsStoreChangesInvalidateMenuFacingSetupState() {
+        let harness = AppStateHarness(apiKey: "")
+        defer { harness.cleanup() }
+
+        XCTAssertTrue(harness.appState.needsAPIKeySetup)
+
+        var appStateChangeCount = 0
+        let cancellable = harness.appState.objectWillChange.sink {
+            appStateChangeCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        harness.settingsStore.apiKey = "fixture-openai-key"
+
+        XCTAssertFalse(harness.appState.needsAPIKeySetup)
+        XCTAssertGreaterThanOrEqual(appStateChangeCount, 1)
+    }
+
     func testRecordingControlsStartFlowShowsPanelAndStartsSession() async {
         let harness = AppStateHarness()
         defer { harness.cleanup() }

--- a/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
+++ b/Tests/BugNarratorUITests/BugNarratorSettingsUITests.swift
@@ -35,6 +35,27 @@ final class BugNarratorSettingsUITests: XCTestCase {
     }
 
     @MainActor
+    func testSavedOpenAIKeyKeepsSettingsCredentialActionsEnabled() throws {
+        let app = launchSettingsApp(scope: "saved-openai-key-actions", seedCredentials: true)
+        defer { app.terminate() }
+
+        let settingsWindow = app.windows["BugNarrator Settings"]
+        XCTAssertTrue(settingsWindow.waitForExistence(timeout: 5))
+        waitForSettingsLayout()
+
+        XCTAssertTrue(app.descendants(matching: .any)["AI provider status: Ready"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Saved key"].waitForExistence(timeout: 5))
+
+        let validateKeyButton = app.buttons["Validate Key"]
+        XCTAssertTrue(waitForSettingsElement(validateKeyButton, in: settingsWindow))
+        XCTAssertTrue(validateKeyButton.isEnabled)
+
+        let removeKeyButton = app.buttons["Remove Key"]
+        XCTAssertTrue(waitForSettingsElement(removeKeyButton, in: settingsWindow))
+        XCTAssertTrue(removeKeyButton.isEnabled)
+    }
+
+    @MainActor
     func testSettingsCredentialFieldsAcceptTypingWithoutLockingWindow() throws {
         let app = launchSettingsApp(scope: "credential-fields-editable")
         defer { app.terminate() }
@@ -282,8 +303,17 @@ final class BugNarratorSettingsUITests: XCTestCase {
     }
 
     @MainActor
-    private func launchSettingsApp(scope: String, launchAtLoginStatus: String = "disabled") -> XCUIApplication {
-        launchApp(scope: scope, openSettings: true, launchAtLoginStatus: launchAtLoginStatus)
+    private func launchSettingsApp(
+        scope: String,
+        launchAtLoginStatus: String = "disabled",
+        seedCredentials: Bool = false
+    ) -> XCUIApplication {
+        launchApp(
+            scope: scope,
+            openSettings: true,
+            seedSessionLibrary: seedCredentials,
+            launchAtLoginStatus: launchAtLoginStatus
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Forward SettingsStore changes through AppState so menu-bar setup state refreshes when OpenAI credential readiness changes
- Add AppState and Settings UI regression coverage for saved OpenAI key readiness and enabled credential actions
- Bump macOS release version to 1.0.37 for the signed deployment

Closes #402

## Validation
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests/testSettingsStoreChangesInvalidateMenuFacingSetupState CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests/testSettingsStoreChangesInvalidateMenuFacingSetupState -only-testing:BugNarratorTests/SettingsStoreTests CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorUITests/BugNarratorSettingsUITests/testSavedOpenAIKeyKeepsSettingsCredentialActionsEnabled CODE_SIGNING_ALLOWED=NO
- xcodebuild test -project BugNarrator.xcodeproj -scheme BugNarrator -destination 'platform=macOS' -only-testing:BugNarratorTests/AppStateTests/testSettingsStoreChangesInvalidateMenuFacingSetupState -only-testing:BugNarratorTests/SettingsStoreTests -only-testing:BugNarratorUITests/BugNarratorSettingsUITests/testSavedOpenAIKeyKeepsSettingsCredentialActionsEnabled CODE_SIGNING_ALLOWED=NO
- ./scripts/validate.sh origin/main

## Security
- Diff secret scan clean
- No GitHub security finding addressed in this scoped fix
