### PR TITLE
ONBOARD: Empty Session Library shows no CTA — "Try a Recording" pointer to the menu bar (#377)

### DIFF
--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -201,6 +201,16 @@ struct TranscriptView: View {
                         appState.openSettings()
                     }
                 }
+            } else if allSessions.isEmpty {
+                ContentUnavailableView {
+                    Label("No sessions yet", systemImage: "waveform")
+                } description: {
+                    Text("Open the recording controls to capture your first BugNarrator session.")
+                } actions: {
+                    Button("Open Recording Controls") {
+                        appState.openRecordingControls()
+                    }
+                }
             } else if let emptyState {
                 ContentUnavailableView {
                     Label(emptyState.title, systemImage: emptyState.systemImage)


### PR DESCRIPTION
Closes #377

## Summary
- Add a configured-but-empty session library state.
- Provide an Open Recording Controls CTA so first-time users can start a session from the library.

## Notes
- Kept the animated menu-bar pointer out of scope to avoid adding a separate notification/animation path in this small PR.

## Validation
- ./scripts/validate.sh origin/main
- git diff --check
- git secrets --scan (no findings)

## Security
- No open security findings were identified in scope for this empty-state UI fix.
