### PR TITLE
WIN-009: Add Azure Trusted Signing path for Windows releases

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -73,4 +73,4 @@ Current Windows milestone status:
 Current follow-up parity tickets:
 
 - `RR-002` / #44 remains the real Windows desktop validation gate.
-- `WIN-009` / #75 now has the repository-side signed tester release path; the remaining external dependency is a real Windows code-signing certificate configured outside the repo.
+- `WIN-009` / #75 now has the repository-side signed tester release path, including an Azure Trusted Signing flow (`windows/scripts/sign-windows-trustedsigning.ps1`, plus `release-windows-tester.ps1 -UseTrustedSigning`); the remaining external dependency is the Trusted Signing identity validation being approved so a `PublicTrust` certificate profile can be created.

--- a/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
+++ b/windows/docs/WINDOWS_SIGNING_AND_RELEASE.md
@@ -70,9 +70,56 @@ The GitHub Actions workflow is manual (`workflow_dispatch`) and requires these r
 - `BUGNARRATOR_WINDOWS_CERT_BASE64`: base64-encoded PFX certificate
 - `BUGNARRATOR_WINDOWS_CERT_PASSWORD`: PFX password
 
+## Signing With Azure Trusted Signing
+
+Azure Trusted Signing is the preferred path: there is no PFX file or password to manage, and the
+certificate is short-lived and cloud-held. It is wired through:
+
+- `windows/scripts/sign-windows-trustedsigning.ps1`
+- the `-UseTrustedSigning` switch on `windows/scripts/release-windows-tester.ps1`
+
+It signs with `signtool` plus the `Azure.CodeSigning` dlib (from the
+`Microsoft.Trusted.Signing.Client` NuGet package, restored on demand if not already cached).
+Authentication uses Azure.Identity `DefaultAzureCredential`, so it works from a local `az login`
+session, or from `AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` in CI.
+
+Prerequisites:
+
+- the signing identity holds the **Trusted Signing Certificate Profile Signer** data-plane role on
+  the account (Azure has since renamed this "Artifact Signing Certificate Profile Signer")
+- a certificate profile exists on the account; a `PublicTrust` profile requires a **completed
+  identity validation**
+
+Current BugNarrator account (in subscription `7fb728a1-...`, tenant `alanabdenterprises.onmicrosoft.com`):
+
+- Endpoint: `https://wus3.codesigning.azure.net/`
+- Account: `bugnarrator-signing`
+- Certificate profile: `bugnarrator-public` (PublicTrust) — these are the script defaults
+
+Sign a single file:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File windows/scripts/sign-windows-trustedsigning.ps1 `
+  -FilePath windows/artifacts/publish/win-x64/BugNarrator.Windows.exe
+```
+
+Produce a signed tester release with Trusted Signing:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File windows/scripts/release-windows-tester.ps1 `
+  -Runtime win-x64 -UseTrustedSigning
+```
+
+The release script's verify/repack/validate/release-note steps are unchanged — Authenticode
+verification via `Get-AuthenticodeSignature` is signing-method agnostic.
+
 ## Current Release Blocker
 
-The current blocker for public signed distribution is certificate availability, not the script entrypoints.
+The remaining blocker for public signed distribution is the **Trusted Signing identity validation**,
+not the script entrypoints. The account, RBAC role, tooling, and scripts are in place, but a
+`PublicTrust` certificate profile cannot be created until the tenant's identity validation is
+approved by Microsoft. Once it is approved, create the profile and run the release with
+`-UseTrustedSigning`.
 
 This branch does not include:
 
@@ -80,7 +127,9 @@ This branch does not include:
 - a CI signing secret
 - an installer authoring pipeline
 
-Until a real code-signing certificate is provisioned and configured in the release environment, the signed tester release workflow will fail intentionally rather than producing an unsigned artifact that looks signed.
+The PFX-based path (`sign-windows.ps1`, `BUGNARRATOR_CERT_PATH` / `BUGNARRATOR_CERT_PASSWORD`)
+remains available as an alternative; it will fail intentionally rather than produce an unsigned
+artifact that looks signed.
 
 ## Recommended Next Release Steps
 

