### PR TITLE
ARCH: Extract MenuProductInfoView from MenuBarView (#457)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
 		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
+		56B6B994C39B8B439752CCA3 /* MenuProductInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */; };
 		56FD14656CE943A240D9DEE5 /* TranscriptSharedHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */; };
 		57C3B6C3C646F1588CF4E45C /* JiraExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */; };
 		5839C40FC99D94A9C910A218 /* ExportReviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED395C71ADE17A2DFA5BD21 /* ExportReviewSheet.swift */; };
@@ -322,6 +323,7 @@
 		8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUploadPolicy.swift; sourceTree = "<group>"; };
 		8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotAnnotationTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
+		90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProductInfoView.swift; sourceTree = "<group>"; };
 		90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
 		92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
@@ -521,6 +523,14 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
+		6B5718CA7DF93E9C2A51A16C /* Menu */ = {
+			isa = PBXGroup;
+			children = (
+				90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */,
+			);
+			path = Menu;
+			sourceTree = "<group>";
+		};
 		7E537D104A7237092C8B8BC4 /* BugNarratorUITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -559,6 +569,7 @@
 				1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */,
 				A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */,
 				B09CA463A8DF59221937A2C7 /* TranscriptView.swift */,
+				6B5718CA7DF93E9C2A51A16C /* Menu */,
 				DAC46A7438CFA4B1A35966FB /* Transcript */,
 			);
 			path = Views;
@@ -946,6 +957,7 @@
 				E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */,
 				821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */,
 				4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */,
+				56B6B994C39B8B439752CCA3 /* MenuProductInfoView.swift in Sources */,
 				2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */,
 				D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */,
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,

--- a/Sources/BugNarrator/Views/Menu/MenuProductInfoView.swift
+++ b/Sources/BugNarrator/Views/Menu/MenuProductInfoView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// Product info, help, and support links shown in the menu bar popover.
+///
+/// Extracted from `MenuBarView` as the first focused section split for #433.
+/// Behavior is unchanged: the `isOptionKeyPressed` flag still reveals the
+/// debug-bundle export, and every action delegates to `AppState`.
+struct MenuProductInfoView: View {
+    @ObservedObject var appState: AppState
+    let isOptionKeyPressed: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Product Info")
+                .font(.headline)
+
+            Text("Documentation, diagnostics, support, and release notes.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            infoButton(
+                title: "About BugNarrator",
+                systemImage: "info.circle",
+                accessibilityLabel: "Open the BugNarrator about window",
+                action: appState.openAbout
+            )
+
+            infoButton(
+                title: "What’s New",
+                systemImage: "sparkles.rectangle.stack",
+                accessibilityLabel: "Open the BugNarrator changelog",
+                action: appState.openChangelog
+            )
+
+            Divider()
+
+            Text("Help And Support")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            infoButton(
+                title: "View Documentation",
+                systemImage: "book.closed",
+                accessibilityLabel: "Open the BugNarrator documentation",
+                action: appState.openDocumentation
+            )
+
+            infoButton(
+                title: "Report an Issue",
+                systemImage: "ladybug",
+                accessibilityLabel: "Open the BugNarrator issue tracker",
+                action: appState.openIssueReporter
+            )
+
+            if isOptionKeyPressed {
+                infoButton(
+                    title: "Export Debug Bundle",
+                    systemImage: "archivebox",
+                    accessibilityLabel: "Export a BugNarrator debug bundle",
+                    action: {
+                        Task {
+                            await appState.exportDebugBundle()
+                        }
+                    }
+                )
+            }
+
+            infoButton(
+                title: "Support Development",
+                systemImage: "heart",
+                accessibilityLabel: "Open the BugNarrator support development window",
+                action: appState.openSupportDevelopment
+            )
+
+            infoButton(
+                title: "Check for Updates",
+                systemImage: "arrow.clockwise",
+                accessibilityLabel: "Open the BugNarrator releases page",
+                action: appState.checkForUpdates
+            )
+        }
+        .padding(14)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func infoButton(
+        title: String,
+        systemImage: String,
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Label(title, systemImage: systemImage)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                Image(systemName: "arrow.up.forward")
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}

