### PR TITLE
fix: make storage failure recovery actionable

### DIFF
--- a/Sources/BugNarrator/Models/AppError.swift
+++ b/Sources/BugNarrator/Models/AppError.swift
@@ -93,7 +93,7 @@ enum AppError: LocalizedError, Equatable {
         case .exportFailure(let message):
             return "Export failed: \(message)"
         case .storageFailure(let message):
-            return "Could not save local session history: \(message)"
+            return "Could not save local session history. The transcript is still in memory — copy it now from the popover before trying again. Details: \(message)"
         case .diagnosticsFailure(let message):
             return "BugNarrator could not prepare diagnostics: \(message)"
         }
@@ -179,7 +179,7 @@ enum AppError: LocalizedError, Equatable {
         case .exportConfigurationMissing:
             return "Finish export setup before continuing."
         case .storageFailure:
-            return "BugNarrator could not update local session history."
+            return "BugNarrator could not save the session. Copy your transcript before retrying."
         default:
             return nil
         }

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -368,16 +368,25 @@ struct MenuBarView: View {
 
     private var storageRecoverySection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("The transcript is still available in BugNarrator. After fixing local storage, open the transcript window and save it to history.")
+            Text("The transcript is still available in BugNarrator. Copy it now, then fix local storage and save it to history.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Button("Open Transcript Window") {
-                appState.openTranscriptHistory()
+            HStack(spacing: 8) {
+                Button("Copy Transcript") {
+                    appState.copyDisplayedTranscript()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(appState.currentTranscript?.hasTranscriptContent != true)
+
+                Button("Open Transcript Window") {
+                    appState.openTranscriptHistory()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
         }
     }
 

--- a/Tests/BugNarratorTests/AppErrorTests.swift
+++ b/Tests/BugNarratorTests/AppErrorTests.swift
@@ -28,6 +28,19 @@ final class AppErrorTests: XCTestCase {
         XCTAssertEqual(AppError.screenRecordingPermissionDenied.recoveryHeadline, "Screen recording access is blocked.")
     }
 
+    func testStorageFailureGivesActionableRecoveryGuidance() {
+        let error = AppError.storageFailure("Disk full")
+
+        XCTAssertEqual(
+            error.userMessage,
+            "Could not save local session history. The transcript is still in memory — copy it now from the popover before trying again. Details: Disk full"
+        )
+        XCTAssertEqual(
+            error.recoveryHeadline,
+            "BugNarrator could not save the session. Copy your transcript before retrying."
+        )
+    }
+
     func testOpenAIKeyErrorsUseSpecificStatusPresentation() {
         XCTAssertEqual(AppError.missingAPIKey.statusTitle, "OpenAI Key Needed")
         XCTAssertEqual(AppError.invalidAPIKey.statusTitle, "OpenAI Key Rejected")

--- a/Tests/BugNarratorTests/AppStateTests.swift
+++ b/Tests/BugNarratorTests/AppStateTests.swift
@@ -627,7 +627,7 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertTrue(
-            harness.appState.status.detail?.hasPrefix("Transcript ready, but Could not save local session history:") == true
+            harness.appState.status.detail?.hasPrefix("Transcript ready, but Could not save local session history. The transcript is still in memory") == true
         )
         XCTAssertEqual(harness.appState.currentTranscript?.transcript, "Transcript survived local save failure.")
         XCTAssertFalse(harness.appState.currentTranscriptIsPersisted)
@@ -2194,7 +2194,7 @@ final class AppStateTests: XCTestCase {
 
         XCTAssertEqual(harness.appState.status.phase, .error)
         XCTAssertTrue(
-            harness.appState.status.detail?.hasPrefix("Could not save local session history:") == true
+            harness.appState.status.detail?.hasPrefix("Could not save local session history. The transcript is still in memory") == true
         )
         XCTAssertEqual(
             harness.appState.currentTranscript?.issueExtraction?.issues.first?.title,


### PR DESCRIPTION
## Summary
- Tell users to copy the in-memory transcript when local session history cannot be saved
- Add a Copy Transcript action to the menu-bar storage recovery section
- Update storage failure regression coverage

## Validation
- ./scripts/validate.sh origin/main

Closes #362