### PR TITLE
fix: harden recording controls window presentation

### DIFF
--- a/Sources/BugNarrator/WindowCoordinator.swift
+++ b/Sources/BugNarrator/WindowCoordinator.swift
@@ -93,7 +93,8 @@ final class WindowCoordinator {
             recordingControlWindowController = makeRecordingControlWindowController()
         }
 
-        present(recordingControlWindowController!)
+        guard let recordingControlWindowController else { return }
+        present(recordingControlWindowController)
     }
 
     private func present(_ windowController: NSWindowController) {


### PR DESCRIPTION
## Summary
- Replace the force unwrap when presenting the recording controls window with an optional binding
- Preserve the existing window creation/presentation behavior while avoiding a trap if the controller is unexpectedly unavailable

## Validation
- ./scripts/validate.sh origin/main

Closes #420