### PR TITLE
feat: add Help menu (User Guide / Report a Bug / Repository)

### DIFF
--- a/Sources/BugNarrator/BugNarratorApp.swift
+++ b/Sources/BugNarrator/BugNarratorApp.swift
@@ -187,6 +187,19 @@ struct BugNarratorApp: App {
             .background(WindowSceneRegistrar(appState: appState, windowCoordinator: windowCoordinator))
         }
         .menuBarExtraStyle(.window)
+        .commands {
+            CommandGroup(replacing: .help) {
+                Button("BugNarrator User Guide") {
+                    NSWorkspace.shared.open(BugNarratorLinks.documentation)
+                }
+                Button("Report a Bug") {
+                    NSWorkspace.shared.open(BugNarratorLinks.issues)
+                }
+                Button("Visit Repository") {
+                    NSWorkspace.shared.open(BugNarratorLinks.repository)
+                }
+            }
+        }
 
         Window("BugNarrator Sessions", id: WindowCoordinator.SceneID.transcript) {
             TranscriptView(

--- a/Sources/BugNarrator/Views/SupportView.swift
+++ b/Sources/BugNarrator/Views/SupportView.swift
@@ -7,6 +7,7 @@ struct SupportView: View {
         VStack(alignment: .leading, spacing: 20) {
             headerSection
             actionSection
+            helpResourcesSection
             footerCard
             Spacer(minLength: 0)
         }
@@ -56,6 +57,20 @@ struct SupportView: View {
             .accessibilityLabel("Open the PayPal donation page")
             .accessibilityHint("Opens PayPal in your default browser")
         }
+        .padding(18)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private var helpResourcesSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Help & Resources")
+                .font(.headline)
+
+            Link("BugNarrator User Guide", destination: BugNarratorLinks.documentation)
+            Link("Report a Bug", destination: BugNarratorLinks.issues)
+            Link("Visit Repository", destination: BugNarratorLinks.repository)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(18)
         .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
     }

--- a/Tests/BugNarratorTests/ProductInfoTests.swift
+++ b/Tests/BugNarratorTests/ProductInfoTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import BugNarrator
 
 final class ProductInfoTests: XCTestCase {
+    func testHelpMenuLinkDestinations() {
+        // Locks the Help menu / Support view link destinations so an accidental
+        // edit to BugNarratorLinks is caught in CI.
+        XCTAssertEqual(
+            BugNarratorLinks.documentation.absoluteString,
+            "https://github.com/ABD-Enterprises/bug-narrator/blob/main/docs/UserGuide.md"
+        )
+        XCTAssertEqual(
+            BugNarratorLinks.issues.absoluteString,
+            "https://github.com/ABD-Enterprises/bug-narrator/issues/new"
+        )
+        XCTAssertEqual(
+            BugNarratorLinks.repository.absoluteString,
+            "https://github.com/ABD-Enterprises/bug-narrator"
+        )
+    }
+
     func testMetadataBuildsVersionDescriptionFromInfoDictionary() {
         let metadata = BugNarratorMetadata(
             infoDictionary: [


### PR DESCRIPTION
Closes #379

## Summary
- `CommandGroup(replacing: .help)` with three items opening existing `BugNarratorLinks` destinations.
- Mirrored as a "Help & Resources" section in the in-app Support view for parity.
- "Show Welcome Tour" item deferred until first-run onboarding (#357) exists (documented on #357).

## Validation
- [x] Build succeeds
- [x] ProductInfoTests pass (added a link-destination lock test)
- [x] Guardrails pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)