### PR TITLE
docs: reflect current BugNarrator behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ It can:
 
 BugNarrator does not ship with built-in AI access or credits.
 
-OpenAI is the default provider. In `Settings`, you can also choose an OpenAI-compatible enterprise gateway or a local-compatible endpoint when that endpoint exposes the OpenAI-compatible APIs BugNarrator needs.
+OpenAI is the hosted default provider. In `Settings`, you can also choose `OpenAI-Compatible`, `Local-Compatible`, or `Local (Parakeet)`.
 
 Important:
 
+- `OpenAI` requires your own OpenAI API key and uses `https://api.openai.com` unless you override it
+- `OpenAI-Compatible` is for enterprise gateways or hosted providers that expose compatible transcription and chat endpoints
+- `Local-Compatible` is for local or self-hosted OpenAI-compatible endpoints such as LM Studio or Ollama
+- `Local (Parakeet)` transcribes on this Mac through the local server at `http://localhost:8422`, does not use an API key, and does not upload audio
 - transcription requires a provider endpoint compatible with `/v1/audio/transcriptions`
-- issue extraction requires a provider endpoint compatible with `/v1/chat/completions`
-- local-compatible providers can leave the API key blank if the local endpoint does not require authentication
-- unsupported local/default model combinations show clear setup guidance in Settings instead of starting a broken transcription
+- review summary and issue extraction require a provider endpoint compatible with `/v1/chat/completions`
+- unsupported provider/model combinations show clear setup guidance in Settings instead of starting a broken transcription
 - provider usage may cost money on your account when you use a hosted provider
 - the app stores your provider credential in macOS Keychain when available
 - credentials are not bundled into the source code or compiled app
@@ -89,7 +92,7 @@ Important:
 
 1. Launch BugNarrator and open the menu bar item.
 2. Open `Settings`.
-3. Choose an AI provider and enter the required key or base URL.
+3. Choose an AI provider. Use `OpenAI` for hosted transcription and issue extraction, or `Local (Parakeet)` for local transcription after the local Parakeet server is installed and running.
 4. Optionally click `Validate Key` or `Validate Connection`.
 5. Click `Show Recording Controls`.
 6. Click `Start Recording`.
@@ -287,8 +290,8 @@ For public distribution, use a `Developer ID Application` certificate plus notar
 
 ## Known Limitations
 
-- transcription and issue extraction require network access
-- BugNarrator does not yet support offline Whisper
+- hosted transcription, review summary, issue extraction, GitHub export, and Jira export require network access
+- `Local (Parakeet)` is transcription-only; review summary and issue extraction still require an OpenAI-compatible chat provider
 - GitHub and Jira export include screenshot references in issue bodies instead of uploading attachments automatically
 - session deletion is permanent today
 

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -213,7 +213,7 @@ Structured counterpart: [docs/testing/testing.md](testing/testing.md)
   Expected: BugNarrator explains that the local screenshot file is no longer available instead of failing silently.
 - Disconnect networking or force a timeout during transcription.
   Expected: transcription ends in a clear timeout or API error state and the app returns to a usable state.
-- Use an invalid hosted-provider API key or unsupported local-compatible model combination.
+- Use an invalid hosted-provider API key, unsupported local-compatible model combination, or stopped `Local (Parakeet)` server.
   Expected: transcription or issue extraction ends in clear provider setup guidance, Settings opens when useful, and the preserved session remains available so transcription can be retried after the configuration is fixed.
 - Simulate a local history write failure after a successful transcription if practical.
   Expected: the transcript window still opens, the completed session remains available as an unsaved session, screenshots remain accessible, and `Save to History` can be retried later after storage is fixed.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -16,15 +16,18 @@ Use this checklist before cutting a public test build or release candidate.
 - Confirm the Release app bundle contains `Contents/Resources/AppIcon.icns` and `Contents/Resources/Assets.car`.
 - Confirm the signed Release app and the mounted DMG app both retain `com.apple.security.device.audio-input=true`.
 - Launch the built app and confirm the menu bar item appears.
