### PR TITLE
feat: auto-show What's New once after each version bump

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -875,6 +875,21 @@ final class AppState: ObservableObject {
         appUtilityActionPresenter.present(appUtilityActions.checkForUpdates())
     }
 
+    /// Presents the changelog once after a version bump. Records the shown
+    /// version immediately so a force-quit before dismissal does not re-trigger.
+    func presentChangelogIfNeeded(metadata: BugNarratorMetadata = BugNarratorMetadata()) {
+        let hasExistingUserState = !transcriptStore.sessions.isEmpty
+        guard settingsStore.shouldAutoShowChangelog(
+            currentVersion: metadata.version,
+            hasExistingUserState: hasExistingUserState
+        ) else {
+            return
+        }
+
+        settingsStore.markChangelogShown(version: metadata.version)
+        showChangelogWindow?()
+    }
+
     func copyDebugInfo() {
         let result = supportDataController.copyDebugInfo(sessionID: currentDebugSessionID)
         supportDataActionPresenter.presentCopyDebugInfo(result)

--- a/Sources/BugNarrator/BugNarratorApp.swift
+++ b/Sources/BugNarrator/BugNarratorApp.swift
@@ -50,6 +50,8 @@ private struct WindowSceneRegistrar: View {
                 appState.showSupportWindow = { [weak windowCoordinator] in
                     windowCoordinator?.showSupportWindow()
                 }
+
+                appState.presentChangelogIfNeeded()
             }
     }
 }

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -437,6 +437,28 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    @Published var autoShowChangelogOnUpdate: Bool = true {
+        didSet {
+            guard hasLoaded else { return }
+            defaults.set(autoShowChangelogOnUpdate, forKey: Keys.autoShowChangelogOnUpdate)
+        }
+    }
+
+    /// Decides whether to auto-present the changelog once after a version bump.
+    /// Brand-new installs (no recorded version and no existing user state) defer
+    /// to onboarding instead of showing the changelog.
+    func shouldAutoShowChangelog(currentVersion: String, hasExistingUserState: Bool) -> Bool {
+        guard autoShowChangelogOnUpdate else { return false }
+        if let lastShown = stringValue(forKey: Keys.lastShownChangelogVersion) {
+            return lastShown != currentVersion
+        }
+        return hasExistingUserState
+    }
+
+    func markChangelogShown(version: String) {
+        defaults.set(version, forKey: Keys.lastShownChangelogVersion)
+    }
+
     @Published private(set) var apiKeyPersistenceState: APIKeyPersistenceState = .empty
     @Published private(set) var githubTokenPersistenceState: APIKeyPersistenceState = .empty
     @Published private(set) var jiraTokenPersistenceState: APIKeyPersistenceState = .empty
@@ -1181,6 +1203,7 @@ final class SettingsStore: ObservableObject {
 
         debugMode = boolValue(forKey: Keys.debugMode) ?? false
         operationalTelemetryEnabled = boolValue(forKey: Keys.operationalTelemetryEnabled) ?? true
+        autoShowChangelogOnUpdate = boolValue(forKey: Keys.autoShowChangelogOnUpdate) ?? true
         migrateLegacyBuiltInHotkeysIfNeeded()
         normalizeLoadedHotkeyConflicts()
         BugNarratorDiagnostics.setDebugModeEnabled(debugMode)
@@ -1975,6 +1998,8 @@ private enum Keys {
     static let jiraIssueType = "settings.jiraIssueType"
     static let debugMode = "settings.debugMode"
     static let operationalTelemetryEnabled = OperationalTelemetryRecorder.enabledDefaultsKey
+    static let autoShowChangelogOnUpdate = "settings.autoShowChangelogOnUpdate"
+    static let lastShownChangelogVersion = "settings.lastShownChangelogVersion"
 }
 
 enum APIKeyPersistenceState: Equatable {

--- a/Sources/BugNarrator/Views/ChangelogView.swift
+++ b/Sources/BugNarrator/Views/ChangelogView.swift
@@ -2,11 +2,13 @@ import SwiftUI
 
 struct ChangelogView: View {
     @ObservedObject var appState: AppState
+    @ObservedObject private var settingsStore: SettingsStore
 
     private let changelog: ChangelogDocument
 
     init(appState: AppState, changelog: ChangelogDocument = ChangelogDocument()) {
         self.appState = appState
+        self.settingsStore = appState.settingsStore
         self.changelog = changelog
     }
 
@@ -43,6 +45,10 @@ struct ChangelogView: View {
             Text("Release notes for BugNarrator. Use this as a lightweight in-app view of the bundled changelog.")
                 .font(.body)
                 .foregroundStyle(.secondary)
+
+            Toggle("Show automatically after each update", isOn: $settingsStore.autoShowChangelogOnUpdate)
+                .font(.subheadline)
+                .accessibilityLabel("Show the changelog automatically after each update")
         }
     }
 }

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -11,6 +11,53 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testShouldAutoShowChangelogDefersOnBrandNewInstall() {
+        let suiteName = "BugNarrator-ChangelogAutoShow-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        // Brand-new install: no recorded version, no existing user state -> defer to onboarding.
+        XCTAssertFalse(store.shouldAutoShowChangelog(currentVersion: "1.0.40", hasExistingUserState: false))
+        // Upgrade from a pre-feature version (existing sessions, no recorded version) -> show once.
+        XCTAssertTrue(store.shouldAutoShowChangelog(currentVersion: "1.0.40", hasExistingUserState: true))
+    }
+
+    func testShouldAutoShowChangelogTracksVersionAndOptOut() {
+        let suiteName = "BugNarrator-ChangelogAutoShow-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        store.markChangelogShown(version: "1.0.40")
+        // Same version after shown -> no re-show.
+        XCTAssertFalse(store.shouldAutoShowChangelog(currentVersion: "1.0.40", hasExistingUserState: true))
+        // New version -> show again.
+        XCTAssertTrue(store.shouldAutoShowChangelog(currentVersion: "1.0.41", hasExistingUserState: true))
+
+        // Opt-out suppresses all auto-shows regardless of version.
+        store.autoShowChangelogOnUpdate = false
+        XCTAssertFalse(store.shouldAutoShowChangelog(currentVersion: "1.0.41", hasExistingUserState: true))
+    }
+
+    func testAutoShowChangelogPreferencePersists() {
+        let suiteName = "BugNarrator-ChangelogAutoShowPersist-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let first = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        XCTAssertTrue(first.autoShowChangelogOnUpdate)
+        first.autoShowChangelogOnUpdate = false
+
+        let second = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+        XCTAssertFalse(second.autoShowChangelogOnUpdate)
+    }
+
     func testFirstLaunchStartsWithAllHotkeysDisabled() {
         let suiteName = "BugNarrator-SettingsNoHotkeyDefaultsTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
Closes #386

## Summary
On launch, present the existing changelog view once when the app version differs from the last-shown version. Brand-new installs (no recorded version + empty library) defer to onboarding. Adds a "Show automatically after each update" opt-out toggle; persists the shown version immediately so a force-quit before dismissal doesn't re-trigger.

## Validation
- [x] Build succeeds
- [x] 59 SettingsStore tests pass (3 new: brand-new-install defer, version tracking + opt-out, persistence)
- [x] Guardrails pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)