### PR TITLE
Fix source file leak on mix failure and neutralize log provider names

### DIFF
--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -104,6 +104,15 @@ final class MixedAudioRecorder: AudioRecording {
         let (systemResult, microphoneResult) = await (systemStopResult, microphoneStopResult)
 
         switch (systemResult, microphoneResult) {
+        case (.failure(let sysErr), .failure(let micErr)):
+            recordingLogger.error(
+                "mixed_recording_both_failed",
+                "Both audio sources failed to stop.",
+                metadata: [
+                    "system_error": sysErr.localizedDescription,
+                    "microphone_error": micErr.localizedDescription,
+                ]
+            )
         case (.failure, .success(let microphoneAudio)):
             try? FileManager.default.removeItem(at: microphoneAudio.fileURL)
         case (.success(let systemAudio), .failure):
@@ -117,16 +126,24 @@ final class MixedAudioRecorder: AudioRecording {
 
         let outputURL = makeMixedRecordingURL()
         let insertionOffsets = sourceStartTimes?.insertionOffsets ?? .zero
-        let mixedAudio = try await mixAudioFiles(
-            microphoneAudio: microphoneAudio,
-            systemAudio: systemAudio,
-            outputURL: outputURL,
-            insertionOffsets: insertionOffsets
-        )
-        removeSourceAudioFiles(
-            [microphoneAudio.fileURL, systemAudio.fileURL],
-            preserving: mixedAudio.fileURL
-        )
+        let sourceFileURLs = [microphoneAudio.fileURL, systemAudio.fileURL]
+        let mixedAudio: RecordedAudio
+        do {
+            mixedAudio = try await mixAudioFiles(
+                microphoneAudio: microphoneAudio,
+                systemAudio: systemAudio,
+                outputURL: outputURL,
+                insertionOffsets: insertionOffsets
+            )
+        } catch {
+            // Clean up source audio files that would otherwise be orphaned.
+            for url in sourceFileURLs {
+                try? FileManager.default.removeItem(at: url)
+            }
+            throw error
+        }
+
+        removeSourceAudioFiles(sourceFileURLs, preserving: mixedAudio.fileURL)
 
         recordingLogger.info(
             "mixed_recording_stopped",

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -101,7 +101,7 @@ actor TranscriptionClient: TranscriptionServing {
 
         logger.info(
             "transcription_chunked_requested",
-            "Uploading chunked audio to OpenAI for transcription.",
+            "Uploading chunked audio for transcription.",
             metadata: [
                 "file_name": fileURL.lastPathComponent,
                 "chunk_count": "\(chunks.count)",
@@ -117,7 +117,7 @@ actor TranscriptionClient: TranscriptionServing {
         for (index, chunk) in chunks.enumerated() {
             logger.debug(
                 "transcription_chunk_upload",
-                "Uploading a transcription chunk to OpenAI.",
+                "Uploading a transcription chunk.",
                 metadata: [
                     "chunk_index": "\(index + 1)",
                     "chunk_count": "\(chunks.count)",
@@ -145,7 +145,7 @@ actor TranscriptionClient: TranscriptionServing {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !transcript.isEmpty else {
-            logger.warning("transcription_empty", "OpenAI returned an empty transcript after chunked transcription.")
+            logger.warning("transcription_empty", "The provider returned an empty transcript after chunked transcription.")
             throw AppError.emptyTranscript
         }
 
@@ -153,7 +153,7 @@ actor TranscriptionClient: TranscriptionServing {
         logQualityFindings(qualityFindings, fileName: fileURL.lastPathComponent)
         logger.info(
             "transcription_chunked_completed",
-            "OpenAI returned a completed transcript after chunked transcription.",
+            "Completed transcript received after chunked transcription.",
             metadata: [
                 "character_count": "\(transcript.count)",
                 "segments_count": "\(adjustedSegments.count)",
@@ -255,7 +255,7 @@ actor TranscriptionClient: TranscriptionServing {
         if attempt == 0 {
             logger.info(
                 "transcription_requested",
-                "Uploading audio to OpenAI for transcription.",
+                "Uploading audio for transcription.",
                 metadata: [
                     "file_name": fileURL.lastPathComponent,
                     "model": request.model,
@@ -276,7 +276,7 @@ actor TranscriptionClient: TranscriptionServing {
             guard (200...299).contains(httpResponse.statusCode) else {
                 logger.warning(
                     "transcription_rejected",
-                    "OpenAI rejected the transcription request.",
+                    "The provider rejected the transcription request.",
                     metadata: ["status_code": "\(httpResponse.statusCode)"]
                 )
                 throw OpenAIErrorMapper.mapResponse(
@@ -291,7 +291,7 @@ actor TranscriptionClient: TranscriptionServing {
             let transcript = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
 
             guard !transcript.isEmpty else {
-                logger.warning("transcription_empty", "OpenAI returned an empty transcript.")
+                logger.warning("transcription_empty", "The provider returned an empty transcript.")
                 throw AppError.emptyTranscript
             }
 
@@ -299,7 +299,7 @@ actor TranscriptionClient: TranscriptionServing {
             logQualityFindings(qualityFindings, fileName: fileURL.lastPathComponent)
             logger.info(
                 "transcription_completed",
-                "OpenAI returned a completed transcript.",
+                "Completed transcript received.",
                 metadata: [
                     "character_count": "\(transcript.count)",
                     "segments_count": "\(result.segments?.count ?? 0)"
@@ -343,7 +343,7 @@ actor TranscriptionClient: TranscriptionServing {
 
     func validateAPIKey(_ apiKey: String, apiBaseURL: URL) async throws {
         let request = makeValidationRequest(apiKey: apiKey, apiBaseURL: apiBaseURL)
-        logger.info("openai_key_validation_requested", "Validating the OpenAI API key.")
+        logger.info("openai_key_validation_requested", "Validating the provider connection.")
 
         do {
             let (data, response) = try await session.data(for: request)
@@ -356,7 +356,7 @@ actor TranscriptionClient: TranscriptionServing {
             guard (200...299).contains(httpResponse.statusCode) else {
                 logger.warning(
                     "openai_key_validation_rejected",
-                    "The OpenAI API key validation request was rejected.",
+                    "The provider validation request was rejected.",
                     metadata: ["status_code": "\(httpResponse.statusCode)"]
                 )
                 throw OpenAIErrorMapper.mapResponse(
@@ -365,7 +365,7 @@ actor TranscriptionClient: TranscriptionServing {
                     fallback: AppError.transcriptionFailure
                 )
             }
-            logger.info("openai_key_validation_succeeded", "The OpenAI API key was accepted.")
+            logger.info("openai_key_validation_succeeded", "The provider connection was validated.")
         } catch {
             logger.error(
                 "openai_key_validation_failed",


### PR DESCRIPTION
## Summary

- **Source file leak fix**: When `mixAudioFiles` fails (export timeout, composition error), both source audio files are now cleaned up instead of leaking in RecoveredRecordings
- **Double failure logging**: When both sub-recorders fail, both errors are now logged before throwing
- **Provider-neutral logs**: All hardcoded "OpenAI" references in TranscriptionClient log messages replaced with provider-neutral language (accurate for Parakeet, local, and cloud providers)

## Test plan

- [x] 562 unit tests pass, 0 failures
- [x] No UI tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)