+- Install the signed app into `/Applications`, launch that copy, click the menu bar item, and confirm the popover opens without a fresh `~/Library/Logs/DiagnosticReports/BugNarrator*.ips` crash report.
 - Confirm first launch does not trigger an unexpected Keychain prompt before the user opens Settings or starts a credential-dependent workflow.
 
 ## Core Product Workflow
 
 - Add or validate the intended AI provider configuration in Settings.
+- If testing `Local (Parakeet)`, start the local server first and confirm `Check Server` succeeds.
 - Start a recording session and confirm the app enters `Recording`.
 - Capture at least one screenshot during the session and confirm it creates a visible timeline moment in review.
-- Stop the session and confirm transcription succeeds.
-- Confirm the transcript, review summary, screenshots, and extracted issues appear in the session library.
+- Stop the session and confirm transcription succeeds with the selected provider.
+- For chat-capable providers, confirm the transcript, review summary, screenshots, and extracted issues appear in the session library.
+- For `Local (Parakeet)`, confirm the transcript and screenshots appear in the session library and automatic issue extraction stays disabled until a chat-capable provider is selected.
 - Export a session bundle and verify `transcript.md` plus the `screenshots` folder are created.
 
 ## Export Integrations

--- a/docs/TESTING_NOTES.md
+++ b/docs/TESTING_NOTES.md
@@ -30,7 +30,9 @@ For public-release validation, also run the signed and notarized DMG workflow do
 
 - live microphone permission prompts and denied-permission recovery
 - end-to-end transcription against the real OpenAI API
+- end-to-end local transcription against the `Local (Parakeet)` server
 - real screenshot capture behavior with macOS Screen Recording permission
+- signed-app menu bar smoke testing from `/Applications`: launch the installed app, click the menu bar item, confirm the popover opens, and confirm no fresh `~/Library/Logs/DiagnosticReports/BugNarrator*.ips` crash report appears
 - real GitHub export against a repository you control
 - real Jira Cloud export against a project you control
 - opening the generated DMG in Finder and validating the drag-to-Applications flow

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -49,13 +49,15 @@ It helps you:
 1. Launch BugNarrator and confirm the menu bar icon appears.
 2. Open `Settings`.
 3. Choose an AI provider.
-4. Enter the required API key or base URL for that provider.
+4. Enter the required API key or base URL for that provider, or leave the key blank for `Local (Parakeet)`.
 5. Optionally click `Validate Key` or `Validate Connection`.
 6. Optionally assign global hotkeys for `Start Recording`, `Stop Recording`, and `Capture Screenshot`. They begin as `Not Set` until you choose them.
 7. Click `Show Recording Controls`.
 8. Start a session with `Start Recording`.
 
-BugNarrator does not ship with built-in AI access or credits. OpenAI is the default provider. You can also select an OpenAI-compatible enterprise gateway or a local-compatible endpoint when that endpoint exposes the OpenAI-compatible transcription and chat APIs BugNarrator needs. Hosted provider usage may incur charges on that provider account.
+BugNarrator does not ship with built-in AI access or credits. `OpenAI` is the hosted default provider and requires your own API key. You can also select `OpenAI-Compatible` for an enterprise gateway or hosted compatible provider, `Local-Compatible` for local or self-hosted OpenAI-compatible endpoints, or `Local (Parakeet)` for transcription on this Mac through `http://localhost:8422`.
+
+`Local (Parakeet)` does not use an API key and does not upload audio, but the local server must be installed and running before transcription. It is transcription-only; review summary and issue extraction still require an OpenAI-compatible chat provider. Hosted provider usage may incur charges on that provider account.
 
 ## Core Workflow
 
@@ -264,7 +266,8 @@ BugNarrator keeps diagnostics local until you explicitly export or copy them for
 
 - confirm your AI provider configuration is valid in `Settings`
 - validate the key if needed
-- confirm the Mac has network access
+- for hosted providers, confirm the Mac has network access
+- for `Local (Parakeet)`, confirm the local transcription server is running
 - retry with a short test recording to rule out an empty or corrupt audio file
 
 ### Microphone Permission Problems
@@ -287,7 +290,8 @@ BugNarrator keeps diagnostics local until you explicitly export or copy them for
 ### Provider Credential Missing
 
 - open `Settings`
