### PR TITLE
Reduce onboarding friction and harden local model integration

### DIFF
--- a/Sources/BugNarrator/Models/AppError.swift
+++ b/Sources/BugNarrator/Models/AppError.swift
@@ -74,8 +74,14 @@ enum AppError: LocalizedError, Equatable {
         case .emptyTranscript:
             return "The transcription finished but returned empty text."
         case .networkTimeout:
+            if provider == .parakeetLocal {
+                return "The local transcription server did not respond in time. Make sure it is running."
+            }
             return "The request to \(providerName) timed out. Check the connection and try again."
         case .networkFailure:
+            if provider == .parakeetLocal {
+                return "BugNarrator could not reach the local transcription server. Start it with: local-transcription/venv/bin/python local-transcription/server.py --preload"
+            }
             return "BugNarrator could not reach \(providerName). Check the connection and try again."
         case .rateLimited(let retryAfter):
             if let retryAfter {

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -56,8 +56,14 @@ enum PendingTranscriptionFailureReason: String, Codable, Equatable {
             }
             return "Recording saved locally. Open Settings, refresh the \(provider.displayName) configuration, then retry transcription from this session."
         case .networkTimeout:
+            if provider == .parakeetLocal {
+                return "Recording saved locally. The local transcription server did not respond. Start it, then retry transcription from this session."
+            }
             return "Recording saved locally. The \(provider.displayName) request timed out, so retry transcription from this session when the connection is stable."
         case .networkFailure:
+            if provider == .parakeetLocal {
+                return "Recording saved locally. The local transcription server is not running. Start it, then retry transcription from this session."
+            }
             return "Recording saved locally. BugNarrator could not reach \(provider.displayName), so retry transcription from this session when the connection is available."
         case .rateLimited:
             return "Recording saved locally. \(provider.displayName) rate limited the request, so wait a moment and retry transcription from this session."

--- a/Sources/BugNarrator/Views/RecordingControlPanelView.swift
+++ b/Sources/BugNarrator/Views/RecordingControlPanelView.swift
@@ -178,6 +178,9 @@ struct RecordingControlPanelView: View {
             return "You can keep recording without finishing \(provider.displayName) setup. Open Settings before stopping if you want transcription."
         }
 
+        if appState.settingsStore.aiProvider == .parakeetLocal && appState.status.phase != .recording {
+            return "Transcription will use the local Parakeet server. Make sure it is running before you stop recording."
+        }
         return "The controls stay open until you close them."
     }
 

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -22,15 +22,28 @@ struct SettingsView: View {
 
                 GroupBox("Before You Start") {
                     VStack(alignment: .leading, spacing: 10) {
-                        Text("BugNarrator requires your own AI provider configuration.")
-                            .font(.headline)
+                        if settingsStore.aiProvider == .parakeetLocal {
+                            Text("Local transcription is selected.")
+                                .font(.headline)
 
-                        Text("BugNarrator does not ship with bundled AI access or credits. Configure your provider below before you transcribe a session or run issue extraction.")
-                            .foregroundStyle(.secondary)
+                            Text("BugNarrator will transcribe recordings on this Mac using Parakeet. No API key, no cloud upload, no cost. Start the local transcription server before recording.")
+                                .foregroundStyle(.secondary)
 
-                        Text("Transcription and issue extraction use the selected provider and may incur charges on that provider account.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+                            Text("Run in Terminal: local-transcription/venv/bin/python local-transcription/server.py --preload")
+                                .font(.footnote.monospaced())
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        } else {
+                            Text("BugNarrator requires your own AI provider configuration.")
+                                .font(.headline)
+
+                            Text("BugNarrator does not ship with bundled AI access or credits. Configure your provider below before you transcribe a session or run issue extraction.")
+                                .foregroundStyle(.secondary)
+
+                            Text("Transcription and issue extraction use the selected provider and may incur charges on that provider account.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
 

--- a/Tests/BugNarratorTests/AppErrorPresenterTests.swift
+++ b/Tests/BugNarratorTests/AppErrorPresenterTests.swift
@@ -132,8 +132,8 @@ final class AppErrorPresenterTests: XCTestCase {
         }
         XCTAssertFalse(text.contains("OpenAI"), "Parakeet error text should not contain OpenAI: \(text)")
         XCTAssertTrue(
-            text.contains(AIProvider.parakeetLocal.displayName),
-            "Parakeet error text should reference active provider: \(text)"
+            text.contains("local transcription server") || text.contains(AIProvider.parakeetLocal.displayName),
+            "Parakeet error text should reference local server or active provider: \(text)"
         )
     }
 


### PR DESCRIPTION
## Summary

- **Parakeet onboarding**: Settings "Before You Start" shows the server start command instead of API key instructions when Local (Parakeet) is selected
- **Recording controls**: Footer reminds user about the local server before they stop recording
- **Actionable errors**: Connection refused/timeout for Parakeet now says "start the local transcription server" instead of generic network error
- **Recovery messages**: Preserved sessions reference starting the server specifically for Parakeet

## Test plan

- [x] 562 unit tests pass, 0 failures
- [x] No UI tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)