--- a/Sources/BugNarrator/Views/Menu/MenuProductInfoView.swift
+++ b/Sources/BugNarrator/Views/Menu/MenuProductInfoView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// Behavior is unchanged: the `isOptionKeyPressed` flag still reveals the
 /// debug-bundle export, and every action delegates to `AppState`.
 struct MenuProductInfoView: View {
-    @ObservedObject var appState: AppState
+    let appState: AppState
     let isOptionKeyPressed: Bool
 
     var body: some View {

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -35,7 +35,7 @@ struct MenuBarView: View {
                 sessionLibraryCard
             }
 
-            productInfoSection
+            MenuProductInfoView(appState: appState, isOptionKeyPressed: isOptionKeyPressed)
             footerSection
         }
         .padding(16)
@@ -686,101 +686,6 @@ struct MenuBarView: View {
             try? await Task.sleep(nanoseconds: delayNanoseconds)
             await action()
         }
-    }
-
-    private var productInfoSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Product Info")
-                .font(.headline)
-
-            Text("Documentation, diagnostics, support, and release notes.")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-            infoButton(
-                title: "About BugNarrator",
-                systemImage: "info.circle",
-                accessibilityLabel: "Open the BugNarrator about window",
-                action: appState.openAbout
-            )
-
-            infoButton(
-                title: "What’s New",
-                systemImage: "sparkles.rectangle.stack",
-                accessibilityLabel: "Open the BugNarrator changelog",
-                action: appState.openChangelog
-            )
-
-            Divider()
-
-            Text("Help And Support")
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(.secondary)
-
-            infoButton(
-                title: "View Documentation",
-                systemImage: "book.closed",
-                accessibilityLabel: "Open the BugNarrator documentation",
-                action: appState.openDocumentation
-            )
-
-            infoButton(
-                title: "Report an Issue",
-                systemImage: "ladybug",
-                accessibilityLabel: "Open the BugNarrator issue tracker",
-                action: appState.openIssueReporter
-            )
-
-            if isOptionKeyPressed {
-                infoButton(
-                    title: "Export Debug Bundle",
-                    systemImage: "archivebox",
-                    accessibilityLabel: "Export a BugNarrator debug bundle",
-                    action: {
-                        Task {
-                            await appState.exportDebugBundle()
-                        }
-                    }
-                )
-            }
-
-            infoButton(
-                title: "Support Development",
-                systemImage: "heart",
-                accessibilityLabel: "Open the BugNarrator support development window",
-                action: appState.openSupportDevelopment
-            )
-
-            infoButton(
-                title: "Check for Updates",
-                systemImage: "arrow.clockwise",
-                accessibilityLabel: "Open the BugNarrator releases page",
-                action: appState.checkForUpdates
-            )
-        }
-        .padding(14)
-        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-    }
-
-    private func infoButton(
-        title: String,
-        systemImage: String,
-        accessibilityLabel: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                Label(title, systemImage: systemImage)
-                    .foregroundStyle(.primary)
-
-                Spacer()
-
-                Image(systemName: "arrow.up.forward")
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
     }
 
     private func refreshModifierKeys() {


### PR DESCRIPTION
## Summary
First focused-section split for #433. Extracts the **Product Info / Help & Support** section (and the option-key "Export Debug Bundle" affordance) out of the 1,066-line `MenuBarView` into a new `MenuProductInfoView` under `Sources/BugNarrator/Views/Menu/`.

Pure UI extraction — behavior/pixel preserving:
- `productInfoSection` + its `infoButton` helper moved verbatim into `MenuProductInfoView(appState:isOptionKeyPressed:)`.
- `MenuBarView` body renders `MenuProductInfoView(...)` in the same position; the option-key debug-bundle affordance still works (flag passed through).
- No new logic; every action still delegates to `AppState`.

## Validation (local)
- `xcodebuild -scheme BugNarrator -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**
- `xcodebuild … -only-testing:BugNarratorTests test` → **TEST SUCCEEDED**
- `./scripts/validate.sh origin/main` → all PASS (semgrep, swift parse 109 files, effort-leak, docs)

Closes #457
Part of #433 (umbrella stays open for the remaining cuts: setup banner, status card, session-library card).