-- choose an AI provider and enter your own provider credential or base URL
+- choose an AI provider and enter your own provider credential or base URL when that provider requires one
+- for `Local (Parakeet)`, confirm the local server is running instead of adding an API key
 - click `Validate Key` or `Validate Connection` if you want to check it before transcription or issue extraction
 - BugNarrator stores provider credentials in macOS Keychain when available
 - if a completed session could not be transcribed because the provider configuration was missing at stop time, keep the session and retry after restoring the configuration
@@ -329,10 +333,11 @@ What stays local on your Mac:
 
 What is sent to the configured AI provider:
 
-- recorded audio after you stop a session and request transcription
-- transcript context used for review summary or issue extraction
+- for hosted or compatible providers, recorded audio after you stop a session and request transcription
+- for `Local (Parakeet)`, audio is processed by the local server on this Mac instead of uploaded
+- transcript context used for review summary or issue extraction when a chat-capable provider is selected
 
-BugNarrator does not continuously stream live audio to OpenAI while you are still recording.
+BugNarrator does not continuously stream live audio to any AI provider while you are still recording.
 
 ## More Documentation
 

--- a/docs/architecture/product-spec.md
+++ b/docs/architecture/product-spec.md
@@ -205,7 +205,7 @@ BugNarrator generates transcripts after recording ends.
 
 It does not continuously stream live audio to the configured AI provider while the user is still recording.
 
-OpenAI remains the default provider. OpenAI-compatible enterprise gateways and local-compatible endpoints are supported when they expose the transcription and chat APIs BugNarrator needs. Unsupported provider/model combinations must fail before transcription or issue extraction starts with clear setup guidance.
+OpenAI remains the hosted default provider. OpenAI-compatible enterprise gateways and local-compatible endpoints are supported when they expose the transcription and chat APIs BugNarrator needs. Local Parakeet transcription is supported through the local server at `http://localhost:8422`; it requires no API key and must not upload audio. Because Parakeet is transcription-only, review summary and issue extraction must stay disabled until an OpenAI-compatible chat provider is selected. Unsupported provider/model combinations must fail before transcription or issue extraction starts with clear setup guidance.
 
 ### Recovery
 

--- a/docs/user/user-manual.md
+++ b/docs/user/user-manual.md
@@ -37,10 +37,12 @@ You need:
 1. Open the menu bar item.
 2. Open `Settings`.
 3. Choose an AI provider.
-4. Enter the required API key or base URL.
+4. Enter the required API key or base URL, or leave the key blank for `Local (Parakeet)`.
 5. Optionally validate the key or connection.
 
-BugNarrator does not ship with built-in AI access or credits. OpenAI remains the default provider, and OpenAI-compatible enterprise or local-compatible endpoints can be configured when they expose the transcription and chat APIs BugNarrator needs.
+BugNarrator does not ship with built-in AI access or credits. `OpenAI` remains the hosted default provider and requires your own API key. `OpenAI-Compatible` and `Local-Compatible` endpoints can also be configured when they expose the APIs BugNarrator needs. `Local (Parakeet)` transcribes on this Mac through `http://localhost:8422`, does not use an API key, and does not upload audio.
+
+`Local (Parakeet)` is transcription-only. Review summary and issue extraction still require an OpenAI-compatible chat provider.
 
 ## Recording Workflow
 
@@ -54,7 +56,7 @@ The recording controls window stays open until you close it.
 
 If the AI provider configuration is missing, invalid, or revoked when the recording finishes, BugNarrator preserves the finished session in the library so you can restore the configuration and retry transcription later.
 
-Sessions waiting for transcription retry are also surfaced in the menu bar window and at the top of the session-library list, so the recovery flow stays visible after relaunch.
+Finished sessions waiting for transcription retry are surfaced in the menu bar window and at the top of the session-library list after relaunch.
 
 ## Review Workflow
 


### PR DESCRIPTION
## Summary
- Document current AI provider choices, including OpenAI, compatible endpoints, and Local (Parakeet)
- Clarify that Local (Parakeet) is transcription-only, uses localhost:8422, requires no API key, and does not upload audio
- Add signed installed-app menu bar crash smoke coverage to testing and release docs
- Update retryable-session and privacy wording to match current behavior

## Validation
- ./scripts/repo-docs-audit.sh
- ./scripts/effort-leak-audit.sh
- ./scripts/validate.sh origin/main

Closes #416