### PR TITLE
feat: Settings setup-progress, privacy disclosure, per-field affordances

### DIFF
--- a/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
+++ b/Sources/BugNarrator/Services/OperationalTelemetryRecorder.swift
@@ -43,18 +43,29 @@ extension TelemetryEventName {
 }
 
 struct OperationalTelemetryRecorder {
+    /// UserDefaults key shared with SettingsStore so the recorder can honor the
+    /// user's opt-out without a direct dependency on the settings object.
+    static let enabledDefaultsKey = "settings.operationalTelemetryEnabled"
+
     private let fileManager: FileManager
     private let storageURL: URL
+    private let userDefaults: UserDefaults
     private let encoder = JSONEncoder()
 
-    init(fileManager: FileManager = .default, storageURL: URL? = nil) {
+    init(fileManager: FileManager = .default, storageURL: URL? = nil, userDefaults: UserDefaults = .standard) {
         self.fileManager = fileManager
         self.storageURL = storageURL ?? AppSupportLocation.appDirectory(fileManager: fileManager)
             .appendingPathComponent("operational-telemetry.jsonl")
+        self.userDefaults = userDefaults
         encoder.dateEncodingStrategy = .iso8601
     }
 
+    private var isEnabled: Bool {
+        userDefaults.object(forKey: Self.enabledDefaultsKey) as? Bool ?? true
+    }
+
     func record(_ name: String, metadata: [String: String] = [:]) {
+        guard isEnabled else { return }
         do {
             let parentDirectoryURL = storageURL.deletingLastPathComponent()
             if !fileManager.fileExists(atPath: parentDirectoryURL.path) {

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -430,10 +430,18 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    @Published var operationalTelemetryEnabled: Bool = true {
+        didSet {
+            guard hasLoaded else { return }
+            defaults.set(operationalTelemetryEnabled, forKey: Keys.operationalTelemetryEnabled)
+        }
+    }
+
     @Published private(set) var apiKeyPersistenceState: APIKeyPersistenceState = .empty
     @Published private(set) var githubTokenPersistenceState: APIKeyPersistenceState = .empty
     @Published private(set) var jiraTokenPersistenceState: APIKeyPersistenceState = .empty
     @Published private(set) var hotkeyConflictMessage: String?
+    @Published private(set) var conflictingHotkeyAction: HotkeyAction?
     @Published private(set) var openAtStartupSupported = true
     @Published private(set) var openAtStartupStatusMessage: String?
     @Published private(set) var openAtStartupStatusTone: SettingsCalloutTone = .secondary
@@ -1172,6 +1180,7 @@ final class SettingsStore: ObservableObject {
         migrateLegacyPlaintextJiraEmailIfNeeded()
 
         debugMode = boolValue(forKey: Keys.debugMode) ?? false
+        operationalTelemetryEnabled = boolValue(forKey: Keys.operationalTelemetryEnabled) ?? true
         migrateLegacyBuiltInHotkeysIfNeeded()
         normalizeLoadedHotkeyConflicts()
         BugNarratorDiagnostics.setDebugModeEnabled(debugMode)
@@ -1279,12 +1288,21 @@ final class SettingsStore: ObservableObject {
                 ]
             )
             hotkeyConflictMessage = "\(changedShortcut.displayString) is already assigned to \(conflictingAction.title). Clear it first or choose a different shortcut."
+            conflictingHotkeyAction = conflictingAction
             setShortcut(previousShortcut, for: changedAction)
             return
         }
 
         hotkeyConflictMessage = nil
+        conflictingHotkeyAction = nil
         persistHotkey(changedShortcut, key: storageKey(for: changedAction))
+    }
+
+    /// Clears the binding for the named action, resolving a reported conflict.
+    func clearHotkey(for action: HotkeyAction) {
+        setShortcut(.disabled, for: action)
+        hotkeyConflictMessage = nil
+        conflictingHotkeyAction = nil
     }
 
     private func migrateLegacyBuiltInHotkeysIfNeeded() {
@@ -1956,6 +1974,7 @@ private enum Keys {
     static let jiraIssueTypeID = "settings.jiraIssueTypeID"
     static let jiraIssueType = "settings.jiraIssueType"
     static let debugMode = "settings.debugMode"
+    static let operationalTelemetryEnabled = OperationalTelemetryRecorder.enabledDefaultsKey
 }
 
 enum APIKeyPersistenceState: Equatable {

--- a/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorLinks.swift
@@ -6,6 +6,8 @@ enum BugNarratorLinks {
     static let issues = URL(string: "https://github.com/ABD-Enterprises/bug-narrator/issues/new")!
     static let releases = URL(string: "https://github.com/ABD-Enterprises/bug-narrator/releases")!
     static let supportDevelopment = URL(string: "https://www.paypal.com/donate/?hosted_button_id=FWFQ6KCZBWWH8")!
+    static let generateGitHubToken = URL(string: "https://github.com/settings/tokens/new?scopes=repo&description=BugNarrator")!
+    static let generateJiraToken = URL(string: "https://id.atlassian.com/manage-profile/security/api-tokens")!
     static let microphonePrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
     static let screenRecordingPrivacySettings = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
     static let securityPrivacySettings = URL(fileURLWithPath: "/System/Library/PreferencePanes/Security.prefPane")

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -152,9 +152,17 @@ struct SettingsView: View {
                         hotkeyRow(action: .captureScreenshot, shortcut: $settingsStore.screenshotHotkeyShortcut)
 
                         if let hotkeyConflictMessage = settingsStore.hotkeyConflictMessage {
-                            Text(hotkeyConflictMessage)
-                                .font(.footnote)
-                                .foregroundStyle(.red)
+                            HStack(spacing: 8) {
+                                Text(hotkeyConflictMessage)
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                                if let conflicting = settingsStore.conflictingHotkeyAction {
+                                    Button("Clear \(conflicting.title)") {
+                                        settingsStore.clearHotkey(for: conflicting)
+                                    }
+                                    .controlSize(.small)
+                                }
+                            }
                         }
 
                         Text("Hotkeys use Carbon and do not require Accessibility access. Screenshot hotkeys only work while a session is recording. If you choose a shortcut that is already assigned to another BugNarrator action, the new assignment is rejected until you clear or change the conflicting shortcut.")
@@ -174,7 +182,11 @@ struct SettingsView: View {
                                 isDisabled: secureControlsDisabled,
                                 accessibilityLabel: "GitHub personal access token"
                             )
+                            .help(secureControlsDisabled ? secureControlsDisabledHint : "Paste a GitHub personal access token with the repo scope.")
                         }
+
+                        Link("Generate a GitHub token →", destination: BugNarratorLinks.generateGitHubToken)
+                            .font(.footnote)
 
                         gitHubPrerequisites
 
@@ -292,7 +304,11 @@ struct SettingsView: View {
                                 isDisabled: secureControlsDisabled,
                                 accessibilityLabel: "Jira API token"
                             )
+                            .help(secureControlsDisabled ? secureControlsDisabledHint : "Paste an Atlassian API token created for your Jira Cloud account.")
                         }
+
+                        Link("Generate a Jira API token →", destination: BugNarratorLinks.generateJiraToken)
+                            .font(.footnote)
 
                         jiraPrerequisites
 
@@ -318,10 +334,19 @@ struct SettingsView: View {
 
                         labeledField(title: "Project") {
                             if appState.jiraProjects.isEmpty {
-                                Text(settingsStore.normalizedJiraProjectKey.isEmpty ? jiraProjectPlaceholder : settingsStore.normalizedJiraProjectKey)
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .accessibilityLabel("Jira project key")
+                                HStack {
+                                    Text(settingsStore.normalizedJiraProjectKey.isEmpty ? jiraProjectPlaceholder : settingsStore.normalizedJiraProjectKey)
+                                        .foregroundStyle(.secondary)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .accessibilityLabel("Jira project key")
+                                    if settingsStore.jiraProjectDiscoveryIsReady {
+                                        Button("Load Projects") {
+                                            Task { await appState.validateJiraConfiguration() }
+                                        }
+                                        .controlSize(.small)
+                                        .disabled(secureControlsDisabled || appState.jiraValidationState == .validating)
+                                    }
+                                }
                             } else {
                                 Picker("Jira project", selection: jiraProjectSelection) {
                                     Text("Choose a project")
@@ -471,6 +496,15 @@ struct SettingsView: View {
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
+
+                        Divider()
+
+                        Toggle("Record local usage analytics", isOn: $settingsStore.operationalTelemetryEnabled)
+                            .help("Records named app events (recordings started, transcriptions completed, errors) to a local file. Nothing is uploaded.")
+
+                        Text("BugNarrator records anonymous usage events to a local file (operational-telemetry.jsonl) to help diagnose issues. The data never leaves this Mac and is included in Export Data. Turn this off to stop recording new events.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -500,6 +534,16 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Setup Status")
                 .font(.headline)
+
+            let configured = setupConfiguredCount
+            let total = setupTotalCount
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(configured) of \(total) configured")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                ProgressView(value: Double(configured), total: Double(total))
+                    .accessibilityLabel("Setup progress: \(configured) of \(total) configured")
+            }
 
             VStack(spacing: 8) {
                 settingsStatusRow(
@@ -584,6 +628,20 @@ struct SettingsView: View {
 
     private var secureControlsDisabled: Bool {
         appState.status.phase == .recording || appState.status.phase == .transcribing
+    }
+
+    private var setupTotalCount: Int { 3 }
+
+    private var setupConfiguredCount: Int {
+        var count = 0
+        if openAIReadiness == .ready { count += 1 }
+        if gitHubReadiness == .ready { count += 1 }
+        if jiraReadiness == .ready { count += 1 }
+        return count
+    }
+
+    private var secureControlsDisabledHint: String {
+        "Disabled while recording or transcribing is in progress."
     }
 
     private var availableRecordingAudioSources: [RecordingAudioSource] {

--- a/Tests/BugNarratorTests/OperationalTelemetryRecorderTests.swift
+++ b/Tests/BugNarratorTests/OperationalTelemetryRecorderTests.swift
@@ -22,6 +22,43 @@ final class OperationalTelemetryRecorderTests: XCTestCase {
         XCTAssertTrue(lines[1].contains(TelemetryEvent.transcriptionCompleted.rawValue))
     }
 
+    func testRecorderSkipsWritesWhenTelemetryDisabled() throws {
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BugNarrator-OperationalTelemetryRecorderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let suiteName = "BugNarrator-Telemetry-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: OperationalTelemetryRecorder.enabledDefaultsKey)
+
+        let storageURL = rootDirectoryURL.appendingPathComponent("telemetry.jsonl")
+        let recorder = OperationalTelemetryRecorder(storageURL: storageURL, userDefaults: defaults)
+
+        recorder.record(.recordingStarted)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storageURL.path))
+    }
+
+    func testRecorderWritesWhenTelemetryFlagUnset() throws {
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BugNarrator-OperationalTelemetryRecorderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let suiteName = "BugNarrator-Telemetry-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let storageURL = rootDirectoryURL.appendingPathComponent("telemetry.jsonl")
+        let recorder = OperationalTelemetryRecorder(storageURL: storageURL, userDefaults: defaults)
+
+        recorder.record(.recordingStarted)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: storageURL.path))
+    }
+
     func testRecorderRedactsSensitiveMetadataBeforePersisting() throws {
         let rootDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-OperationalTelemetryRecorderTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #371, #358, #359, #363, #382, #366

## Summary
- **#371** "X of Y configured" progress header with ProgressView above Setup Status
- **#358** Telemetry disclosure + opt-out toggle in Settings → Privacy; recorder honors the flag
- **#359** "Clear conflicting binding" button on hotkey conflict
- **#363** Inline "Load Projects" button in the empty Jira project picker
- **#382** "Generate a token →" deep links for GitHub PAT and Jira API token
- **#366** Per-field disabled-state hints on credential fields

## Validation
- [x] Build succeeds
- [x] 565 unit tests pass (2 new telemetry opt-out tests)
- [x] Guardrails pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)