### PR TITLE
UX: No "Reveal in Finder" affordance after a recording save or issue-export success (#365)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -349,6 +349,13 @@ final class AppState: ObservableObject {
             errorPresenter: self.errorPresenter,
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() }
         )
+        let appUtilityActionPresenter = AppUtilityActionResultPresenter(
+            statusPhase: { presentationState.status.phase },
+            setStatus: { status in
+                presentationState.setStatus(status, error: nil)
+            }
+        )
+        self.appUtilityActionPresenter = appUtilityActionPresenter
         self.finishedRecordingPostTranscriptionResultHandler = FinishedRecordingPostTranscriptionResultHandler(
             sessionLibrary: sessionLibrary,
             recordingSessionController: recordingSessionController,
@@ -358,15 +365,25 @@ final class AppState: ObservableObject {
             autoCopyTranscript: { settingsStore.autoCopyTranscript },
             cleanupPendingRecordedAudio: {
                 recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
+            },
+            showSavedSessionReveal: { session in
+                guard let artifactsDirectoryURL = session.artifactsDirectoryURL else {
+                    return
+                }
+
+                transientToastController.showToast(
+                    "Session saved",
+                    style: .success,
+                    durationNanoseconds: 5_000_000_000,
+                    action: TransientToastAction(
+                        title: "Reveal",
+                        accessibilityLabel: "Reveal in Finder"
+                    ) {
+                        appUtilityActionPresenter.present(appUtilityActions.revealInFinder(artifactsDirectoryURL))
+                    }
+                )
             }
         )
-        let appUtilityActionPresenter = AppUtilityActionResultPresenter(
-            statusPhase: { presentationState.status.phase },
-            setStatus: { status in
-                presentationState.setStatus(status, error: nil)
-            }
-        )
-        self.appUtilityActionPresenter = appUtilityActionPresenter
         self.supportDataActionPresenter = SupportDataActionPresenter(
             presentationState: presentationState,
             errorPresenter: self.errorPresenter,
@@ -1170,6 +1187,9 @@ final class AppState: ObservableObject {
             }
 
             issueExportPresentationController.presentCompletion(completion)
+            if completion.performedRemoteExport {
+                showRevealInFinderToast("Export receipt saved", revealing: ExportReceiptStore.defaultStorageURL)
+            }
             await refreshExportHistory()
         } catch {
             recordingSessionController.endActivity()
@@ -1179,6 +1199,24 @@ final class AppState: ObservableObject {
 
     func openScreenshot(_ screenshot: SessionScreenshot) {
         appUtilityActionPresenter.present(appUtilityActions.openScreenshot(screenshot))
+    }
+
+    func showRevealInFinderToast(_ message: String, revealing url: URL) {
+        transientToastController.showToast(
+            message,
+            style: .success,
+            durationNanoseconds: 5_000_000_000,
+            action: TransientToastAction(
+                title: "Reveal",
+                accessibilityLabel: "Reveal in Finder"
+            ) { [weak self] in
+                self?.revealInFinder(url)
+            }
+        )
+    }
+
+    func revealInFinder(_ url: URL) {
+        appUtilityActionPresenter.present(appUtilityActions.revealInFinder(url))
     }
 
     private func prepareErrorPresentationSideEffects() {

--- a/Sources/BugNarrator/Models/TransientToast.swift
+++ b/Sources/BugNarrator/Models/TransientToast.swift
@@ -14,13 +14,39 @@ enum TransientToastStyle: String, Equatable {
     }
 }
 
+struct TransientToastAction: Equatable {
+    let title: String
+    let accessibilityLabel: String
+    let perform: @MainActor () -> Void
+
+    init(
+        title: String,
+        accessibilityLabel: String? = nil,
+        perform: @escaping @MainActor () -> Void
+    ) {
+        self.title = title
+        self.accessibilityLabel = accessibilityLabel ?? title
+        self.perform = perform
+    }
+
+    static func == (lhs: TransientToastAction, rhs: TransientToastAction) -> Bool {
+        lhs.title == rhs.title && lhs.accessibilityLabel == rhs.accessibilityLabel
+    }
+}
+
 struct TransientToast: Identifiable, Equatable {
     let id = UUID()
     let message: String
     let style: TransientToastStyle
+    let action: TransientToastAction?
 
-    init(message: String, style: TransientToastStyle = .success) {
+    init(
+        message: String,
+        style: TransientToastStyle = .success,
+        action: TransientToastAction? = nil
+    ) {
         self.message = message
         self.style = style
+        self.action = action
     }
 }

--- a/Sources/BugNarrator/Services/ExportReceiptStore.swift
+++ b/Sources/BugNarrator/Services/ExportReceiptStore.swift
@@ -51,6 +51,9 @@ protocol ExportReceiptStoring: Sendable {
 }
 
 actor ExportReceiptStore: ExportReceiptStoring {
+    static let defaultStorageURL = AppSupportLocation.appDirectory()
+        .appendingPathComponent("export-receipts.json", isDirectory: false)
+
     private let fileManager: FileManager
     private let storageURL: URL
     private let encoder = JSONEncoder()
@@ -59,8 +62,7 @@ actor ExportReceiptStore: ExportReceiptStoring {
 
     init(
         fileManager: FileManager = .default,
-        storageURL: URL = AppSupportLocation.appDirectory()
-            .appendingPathComponent("export-receipts.json", isDirectory: false)
+        storageURL: URL = ExportReceiptStore.defaultStorageURL
     ) {
         self.fileManager = fileManager
         self.storageURL = storageURL

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -144,6 +144,7 @@ final class FinishedRecordingPostTranscriptionResultHandler {
     private let postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter
     private let autoCopyTranscript: () -> Bool
     private let cleanupPendingRecordedAudio: () -> Void
+    private let showSavedSessionReveal: (TranscriptSession) -> Void
 
     init(
         sessionLibrary: SessionLibraryController,
@@ -152,7 +153,8 @@ final class FinishedRecordingPostTranscriptionResultHandler {
         transcriptPersistenceFailurePresenter: TranscriptPersistenceFailurePresenter,
         postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter,
         autoCopyTranscript: @escaping () -> Bool,
-        cleanupPendingRecordedAudio: @escaping () -> Void
+        cleanupPendingRecordedAudio: @escaping () -> Void,
+        showSavedSessionReveal: @escaping (TranscriptSession) -> Void = { _ in }
     ) {
         self.sessionLibrary = sessionLibrary
         self.recordingSessionController = recordingSessionController
@@ -161,14 +163,16 @@ final class FinishedRecordingPostTranscriptionResultHandler {
         self.postTranscriptionFailurePresenter = postTranscriptionFailurePresenter
         self.autoCopyTranscript = autoCopyTranscript
         self.cleanupPendingRecordedAudio = cleanupPendingRecordedAudio
+        self.showSavedSessionReveal = showSavedSessionReveal
     }
 
     func handle(_ result: PostTranscriptionPipelineResult) {
         switch result {
-        case .success:
+        case .success(let session):
             cleanupPendingRecordedAudio()
             recordingSessionController.endActivity()
             statusPresenter.presentSuccess()
+            showSavedSessionReveal(session)
 
         case .persistenceFailure(let session, let error):
             handleCompletedTranscriptPersistenceFailure(error, session: session)

--- a/Sources/BugNarrator/Services/TranscriptExporter.swift
+++ b/Sources/BugNarrator/Services/TranscriptExporter.swift
@@ -45,7 +45,7 @@ struct TranscriptExporter {
         self.bundleWriter = AtomicBundleDirectoryWriter(fileManager: fileManager)
     }
 
-    func export(session: TranscriptSession, as format: TranscriptExportFormat) throws {
+    func export(session: TranscriptSession, as format: TranscriptExportFormat) throws -> URL? {
         let savePanel = NSSavePanel()
         savePanel.allowedContentTypes = [format.contentType]
         savePanel.canCreateDirectories = true
@@ -53,7 +53,7 @@ struct TranscriptExporter {
         savePanel.nameFieldStringValue = session.suggestedFileName(fileExtension: format.fileExtension)
 
         guard savePanel.runModal() == .OK, let url = savePanel.url else {
-            return
+            return nil
         }
 
         let content: String
@@ -73,9 +73,10 @@ struct TranscriptExporter {
                 "format": format.fileExtension
             ]
         )
+        return url
     }
 
-    func exportBundle(session: TranscriptSession) throws {
+    func exportBundle(session: TranscriptSession) throws -> URL? {
         let openPanel = NSOpenPanel()
         openPanel.canChooseFiles = false
         openPanel.canChooseDirectories = true
@@ -85,10 +86,10 @@ struct TranscriptExporter {
         openPanel.message = "Choose a folder for the exported BugNarrator session bundle."
 
         guard openPanel.runModal() == .OK, let destinationRoot = openPanel.url else {
-            return
+            return nil
         }
 
-        _ = try writeBundle(session: session, to: destinationRoot)
+        return try writeBundle(session: session, to: destinationRoot)
     }
 
     func writeBundle(session: TranscriptSession, to destinationRoot: URL) throws -> URL {

--- a/Sources/BugNarrator/Services/TransientToastController.swift
+++ b/Sources/BugNarrator/Services/TransientToastController.swift
@@ -16,10 +16,11 @@ final class TransientToastController {
     func showToast(
         _ message: String,
         style: TransientToastStyle = .success,
-        durationNanoseconds: UInt64 = 2_000_000_000
+        durationNanoseconds: UInt64 = 2_000_000_000,
+        action: TransientToastAction? = nil
     ) {
         dismissTask?.cancel()
-        presentationState.showToast(TransientToast(message: message, style: style))
+        presentationState.showToast(TransientToast(message: message, style: style, action: action))
         dismissTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: durationNanoseconds)
             guard !Task.isCancelled else {

--- a/Sources/BugNarrator/Views/RecordingControlPanelView.swift
+++ b/Sources/BugNarrator/Views/RecordingControlPanelView.swift
@@ -22,19 +22,7 @@ struct RecordingControlPanelView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .top) {
             if let transientToast = appState.transientToast {
-                Label(transientToast.message, systemImage: transientToast.style.symbolName)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(transientToast.style == .success ? .green : .secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(.regularMaterial, in: Capsule())
-                    .overlay(
-                        Capsule()
-                            .stroke(.quaternary.opacity(0.55), lineWidth: 1)
-                    )
-                    .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
-                    .padding(.top, 10)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                transientToastView(transientToast)
             }
         }
         .animation(.easeInOut(duration: 0.18), value: appState.transientToast)
@@ -62,6 +50,35 @@ struct RecordingControlPanelView: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(statusTint)
         }
+    }
+
+    private func transientToastView(_ transientToast: TransientToast) -> some View {
+        HStack(spacing: 8) {
+            Label(transientToast.message, systemImage: transientToast.style.symbolName)
+
+            if let action = transientToast.action {
+                Divider()
+                    .frame(height: 14)
+
+                Button(action.title) {
+                    action.perform()
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(action.accessibilityLabel)
+            }
+        }
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(transientToast.style == .success ? .green : .secondary)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(.quaternary.opacity(0.55), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.12), radius: 6, y: 2)
+        .padding(.top, 10)
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     private var statusSummary: some View {

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -1967,7 +1967,9 @@ struct TranscriptView: View {
 
     private func export(session: TranscriptSession, format: TranscriptExportFormat) {
         do {
-            try exporter.export(session: session, as: format)
+            if let exportedURL = try exporter.export(session: session, as: format) {
+                appState.showRevealInFinderToast("Transcript exported", revealing: exportedURL)
+            }
         } catch {
             exportErrorMessage = error.localizedDescription
         }
@@ -1975,7 +1977,9 @@ struct TranscriptView: View {
 
     private func exportBundle(session: TranscriptSession) {
         do {
-            try exporter.exportBundle(session: session)
+            if let bundleURL = try exporter.exportBundle(session: session) {
+                appState.showRevealInFinderToast("Session bundle exported", revealing: bundleURL)
+            }
         } catch {
             exportErrorMessage = error.localizedDescription
         }

--- a/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
@@ -10,12 +10,14 @@ final class FinishedRecordingPostTranscriptionResultHandlerTests: XCTestCase {
         harness.audioRecorder.stopResults = [.success(recordedAudio)]
         _ = try await harness.recordingSessionController.stopRecording()
 
-        harness.handler.handle(.success(makeSampleTranscriptSession(index: 1)))
+        let session = makeSampleTranscriptSession(index: 1)
+        harness.handler.handle(.success(session))
 
         XCTAssertNil(harness.recordingSessionController.pendingRecordedAudioSnapshot)
         XCTAssertFalse(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
         XCTAssertEqual(harness.presentationState.status.phase, .success)
         XCTAssertEqual(harness.presentationState.status.detail, "Session saved. Transcript copied to the clipboard.")
+        XCTAssertEqual(harness.revealSpy.sessionIDs, [session.id])
         XCTAssertFalse(harness.transcriptWindowSpy.didShow)
     }
 
@@ -72,6 +74,7 @@ private final class FinishedRecordingPostTranscriptionResultHandlerHarness {
     let presentationState: AppPresentationState
     let transcriptWindowSpy = TranscriptWindowSpy()
     let settingsWindowSpy = SettingsWindowSpy()
+    let revealSpy = SavedSessionRevealSpy()
     let handler: FinishedRecordingPostTranscriptionResultHandler
 
     init(debugMode: Bool = false) throws {
@@ -141,6 +144,9 @@ private final class FinishedRecordingPostTranscriptionResultHandlerHarness {
             autoCopyTranscript: { true },
             cleanupPendingRecordedAudio: { [recordingSessionController] in
                 recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: debugMode)
+            },
+            showSavedSessionReveal: { [revealSpy] session in
+                revealSpy.sessionIDs.append(session.id)
             }
         )
     }
@@ -164,4 +170,9 @@ private final class TranscriptWindowSpy {
 @MainActor
 private final class SettingsWindowSpy {
     var didShow = false
+}
+
+@MainActor
+private final class SavedSessionRevealSpy {
+    var sessionIDs: [UUID] = []
 }

--- a/Tests/BugNarratorTests/TransientToastTests.swift
+++ b/Tests/BugNarratorTests/TransientToastTests.swift
@@ -18,4 +18,20 @@ final class TransientToastTests: XCTestCase {
         XCTAssertEqual(toast.style, .informational)
         XCTAssertEqual(toast.style.symbolName, "xmark.circle")
     }
+
+    @MainActor
+    func testToastActionRunsHandler() {
+        var didRun = false
+        let toast = TransientToast(
+            message: "Session saved.",
+            action: TransientToastAction(title: "Reveal") {
+                didRun = true
+            }
+        )
+
+        toast.action?.perform()
+
+        XCTAssertEqual(toast.action?.title, "Reveal")
+        XCTAssertTrue(didRun)
+    }
 }


### PR DESCRIPTION
Closes #365

## Summary
- Add optional actions to transient toasts and render a Reveal button in the recording controls toast.
- Surface Reveal in Finder for saved sessions, transcript exports, session bundle exports, and local issue-export receipt JSON.
- Keep the receipt path centralized through ExportReceiptStore.defaultStorageURL.

## Tests
- Added coverage for toast actions.
- Added coverage that finished-recording success invokes the saved-session reveal hook.

## Validation
- ./scripts/validate.sh origin/main
- git diff --check
- git secrets --scan (no findings)

## Security
- No open security findings were identified in scope for this UI artifact-reveal fix.
