### PR TITLE
Build and deploy BugNarrator 1.0.38 (#412)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,14 @@ jobs:
       - name: Select Xcode (project file requires Xcode 26)
         run: |
           # The .xcodeproj is in objectVersion 77, which only Xcode 26+
-          # can read. Two valid layouts:
+          # can read. Valid layouts:
           #   1. GitHub-hosted macos-26 runners: /Applications/Xcode_26*.app
           #      (multiple side-by-side versions are present; pick newest)
           #   2. Self-hosted runners (the brew-sync fleet Mac): just
           #      /Applications/Xcode.app, which we accept if its
           #      CFBundleShortVersionString starts with `26`.
+          #   3. Self-hosted runners with xcode-select already pointing at
+          #      an Xcode 26 developer directory outside the app paths above.
           XCODE_APP=$(find /Applications -maxdepth 1 -type d -name 'Xcode_26*.app' -print | sort -V | tail -1)
 
           if [[ -z "$XCODE_APP" && -d /Applications/Xcode.app ]]; then
@@ -137,7 +139,22 @@ jobs:
           fi
 
           if [[ -z "$XCODE_APP" ]]; then
-            echo "::error::No Xcode 26.x found. Looked for /Applications/Xcode_26*.app and /Applications/Xcode.app. Installed Xcode apps:"
+            SELECTED_DEVELOPER_DIR=$(xcode-select -p 2>/dev/null || echo "")
+            SELECTED_XCODE_APP="${SELECTED_DEVELOPER_DIR%/Contents/Developer}"
+            if [[ -n "$SELECTED_DEVELOPER_DIR" && -d "$SELECTED_XCODE_APP/Contents" ]]; then
+              VERSION=$(defaults read "$SELECTED_XCODE_APP/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "")
+              if [[ "$VERSION" == 26* ]]; then
+                XCODE_APP="$SELECTED_XCODE_APP"
+                echo "Accepting selected Xcode at $XCODE_APP (version $VERSION)."
+              fi
+            fi
+          fi
+
+          if [[ -z "$XCODE_APP" ]]; then
+            echo "::error::No Xcode 26.x found. Looked for /Applications/Xcode_26*.app, /Applications/Xcode.app, and the selected developer directory."
+            echo "Selected developer directory: $(xcode-select -p 2>/dev/null || echo unavailable)"
+            xcodebuild -version || true
+            echo "Installed Xcode apps:"
             ls -d /Applications/Xcode*.app || true
             exit 1
           fi

--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -1040,7 +1040,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.37;
+				MARKETING_VERSION = 1.0.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -1063,7 +1063,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 37;
+				CURRENT_PROJECT_VERSION = 38;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1072,7 +1072,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.37;
+				MARKETING_VERSION = 1.0.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.38 - 2026-06-11
+
 - [FIX] Refreshed menu-bar AI setup state when the saved OpenAI credential changes, so Settings and the menu no longer disagree about a usable key.
 - [FIX] Blocked recording starts until AI transcription setup is usable, defaulted fresh installs to English transcription hints, and added transcript quality warnings for wrong-script output.
 - [INTERNAL] Split AI setup, transcription defaults, and issue extraction settings into an encapsulated SwiftUI section with UI coverage.


### PR DESCRIPTION
Closes #412

## Summary
- Bumped BugNarrator to 1.0.38 (38)
- Cut the current unreleased changelog notes into the 2026-06-11 release section

## Validation
- PASS: ./scripts/validate.sh origin/main
- PASS: git diff --check
- PASS: release diff scan for obvious secret-shaped values

## Security
- GitHub security alert API checks returned 404 with the current token/session, so no alert details were readable from this local environment.
