### PR TITLE
UX: Microphone-permission deny offers recovery only after a failed recording attempt (#364)

### DIFF
--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreGraphics
 import SwiftUI
 
 struct MenuBarView: View {
@@ -87,7 +88,18 @@ struct MenuBarView: View {
             return false
         }
 
-        return AVCaptureDevice.authorizationStatus(for: .audio) != .authorized
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .denied, .restricted:
+            return true
+        case .authorized, .notDetermined:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private var screenRecordingSetupIncomplete: Bool {
+        !CGPreflightScreenCaptureAccess()
     }
 
     private var setupBanner: some View {
@@ -441,6 +453,7 @@ struct MenuBarView: View {
             .accessibilityHint("Opens the recording controls window.")
 
             microphoneLevelSection
+            screenRecordingPermissionSection
 
             switch appState.status.phase {
             case .idle:
@@ -515,6 +528,30 @@ struct MenuBarView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+
+    @ViewBuilder
+    private var screenRecordingPermissionSection: some View {
+        if screenRecordingSetupIncomplete {
+            VStack(alignment: .leading, spacing: 7) {
+                Label("Screenshot access is not enabled", systemImage: "camera.viewfinder")
+                    .font(.footnote.weight(.semibold))
+
+                Text("Recording can continue without screenshots. Enable Screen Recording if you want BugNarrator to capture screenshots during a session.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button("Open Screen Recording Settings") {
+                    appState.openScreenRecordingPrivacySettings()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityLabel("Open Screen Recording privacy settings")
+                .accessibilityHint("Opens the macOS privacy settings for screen recording access")
             }
             .padding(.vertical, 2)
         }

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -1,4 +1,6 @@
 import AppKit
+import AVFoundation
+import CoreGraphics
 import SwiftUI
 
 struct SettingsView: View {
@@ -140,6 +142,24 @@ struct SettingsView: View {
                         Text("If you deny a permission, BugNarrator shows recovery buttons in the menu bar window so you can reopen the right System Settings pane.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
+
+                        if microphonePermissionBlocked {
+                            permissionRecoveryRow(
+                                title: "Microphone access is blocked.",
+                                message: "Open System Settings, enable BugNarrator for Microphone access, then start recording again.",
+                                buttonTitle: "Open Microphone Settings",
+                                action: appState.openMicrophonePrivacySettings
+                            )
+                        }
+
+                        if screenRecordingPermissionMissing {
+                            permissionRecoveryRow(
+                                title: "Screenshot access is not enabled.",
+                                message: "Recording can continue without screenshots. Enable Screen Recording if you want screenshots during a session.",
+                                buttonTitle: "Open Screen Recording Settings",
+                                action: appState.openScreenRecordingPrivacySettings
+                            )
+                        }
                     }
                 }
 
@@ -650,6 +670,25 @@ struct SettingsView: View {
             : [.microphone]
     }
 
+    private var microphonePermissionBlocked: Bool {
+        guard settingsStore.recordingAudioSource.usesMicrophone else {
+            return false
+        }
+
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .denied, .restricted:
+            return true
+        case .authorized, .notDetermined:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private var screenRecordingPermissionMissing: Bool {
+        !CGPreflightScreenCaptureAccess()
+    }
+
     private var openAIReadiness: SettingsReadinessStatus {
         if !settingsStore.aiProvider.requiresAPIKey {
             return settingsStore.aiProviderConfigurationIsReady ? .ready : .needsSetup
@@ -871,6 +910,26 @@ struct SettingsView: View {
         Text(text)
             .font(.footnote)
             .foregroundStyle(.secondary)
+    }
+
+    private func permissionRecoveryRow(
+        title: String,
+        message: String,
+        buttonTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.footnote.weight(.semibold))
+
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Button(buttonTitle, action: action)
+                .controlSize(.small)
+        }
+        .padding(.top, 4)
     }
 
     private func calloutColor(for tone: SettingsCalloutTone) -> Color {


### PR DESCRIPTION
Closes #364

## Summary
- Surface blocked microphone recovery from current macOS authorization state before a failed recording attempt.
- Add pre-failure Screen Recording recovery in the menu bar controls and Settings permissions section.
- Keep copy clear that recording can continue without screenshots.

## Validation
- ./scripts/validate.sh origin/main
- git diff --check
- git secrets --scan (no findings)

## Security
- No open security findings were identified in scope for this UI recovery fix.
