### PR TITLE
Fix BugNarrator menu bar crash in microphone level monitor (#414)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -1040,7 +1040,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1049,7 +1049,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.38;
+				MARKETING_VERSION = 1.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;
@@ -1063,7 +1063,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/BugNarrator.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Resources/Info.plist;
@@ -1072,7 +1072,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.38;
+				MARKETING_VERSION = 1.0.39;
 				PRODUCT_BUNDLE_IDENTIFIER = com.abdenterprises.bugnarrator;
 				PRODUCT_NAME = BugNarrator;
 				SDKROOT = macosx;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.39 - 2026-06-11
+
+- [FIX] Stopped the menu bar microphone level meter from crashing when CoreAudio delivers level updates on its realtime callback queue.
+
 ## 1.0.38 - 2026-06-11
 
 - [FIX] Refreshed menu-bar AI setup state when the saved OpenAI credential changes, so Settings and the menu no longer disagree about a usable key.

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -807,12 +807,19 @@ final class MicrophoneInputLevelMonitor: ObservableObject {
         do {
             let inputNode = engine.inputNode
             inputNode.removeTap(onBus: 0)
-            inputNode.installTap(onBus: 0, bufferSize: 1_024, format: nil) { [weak self] buffer, _ in
-                let level = MicrophoneLevelCalculator.normalizedRMSLevel(for: buffer)
-                Task { @MainActor [weak self] in
-                    self?.currentLevel = level
+            inputNode.installTap(
+                onBus: 0,
+                bufferSize: 1_024,
+                format: nil,
+                block: MicrophoneInputLevelTapFactory.makeTap { [weak self] level in
+                    Task { @MainActor [weak self] in
+                        guard let self, isMonitoring else {
+                            return
+                        }
+                        currentLevel = level
+                    }
                 }
-            }
+            )
 
             try engine.start()
             isMonitoring = true
@@ -890,5 +897,13 @@ enum MicrophoneLevelCalculator {
 
         let rms = sqrt(sumOfSquares / Float(sampleCount))
         return min(1, max(0, rms * 4))
+    }
+}
+
+enum MicrophoneInputLevelTapFactory {
+    static func makeTap(deliverLevel: @escaping @Sendable (Float) -> Void) -> AVAudioNodeTapBlock {
+        { buffer, _ in
+            deliverLevel(MicrophoneLevelCalculator.normalizedRMSLevel(for: buffer))
+        }
     }
 }

--- a/Tests/BugNarratorTests/RecordingAudioSourceTests.swift
+++ b/Tests/BugNarratorTests/RecordingAudioSourceTests.swift
@@ -65,6 +65,21 @@ final class RecordingAudioSourceTests: XCTestCase {
         XCTAssertEqual(MicrophoneLevelCalculator.normalizedRMSLevel(for: buffer), 1, accuracy: 0.000_001)
     }
 
+    func testMicrophoneInputLevelTapCanDeliverFromRealtimeQueue() throws {
+        let buffer = try makePCMBuffer(samples: [0.125, -0.125, 0.125, -0.125])
+        let deliveredLevel = expectation(description: "delivered microphone level")
+        let tap = MicrophoneInputLevelTapFactory.makeTap { level in
+            XCTAssertGreaterThan(level, 0)
+            deliveredLevel.fulfill()
+        }
+
+        DispatchQueue(label: "RealtimeMessenger.mServiceQueue").async {
+            tap(buffer, AVAudioTime(sampleTime: 0, atRate: 44_100))
+        }
+
+        wait(for: [deliveredLevel], timeout: 1)
+    }
+
     private func makePCMBuffer(samples: [Float]) throws -> AVAudioPCMBuffer {
         let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 44_100, channels: 1))
         let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)))


### PR DESCRIPTION
Closes #414

## Summary
- Fixed the menu bar crash caused by the microphone level AVAudioEngine tap inheriting MainActor isolation while CoreAudio invokes it on a realtime callback queue.
- Added a regression test that invokes the microphone level tap from a RealtimeMessenger-style queue.
- Bumped the hotfix release version to 1.0.39 (39).

## Validation
- PASS: ./scripts/validate.sh origin/main
- PASS: xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination "platform=macOS" -only-testing:BugNarratorTests CODE_SIGNING_ALLOWED=NO test
- PASS: focused RecordingAudioSourceTests microphone tap regression
- PASS: git diff --check

## Crash Evidence
- Recent installed-app crash report faulted in MicrophoneInputLevelMonitor.startEngine() on CoreAudio queue RealtimeMessenger.mServiceQueue with a Swift main-actor dispatch assertion.
