### PR TITLE
ARCH: Extract TranscriptView shared helpers (#440)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
 		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
+		56FD14656CE943A240D9DEE5 /* TranscriptSharedHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */; };
 		57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */; };
 		58E53F2092F34D45456CE5DF /* IssueExtractionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */; };
 		58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */; };
@@ -349,6 +350,7 @@
 		C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitorTests.swift; sourceTree = "<group>"; };
 		C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusTests.swift; sourceTree = "<group>"; };
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
+		C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSharedHelpers.swift; sourceTree = "<group>"; };
 		C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
 		C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsServiceTests.swift; sourceTree = "<group>"; };
@@ -547,6 +549,7 @@
 				0DF81E6E8D3A702691797E56 /* SupportView.swift */,
 				A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */,
 				B09CA463A8DF59221937A2C7 /* TranscriptView.swift */,
+				DAC46A7438CFA4B1A35966FB /* Transcript */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -655,6 +658,14 @@
 				7E537D104A7237092C8B8BC4 /* BugNarratorUITests */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		DAC46A7438CFA4B1A35966FB /* Transcript */ = {
+			isa = PBXGroup;
+			children = (
+				C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */,
+			);
+			path = Transcript;
 			sourceTree = "<group>";
 		};
 		F51E64F23D5FFCED4B1BE72E /* Products */ = {
@@ -965,6 +976,7 @@
 				6E7D93B7718A9340695B3B76 /* TranscriptSection.swift in Sources */,
 				05FAED3D483F3C16AEFFB7A5 /* TranscriptSectionBuilder.swift in Sources */,
 				9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */,
+				56FD14656CE943A240D9DEE5 /* TranscriptSharedHelpers.swift in Sources */,
 				A6AF1CAA204EF971F9417E63 /* TranscriptStore.swift in Sources */,
 				29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */,
 				33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */,

--- a/Sources/BugNarrator/Views/Transcript/TranscriptSharedHelpers.swift
+++ b/Sources/BugNarrator/Views/Transcript/TranscriptSharedHelpers.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+
+func normalizedOptionalReproductionStepText(_ value: String) -> String? {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedValue.isEmpty ? nil : trimmedValue
+}
+
+func normalizedOptionalIssueText(_ value: String) -> String? {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmedValue.isEmpty ? nil : trimmedValue
+}
+
+extension TranscriptView {
+    var dividerSection: some View {
+        Divider()
+            .overlay(Color(nsColor: .separatorColor).opacity(0.45))
+    }
+
+    func reviewSectionCard<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(.quaternary.opacity(0.24), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    func metadataChip(label: String, systemImage: String) -> some View {
+        return Label(label, systemImage: systemImage)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(0.32), in: Capsule())
+    }
+
+    func emptyDetailState(title: String, message: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+    }
+
+    func resolveSession(for entry: SessionLibraryEntry) -> TranscriptSession? {
+        if appState.currentTranscript?.id == entry.id {
+            return appState.currentTranscript
+        }
+
+        return transcriptStore.session(with: entry.id)
+    }
+
+    func extractedIssue(sessionID: UUID, issueID: UUID) -> ExtractedIssue? {
+        let sourceSession = liveSession(with: sessionID)
+        return sourceSession?.issueExtraction?.issues.first(where: { $0.id == issueID })
+    }
+
+    func liveSession(with sessionID: UUID) -> TranscriptSession? {
+        if appState.currentTranscript?.id == sessionID {
+            return appState.currentTranscript
+        }
+
+        return transcriptStore.session(with: sessionID)
+    }
+
+    func screenshotActionLabel(for screenshot: SessionScreenshot, index: Int?, action: String) -> String {
+        let ordinal = index.map { "Screenshot \($0 + 1)" } ?? "Screenshot"
+        return "\(action) \(ordinal) at \(screenshot.timeLabel)"
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -1,16 +1,6 @@
 import AppKit
 import SwiftUI
 
-func normalizedOptionalReproductionStepText(_ value: String) -> String? {
-    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmedValue.isEmpty ? nil : trimmedValue
-}
-
-func normalizedOptionalIssueText(_ value: String) -> String? {
-    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmedValue.isEmpty ? nil : trimmedValue
-}
-
 struct TranscriptView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var recordingTimer: RecordingTimerViewModel
@@ -772,11 +762,6 @@ struct TranscriptView: View {
         "\(session.createdAt.formatted(date: .abbreviated, time: .shortened)) • \(ElapsedTimeFormatter.string(from: session.duration)) • \(session.model)"
     }
 
-    private var dividerSection: some View {
-        Divider()
-            .overlay(Color(nsColor: .separatorColor).opacity(0.45))
-    }
-
     private func workspaceActions(_ session: TranscriptSession, availableWidth: CGFloat) -> some View {
         Group {
             if availableWidth < 420 {
@@ -831,22 +816,6 @@ struct TranscriptView: View {
                 rawTranscriptSection(session, availableWidth: availableWidth)
             }
         }
-    }
-
-    private func reviewSectionCard<Content: View>(
-        _ title: String,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
-                .accessibilityAddTraits(.isHeader)
-
-            content()
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .background(.quaternary.opacity(0.24), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     @ViewBuilder
@@ -1061,15 +1030,6 @@ struct TranscriptView: View {
                 }
             }
         }
-    }
-
-    private func metadataChip(label: String, systemImage: String) -> some View {
-        return Label(label, systemImage: systemImage)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(.quaternary.opacity(0.32), in: Capsule())
     }
 
     @ViewBuilder
@@ -1415,19 +1375,6 @@ struct TranscriptView: View {
             let liveItem = currentExportReviewItem(for: item.issue.id) ?? item
             return liveItem.resolution == .exportNew || liveItem.selectedMatch != nil
         }
-    }
-
-    private func emptyDetailState(title: String, message: String) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.headline)
-
-            Text(message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 8)
     }
 
     private func extractIssuesButton(for session: TranscriptSession) -> some View {
@@ -1949,14 +1896,6 @@ struct TranscriptView: View {
         }
     }
 
