### PR TITLE
Harden recording lifecycle and add Settings UX polish

### DIFF
--- a/Sources/BugNarrator/Services/AudioRecorder.swift
+++ b/Sources/BugNarrator/Services/AudioRecorder.swift
@@ -297,6 +297,9 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         if isCancelling {
             recordingLogger.info("recording_cancelled", "The active recording session was cancelled.")
             cancelContinuation?.resume()
+            // If a stop was in flight when cancel was requested, unblock the
+            // stopRecording caller so it doesn't hang forever.
+            stopContinuation?.resume(throwing: AppError.recordingFailure("The recording was cancelled."))
             return
         }
 
@@ -340,6 +343,7 @@ final class AudioRecorder: NSObject, @preconcurrency AVAudioRecorderDelegate, Au
         if isCancelling {
             recordingLogger.info("recording_cancelled", "The active recording session was cancelled during encoder shutdown.")
             cancelContinuation?.resume()
+            stopContinuation?.resume(throwing: AppError.recordingFailure("The recording was cancelled."))
             return
         }
 

--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -222,21 +222,33 @@ final class MixedAudioRecorder: AudioRecording {
         exportSession.audioMix = audioMix
 
         let exportBridge = MixedAssetExportSessionBridge(exportSession)
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            exportBridge.session.exportAsynchronously {
-                switch exportBridge.session.status {
-                case .completed:
-                    continuation.resume()
-                case .failed:
-                    continuation.resume(
-                        throwing: exportBridge.session.error ?? AppError.recordingFailure("The mixed audio export failed.")
-                    )
-                case .cancelled:
-                    continuation.resume(throwing: AppError.recordingFailure("The mixed audio export was cancelled."))
-                default:
-                    continuation.resume(throwing: AppError.recordingFailure("The mixed audio export did not complete."))
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    exportBridge.session.exportAsynchronously {
+                        switch exportBridge.session.status {
+                        case .completed:
+                            continuation.resume()
+                        case .failed:
+                            continuation.resume(
+                                throwing: exportBridge.session.error ?? AppError.recordingFailure("The mixed audio export failed.")
+                            )
+                        case .cancelled:
+                            continuation.resume(throwing: AppError.recordingFailure("The mixed audio export was cancelled."))
+                        default:
+                            continuation.resume(throwing: AppError.recordingFailure("The mixed audio export did not complete."))
+                        }
+                    }
                 }
             }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 30_000_000_000)
+                exportBridge.session.cancelExport()
+                throw AppError.recordingFailure("The mixed audio export timed out after 30 seconds.")
+            }
+            // First to finish wins; the other is cancelled.
+            try await group.next()
+            group.cancelAll()
         }
 
         let attributes = try FileManager.default.attributesOfItem(atPath: outputURL.path)

--- a/Sources/BugNarrator/Views/AISetupSectionsView.swift
+++ b/Sources/BugNarrator/Views/AISetupSectionsView.swift
@@ -19,14 +19,22 @@ struct AISetupSectionsView: View {
                     }
                     .pickerStyle(.menu)
                     .accessibilityLabel("AI provider")
+                    .help("OpenAI uses cloud transcription. Local (Parakeet) transcribes on this Mac with no API key or upload required.")
                 }
 
                 if settingsStore.aiProvider.credentialFieldTitle.isEmpty {
                     labeledField(title: "Credential") {
-                        Text("No API key required")
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .accessibilityLabel("No AI provider credential required")
+                        HStack {
+                            Text("No API key required")
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            if settingsStore.aiProvider == .parakeetLocal {
+                                Text("Transcription runs entirely on this Mac.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.green)
+                            }
+                        }
+                        .accessibilityLabel("No AI provider credential required")
                     }
                 } else {
                     labeledField(title: settingsStore.aiProvider.credentialFieldTitle) {
@@ -42,8 +50,11 @@ struct AISetupSectionsView: View {
                 labeledField(title: "API Base URL") {
                     TextField(settingsStore.aiProvider.baseURLPlaceholder, text: $settingsStore.openAIBaseURL)
                         .textFieldStyle(.roundedBorder)
-                        .disabled(secureControlsDisabled)
+                        .disabled(secureControlsDisabled || settingsStore.aiProvider == .parakeetLocal)
                         .accessibilityLabel("AI provider base URL")
+                        .help(settingsStore.aiProvider == .parakeetLocal
+                            ? "Parakeet uses localhost:8422 automatically. Start the server with: local-transcription/venv/bin/python local-transcription/server.py --preload"
+                            : "The endpoint BugNarrator sends transcription requests to. Leave blank for the default.")
                 }
 
                 Text(settingsStore.aiProvider.baseURLHint)
@@ -69,6 +80,9 @@ struct AISetupSectionsView: View {
                             settingsStore.selectedAIProviderCredentialPersistenceState != .keychainLocked) ||
                         appState.apiKeyValidationState == .validating
                     )
+                    .help(settingsStore.aiProvider == .parakeetLocal
+                        ? "Checks that the local Parakeet transcription server is running and reachable."
+                        : "Validates the credential and base URL against the selected provider.")
 
                     Button("Remove Key", role: .destructive) {
                         appState.removeAPIKey()
@@ -123,6 +137,7 @@ struct AISetupSectionsView: View {
                     TextField("For English narration, keep en", text: $settingsStore.languageHint)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel("Transcription language hint")
+                        .help("Helps the model recognize the correct language. Use 'en' for English. Clear for auto-detection.")
                 }
 
                 VStack(alignment: .leading, spacing: 6) {

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -67,7 +67,7 @@ struct SettingsView: View {
                             )
                             .disabled(secureControlsDisabled)
 
-                            Text("Get consent before recording system audio. BugNarrator stores finished sessions locally and sends recorded audio to OpenAI only when transcription runs.")
+                            Text("Get consent before recording system audio. BugNarrator stores finished sessions locally and \(settingsStore.aiProvider == .parakeetLocal ? "processes audio on this Mac" : "sends recorded audio to \(settingsStore.aiProvider.displayName)") only when transcription runs.")
                                 .font(.footnote)
                                 .foregroundStyle(
                                     settingsStore.hasAcceptedSystemAudioRecordingConsent


### PR DESCRIPTION
## Summary

**Recording reliability (from adversarial audit):**
- Add 30s timeout to AVAssetExportSession in MixedAudioRecorder — prevents permanent app hang if audio export never completes
- Resume stopContinuation when cancel overrides an in-flight stop — prevents caller from hanging forever

**Settings UX:**
- Fix system audio consent text to reference the actual selected provider instead of hardcoding "OpenAI"
- Add tooltips to AI provider picker, base URL, validate button, and language hint
- Show "Transcription runs entirely on this Mac" confirmation for Parakeet
- Disable base URL field for Parakeet (auto-configured to localhost:8422)
- Accept legacy untagged Keychain credentials for the current provider

## Test plan

- [x] 562 unit tests pass, 0 failures
- [x] No UI tests run (user actively using machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)