### PR TITLE
Fix recording reliability, credential display, and Parakeet readiness

### DIFF
--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -274,7 +274,19 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         }
     }
 
-    func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+    nonisolated func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.handleRecordingFinished(successfully: flag)
+        }
+    }
+
+    nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: (any Error)?) {
+        Task { @MainActor [weak self] in
+            self?.handleEncoderError(error)
+        }
+    }
+
+    private func handleRecordingFinished(successfully flag: Bool) {
         let stopContinuation = self.stopContinuation
         let cancelContinuation = self.cancelContinuation
         let pendingStopResult = self.pendingStopResult
@@ -318,7 +330,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         }
     }
 
-    func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: (any Error)?) {
+    private func handleEncoderError(_ error: (any Error)?) {
         let stopContinuation = self.stopContinuation
         let cancelContinuation = self.cancelContinuation
         let isCancelling = self.isCancelling
@@ -364,9 +376,12 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
                 return
             }
 
-            guard !Task.isCancelled, let stopContinuation else {
-                return
-            }
+            guard !Task.isCancelled else { return }
+
+            // Capture and nil-swap the continuation atomically so the delegate
+            // callback cannot also resume it if it fires on the next run-loop tick.
+            guard let continuation = self.stopContinuation else { return }
+            self.stopContinuation = nil
 
             recordingLogger.error(
                 "recording_finalize_timeout",
@@ -374,7 +389,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
                 metadata: ["file_name": fileName]
             )
             cleanup()
-            stopContinuation.resume(
+            continuation.resume(
                 throwing: AppError.recordingFailure("The recorded audio file did not finish finalizing before the timeout.")
             )
         }
@@ -390,9 +405,10 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
                 return
             }
 
-            guard !Task.isCancelled, let cancelContinuation else {
-                return
-            }
+            guard !Task.isCancelled else { return }
+
+            guard let continuation = self.cancelContinuation else { return }
+            self.cancelContinuation = nil
 
             recordingLogger.warning(
                 "recording_cancel_timeout",
@@ -400,7 +416,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
                 metadata: ["file_name": fileName]
             )
             cleanup()
-            cancelContinuation.resume()
+            continuation.resume()
         }
     }
 

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -164,10 +164,12 @@ final class MixedAudioRecorder: AudioRecording {
     }
 
     func cancelRecording(preserveFile: Bool) async {
-        guard isRecording, !isStopping else {
+        guard isRecording else {
             return
         }
 
+        // Allow cancel to override a hung stop so the user is never trapped.
+        isStopping = false
         isRecording = false
         sourceStartTimes = nil
         await microphoneRecorder.cancelRecording(preserveFile: preserveFile)

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -1726,6 +1726,14 @@ final class SettingsStore: ObservableObject {
         allowsLegacyOpenAICredential: Bool
     ) -> Bool {
         guard let savedProvider = savedAIProviderCredentialProvider else {
+            // Legacy credential with no provider tag. Accept it for any
+            // provider that uses the OpenAI credential slot and tag it
+            // so future checks are fast.
+            let credentialExists = apiKeyPersistenceState == .keychain || apiKeyPersistenceState == .keychainLocked
+            if credentialExists && aiProvider.requiresAPIKey {
+                defaults.set(aiProvider.rawValue, forKey: Keys.aiProviderCredentialProvider)
+                return true
+            }
             return allowsLegacyOpenAICredential && aiProvider == .openAI
         }
 


### PR DESCRIPTION
## Summary

- **Recording reliability**: Dispatch AVAudioRecorder delegate callbacks to MainActor explicitly to prevent data races between delegate and timeout handlers. Use atomic nil-swap for continuations to prevent double-resume crashes.
- **Cancel deadlock**: Allow MixedAudioRecorder cancel to override a hung stop so the user is never trapped.
- **Credential display**: Fix legacy Keychain entries showing "No key saved" after provider tagging was added. Untagged credentials are now recognized and tagged on first access.
- **Parakeet verified**: Local transcription server confirmed working end-to-end with BugNarrator's exact request format.

## Test plan

- [x] 562 unit tests pass, 0 failures
- [x] Parakeet server health, models, and transcription endpoints verified
- [x] No UI tests run (user is actively using the machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)