-    private func resolveSession(for entry: SessionLibraryEntry) -> TranscriptSession? {
-        if appState.currentTranscript?.id == entry.id {
-            return appState.currentTranscript
-        }
-
-        return transcriptStore.session(with: entry.id)
-    }
-
     @ViewBuilder
     private func fieldEditor(title: String, text: Binding<String>, minHeight: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1993,11 +1932,6 @@ struct TranscriptView: View {
         } catch {
             exportErrorMessage = error.localizedDescription
         }
-    }
-
-    private func extractedIssue(sessionID: UUID, issueID: UUID) -> ExtractedIssue? {
-        let sourceSession = liveSession(with: sessionID)
-        return sourceSession?.issueExtraction?.issues.first(where: { $0.id == issueID })
     }
 
     private func effectiveGitHubTarget(for issue: ExtractedIssue) -> GitHubIssueExportTarget {
@@ -2044,14 +1978,6 @@ struct TranscriptView: View {
         extractedIssue(sessionID: sessionID, issueID: issueID)?
             .reproductionSteps
             .first(where: { $0.id == stepID })
-    }
-
-    private func liveSession(with sessionID: UUID) -> TranscriptSession? {
-        if appState.currentTranscript?.id == sessionID {
-            return appState.currentTranscript
-        }
-
-        return transcriptStore.session(with: sessionID)
     }
 
     private func issueBinding<Value>(
@@ -2399,11 +2325,6 @@ struct TranscriptView: View {
         }
 
         return components.joined(separator: ". ")
-    }
-
-    private func screenshotActionLabel(for screenshot: SessionScreenshot, index: Int?, action: String) -> String {
-        let ordinal = index.map { "Screenshot \($0 + 1)" } ?? "Screenshot"
-        return "\(action) \(ordinal) at \(screenshot.timeLabel)"
     }
 
     private func sessionPreview(for entry: SessionLibraryEntry) -> String {


### PR DESCRIPTION
Closes #440
Refs #401

## Summary
- Moved shared TranscriptView helpers into `TranscriptSharedHelpers.swift`.
- Added the new helper file to the Xcode project target membership.
- Preserved existing UI strings, empty-state rendering, metadata chips, selection lookup, screenshot action labels, and normalization behavior.
- Kept the broader TranscriptView decomposition tracked in #401 for later section-level extractions.

## Tests
- No new behavioral tests; this is a pure helper move. Existing validation covers compilation and current test suites.

## Validation
- `./scripts/validate.sh origin/main`
- `xcodebuild -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

## Security
- No security finding was in scope for this view-only refactor.
- No secrets or credential material introduced.