### PR TITLE
feat: suggested default shortcut on empty hotkey rows

### DIFF
--- a/Sources/BugNarrator/Models/HotkeyAction.swift
+++ b/Sources/BugNarrator/Models/HotkeyAction.swift
@@ -20,6 +20,12 @@ enum HotkeyAction: UInt32, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// Vetted default offered as a one-click suggestion on empty hotkey rows.
+    /// Uses ⌘⌥⌃-based combinations that avoid common macOS system shortcuts.
+    var suggestedShortcut: HotkeyShortcut? {
+        legacyBuiltInShortcut
+    }
+
     var legacyBuiltInShortcut: HotkeyShortcut? {
         switch self {
         case .startRecording:

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -484,6 +484,19 @@ final class SettingsStore: ObservableObject {
         ]
     }
 
+    /// The action's suggested default, but only when it is enabled and not
+    /// already assigned to a different action — so a suggestion never collides.
+    func suggestedShortcutIfAvailable(for action: HotkeyAction) -> HotkeyShortcut? {
+        guard let suggestion = action.suggestedShortcut, suggestion.isEnabled else {
+            return nil
+        }
+
+        let assignedElsewhere = hotkeyAssignments.contains {
+            $0.action != action && $0.shortcut == suggestion
+        }
+        return assignedElsewhere ? nil : suggestion
+    }
+
     var maskedAPIKey: String {
         mask(
             secret: trimmedAPIKey,

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -893,6 +893,18 @@ struct SettingsView: View {
             Text(action.title)
                 .font(.subheadline.weight(.medium))
             HotkeyRecorderView(actionTitle: action.title, shortcut: shortcut)
+
+            if !shortcut.wrappedValue.isEnabled,
+               let suggestion = settingsStore.suggestedShortcutIfAvailable(for: action) {
+                Button("Use suggested: \(suggestion.displayString)") {
+                    shortcut.wrappedValue = suggestion
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(secureControlsDisabled)
+                .help("Apply the recommended shortcut for \(action.title).")
+                .accessibilityLabel("Use suggested shortcut \(suggestion.displayString) for \(action.title)")
+            }
         }
         .accessibilityElement(children: .contain)
     }

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -58,6 +58,31 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(second.autoShowChangelogOnUpdate)
     }
 
+    func testSuggestedShortcutAvailableWhenUnassignedAndHiddenWhenTaken() {
+        let suiteName = "BugNarrator-HotkeySuggestion-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        // On a fresh install every row is empty, so each action offers its suggestion.
+        let startSuggestion = store.suggestedShortcutIfAvailable(for: .startRecording)
+        XCTAssertEqual(startSuggestion, HotkeyAction.startRecording.suggestedShortcut)
+
+        // Assigning Start's suggested shortcut to Stop must hide it from Start.
+        if let suggestion = HotkeyAction.startRecording.suggestedShortcut {
+            store.stopRecordingHotkeyShortcut = suggestion
+            XCTAssertNil(store.suggestedShortcutIfAvailable(for: .startRecording))
+        }
+
+        // An action that already has a binding still computes its own suggestion
+        // availability independent of its current value; once Start is bound it
+        // is no longer "empty" — the row gate (`!isEnabled`) handles that in the view.
+        store.startRecordingHotkeyShortcut = .disabled
+        XCTAssertNotNil(store.suggestedShortcutIfAvailable(for: .captureScreenshot))
+    }
+
     func testFirstLaunchStartsWithAllHotkeysDisabled() {
         let suiteName = "BugNarrator-SettingsNoHotkeyDefaultsTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
Closes #383

## Summary
- One-click "Use suggested: ⌃⌥…" affordance below each empty hotkey row applies the action's vetted default.
- Suggestion hidden when its default is already assigned to another action (`suggestedShortcutIfAvailable`).
- Applying routes through the existing conflict-check path (rejected + messaged if it collides).

## Validation
- [x] Build succeeds
- [x] 60 SettingsStore tests pass (1 new availability/conflict test)
- [x] Guardrails pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)