--- a/windows/scripts/release-windows-tester.ps1
+++ b/windows/scripts/release-windows-tester.ps1
@@ -7,7 +7,12 @@ param(
     [string]$TimestampUrl = "http://timestamp.digicert.com",
     [string]$DigestAlgorithm = "sha256",
     [string]$SignToolPath = "signtool.exe",
-    [string]$ReleaseNotesPath = ""
+    [string]$ReleaseNotesPath = "",
+    [switch]$UseTrustedSigning,
+    [string]$TrustedSigningEndpoint = "https://wus3.codesigning.azure.net/",
+    [string]$TrustedSigningAccount = "bugnarrator-signing",
+    [string]$TrustedSigningCertificateProfile = "bugnarrator-public",
+    [string]$TrustedSigningTimestampUrl = "http://timestamp.acs.microsoft.com"
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,12 +41,14 @@ function Get-RelativeArtifactPath {
     return [System.Uri]::UnescapeDataString($rootUri.MakeRelativeUri($pathUri).ToString()).Replace('\', '/')
 }
 
-if (-not $env:BUGNARRATOR_CERT_PATH) {
-    throw "Set BUGNARRATOR_CERT_PATH to an external Windows code-signing certificate before producing a signed tester release."
-}
+if (-not $UseTrustedSigning) {
+    if (-not $env:BUGNARRATOR_CERT_PATH) {
+        throw "Set BUGNARRATOR_CERT_PATH to an external Windows code-signing certificate before producing a signed tester release, or pass -UseTrustedSigning to sign with Azure Trusted Signing."
+    }
 
-if (-not $env:BUGNARRATOR_CERT_PASSWORD) {
-    throw "Set BUGNARRATOR_CERT_PASSWORD before producing a signed tester release."
+    if (-not $env:BUGNARRATOR_CERT_PASSWORD) {
+        throw "Set BUGNARRATOR_CERT_PASSWORD before producing a signed tester release, or pass -UseTrustedSigning to sign with Azure Trusted Signing."
+    }
 }
 
 Push-Location $repoRoot
@@ -51,13 +58,28 @@ try {
         throw "package-windows.ps1 failed."
     }
 
-    & "$PSScriptRoot\sign-windows.ps1" `
-        -FilePath $executablePath `
-        -TimestampUrl $TimestampUrl `
-        -DigestAlgorithm $DigestAlgorithm `
-        -SignToolPath $SignToolPath
-    if ($LASTEXITCODE -ne 0) {
-        throw "sign-windows.ps1 failed."
+    if ($UseTrustedSigning) {
+        & "$PSScriptRoot\sign-windows-trustedsigning.ps1" `
+            -FilePath $executablePath `
+            -Endpoint $TrustedSigningEndpoint `
+            -Account $TrustedSigningAccount `
+            -CertificateProfile $TrustedSigningCertificateProfile `
+            -TimestampUrl $TrustedSigningTimestampUrl `
+            -DigestAlgorithm $DigestAlgorithm `
+            -SignToolPath $SignToolPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "sign-windows-trustedsigning.ps1 failed."
+        }
+    }
+    else {
+        & "$PSScriptRoot\sign-windows.ps1" `
+            -FilePath $executablePath `
+            -TimestampUrl $TimestampUrl `
+            -DigestAlgorithm $DigestAlgorithm `
+            -SignToolPath $SignToolPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "sign-windows.ps1 failed."
+        }
     }
 
     & "$PSScriptRoot\verify-windows-signature.ps1" `

--- a/windows/scripts/sign-windows-trustedsigning.ps1
+++ b/windows/scripts/sign-windows-trustedsigning.ps1
@@ -1,0 +1,151 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+    [string]$Endpoint = "https://wus3.codesigning.azure.net/",
+    [string]$Account = "bugnarrator-signing",
+    [string]$CertificateProfile = "bugnarrator-public",
+    [string]$TimestampUrl = "http://timestamp.acs.microsoft.com",
+    [string]$DigestAlgorithm = "SHA256",
+    [string]$SignToolPath = "",
+    [string]$DlibPath = "",
+    [string]$DlibVersion = "1.0.60"
+)
+
+# Signs a file with Azure Trusted Signing using signtool plus the Azure.CodeSigning dlib.
+# Authentication uses Azure.Identity DefaultAzureCredential, so an `az login` session (or the
+# AZURE_TENANT_ID/AZURE_CLIENT_ID/AZURE_CLIENT_SECRET service-principal env vars in CI) is required.
+# The signing identity needs the "Trusted Signing Certificate Profile Signer" data-plane role on the
+# account, and the certificate profile must already exist (a PublicTrust profile requires a completed
+# identity validation).
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+
+if (-not (Test-Path $FilePath)) {
+    throw "The target file was not found: $FilePath"
+}
+
+function Resolve-SignTool {
+    param([string]$Explicit)
+
+    # An explicit value wins when it resolves; otherwise fall back to PATH and then the newest
+    # Windows SDK build, so the common default of "signtool.exe" still works when it is not on PATH.
+    if ($Explicit -and (Test-Path $Explicit)) {
+        return (Resolve-Path $Explicit).Path
+    }
+
+    if ($Explicit) {
+        $command = Get-Command $Explicit -ErrorAction SilentlyContinue
+        if ($command) {
+            return $command.Source
+        }
+    }
+
+    $command = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $candidate = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match '\\x64\\' } |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+
+    if ($candidate) {
+        return $candidate.FullName
+    }
+
+    throw "signtool.exe was not found. Install the Windows SDK or pass -SignToolPath."
+}
+
+function Resolve-Dlib {
+    param([string]$Explicit, [string]$Version)
+
+    if ($Explicit) {
+        if (Test-Path $Explicit) {
+            return (Resolve-Path $Explicit).Path
+        }
+
+        throw "Trusted Signing dlib was not found at $Explicit"
+    }
+
+    if ($env:BUGNARRATOR_SIGNING_DLIB -and (Test-Path $env:BUGNARRATOR_SIGNING_DLIB)) {
+        return (Resolve-Path $env:BUGNARRATOR_SIGNING_DLIB).Path
+    }
+
+    $localsLine = (& dotnet nuget locals global-packages --list) 2>$null | Select-Object -First 1
+    $globalPackages = $null
+    if ($localsLine -match 'global-packages:\s*(.+)$') {
+        $globalPackages = $Matches[1].Trim()
+    }
+    if (-not $globalPackages) {
+        $globalPackages = Join-Path $env:USERPROFILE ".nuget\packages"
+    }
+
+    $dllPath = Join-Path $globalPackages "microsoft.trusted.signing.client\$Version\bin\x64\Azure.CodeSigning.Dlib.dll"
+    if (Test-Path $dllPath) {
+        return $dllPath
+    }
+
+    Write-Host "Restoring Microsoft.Trusted.Signing.Client $Version from NuGet..."
+    $restoreDir = Join-Path ([System.IO.Path]::GetTempPath()) ("bn-ts-" + [System.Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force -Path $restoreDir | Out-Null
+    try {
+        $projectPath = Join-Path $restoreDir "restore.csproj"
+        @(
+            '<Project Sdk="Microsoft.NET.Sdk">',
+            '  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>',
+            '  <ItemGroup>',
+            "    <PackageReference Include=""Microsoft.Trusted.Signing.Client"" Version=""$Version"" />",
+            '  </ItemGroup>',
+            '</Project>'
+        ) | Set-Content -Path $projectPath -Encoding utf8
+
+        & dotnet restore $projectPath | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet restore for Microsoft.Trusted.Signing.Client $Version failed."
+        }
+    }
+    finally {
+        Remove-Item $restoreDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    if (Test-Path $dllPath) {
+        return $dllPath
+    }
+
+    throw "Could not locate Azure.CodeSigning.Dlib.dll for version $Version after restore. Pass -DlibPath."
+}
+
+$signTool = Resolve-SignTool -Explicit $SignToolPath
+$dlib = Resolve-Dlib -Explicit $DlibPath -Version $DlibVersion
+
+# Trusted Signing metadata consumed by the dlib (no secrets; safe to write to a temp file).
+$metadata = [ordered]@{
+    Endpoint               = $Endpoint
+    CodeSigningAccountName = $Account
+    CertificateProfileName = $CertificateProfile
+}
+$metadataPath = Join-Path ([System.IO.Path]::GetTempPath()) ("bugnarrator-signing-" + [System.Guid]::NewGuid().ToString("N") + ".json")
+$metadata | ConvertTo-Json | Set-Content -Path $metadataPath -Encoding utf8
+
+try {
+    & $signTool sign `
+        /v `
+        /fd $DigestAlgorithm `
+        /tr $TimestampUrl `
+        /td $DigestAlgorithm `
+        /dlib $dlib `
+        /dmdf $metadataPath `
+        $FilePath
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "signtool failed with exit code $LASTEXITCODE."
+    }
+}
+finally {
+    Remove-Item $metadataPath -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Signed $FilePath with Azure Trusted Signing ($Account / $CertificateProfile)."

--- a/windows/scripts/sign-windows-trustedsigning.ps1
+++ b/windows/scripts/sign-windows-trustedsigning.ps1
@@ -31,15 +31,15 @@ function Resolve-SignTool {
 
     # An explicit value wins when it resolves; otherwise fall back to PATH and then the newest
     # Windows SDK build, so the common default of "signtool.exe" still works when it is not on PATH.
-    if ($Explicit -and (Test-Path $Explicit)) {
-        return (Resolve-Path $Explicit).Path
-    }
-
     if ($Explicit) {
+        if (Test-Path $Explicit) {
+            return (Resolve-Path $Explicit).Path
+        }
         $command = Get-Command $Explicit -ErrorAction SilentlyContinue
         if ($command) {
             return $command.Source
         }
+        throw "signtool.exe was not found at the specified path: $Explicit"
     }
 
     $command = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
@@ -47,13 +47,17 @@ function Resolve-SignTool {
         return $command.Source
     }
 
-    $candidate = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction SilentlyContinue |
-        Where-Object { $_.FullName -match '\\x64\\' } |
-        Sort-Object FullName -Descending |
-        Select-Object -First 1
+    $sdkBinDir = "C:\Program Files (x86)\Windows Kits\10\bin"
+    if (Test-Path $sdkBinDir) {
+        $candidate = Get-ChildItem -Path $sdkBinDir -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            ForEach-Object { Join-Path $_.FullName "x64\signtool.exe" } |
+            Where-Object { Test-Path $_ } |
+            Select-Object -First 1
 
-    if ($candidate) {
-        return $candidate.FullName
+        if ($candidate) {
+            return $candidate
+        }
     }
 
     throw "signtool.exe was not found. Install the Windows SDK or pass -SignToolPath."
@@ -74,11 +78,18 @@ function Resolve-Dlib {
         return (Resolve-Path $env:BUGNARRATOR_SIGNING_DLIB).Path
     }
 
-    $localsLine = (& dotnet nuget locals global-packages --list) 2>$null | Select-Object -First 1
     $globalPackages = $null
-    if ($localsLine -match 'global-packages:\s*(.+)$') {
-        $globalPackages = $Matches[1].Trim()
+    if ($env:NUGET_PACKAGES -and (Test-Path $env:NUGET_PACKAGES)) {
+        $globalPackages = (Resolve-Path $env:NUGET_PACKAGES).Path
     }
+
+    if (-not $globalPackages) {
+        $localsLine = (& dotnet nuget locals global-packages --list) 2>$null | Select-Object -First 1
+        if ($localsLine -match 'global-packages:\s*(.+)$') {
+            $globalPackages = $Matches[1].Trim()
+        }
+    }
+
     if (-not $globalPackages) {
         $globalPackages = Join-Path $env:USERPROFILE ".nuget\packages"
     }
@@ -121,16 +132,17 @@ function Resolve-Dlib {
 $signTool = Resolve-SignTool -Explicit $SignToolPath
 $dlib = Resolve-Dlib -Explicit $DlibPath -Version $DlibVersion
 
-# Trusted Signing metadata consumed by the dlib (no secrets; safe to write to a temp file).
-$metadata = [ordered]@{
-    Endpoint               = $Endpoint
-    CodeSigningAccountName = $Account
-    CertificateProfileName = $CertificateProfile
-}
-$metadataPath = Join-Path ([System.IO.Path]::GetTempPath()) ("bugnarrator-signing-" + [System.Guid]::NewGuid().ToString("N") + ".json")
-$metadata | ConvertTo-Json | Set-Content -Path $metadataPath -Encoding utf8
-
+$metadataPath = $null
 try {
+    # Trusted Signing metadata consumed by the dlib (no secrets; safe to write to a temp file).
+    $metadata = [ordered]@{
+        Endpoint               = $Endpoint
+        CodeSigningAccountName = $Account
+        CertificateProfileName = $CertificateProfile
+    }
+    $metadataPath = Join-Path ([System.IO.Path]::GetTempPath()) ("bugnarrator-signing-" + [System.Guid]::NewGuid().ToString("N") + ".json")
+    $metadata | ConvertTo-Json | Set-Content -Path $metadataPath -Encoding utf8
+
     & $signTool sign `
         /v `
         /fd $DigestAlgorithm `
@@ -145,7 +157,9 @@ try {
     }
 }
 finally {
-    Remove-Item $metadataPath -Force -ErrorAction SilentlyContinue
+    if ($metadataPath -and (Test-Path $metadataPath)) {
+        Remove-Item $metadataPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 Write-Host "Signed $FilePath with Azure Trusted Signing ($Account / $CertificateProfile)."


### PR DESCRIPTION
Closes #75 (WIN-009).

## Summary

Adds an **Azure Trusted Signing** path for Windows releases — a cloud-held, short-lived certificate with no PFX file or password to manage. This is the preferred signing route going forward; the existing PFX path is untouched and remains available.

## Changes

- **`windows/scripts/sign-windows-trustedsigning.ps1`** — signs with `signtool` + the `Azure.CodeSigning` dlib (from `Microsoft.Trusted.Signing.Client`, restored on demand and cached). Auth uses Azure.Identity `DefaultAzureCredential`, so it works from a local `az login` session or `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET` in CI. `signtool` and the dlib are auto-resolved (newest Windows SDK / NuGet global cache) with `-SignToolPath`, `-DlibPath`, and `BUGNARRATOR_SIGNING_DLIB` overrides.
- **`release-windows-tester.ps1`** — new `-UseTrustedSigning` switch routes to the new script and skips the PFX env-var guards. Without the switch, behavior is byte-for-byte the same PFX flow. Verify/repack/validate/release-note steps are unchanged (`Get-AuthenticodeSignature` is signing-method agnostic).
- **Docs** — `WINDOWS_SIGNING_AND_RELEASE.md` gains a Trusted Signing section (flow, prerequisites, account defaults); the Windows README WIN-009 note is updated.

Defaults target the provisioned account: endpoint `https://wus3.codesigning.azure.net/`, account `bugnarrator-signing`, profile `bugnarrator-public`.

## Verification

- Both scripts pass `Parser::ParseFile` (no syntax errors).
- The dlib acquisition — the script's trickiest part — is verified: `Microsoft.Trusted.Signing.Client` `1.0.60` restores and `Azure.CodeSigning.Dlib.dll` resolves at the expected path.

## Not yet verified (external gate)

The live `signtool` sign call is **blocked on the Trusted Signing identity validation being approved** — a `PublicTrust` certificate profile can't be created until then. The account, the data-plane Signer role, the tooling, and these scripts are all in place; once the validation is approved, create the profile and run `release-windows-tester.ps1 -Runtime win-x64 -UseTrustedSigning`. That's the last step of WIN-009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

