### PR TITLE
ARCH: Extract MenuSessionLibraryCardView from MenuBarView (#459)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */; };
 		5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D753EF601F00C09C7FF276C /* TransientToast.swift */; };
 		5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */; };
+		5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */; };
 		5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49B2B79731E3A62B083174 /* IssueExportController.swift */; };
 		5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */; };
 		5CB8DACFD986D905D03D0E6A /* ChangelogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */; };
@@ -374,6 +375,7 @@
 		D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
 		DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStore.swift; sourceTree = "<group>"; };
+		DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSessionLibraryCardView.swift; sourceTree = "<group>"; };
 		DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueScreenshotAnnotationPreview.swift; sourceTree = "<group>"; };
 		DECC036914FC012EF9F81EAB /* JiraExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProviderTests.swift; sourceTree = "<group>"; };
 		DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 			isa = PBXGroup;
 			children = (
 				90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */,
+				DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -958,6 +961,7 @@
 				821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */,
 				4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */,
 				56B6B994C39B8B439752CCA3 /* MenuProductInfoView.swift in Sources */,
+				5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */,
 				2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */,
 				D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */,
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,

--- a/Sources/BugNarrator/Views/Menu/MenuSessionLibraryCardView.swift
+++ b/Sources/BugNarrator/Views/Menu/MenuSessionLibraryCardView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Session-library entry point plus pending-transcription retry controls
+/// shown in the menu bar popover.
+///
+/// Extracted from `MenuBarView` as a focused section split for #433.
+/// Behavior is unchanged; every action delegates to `AppState`.
+struct MenuSessionLibraryCardView: View {
+    let appState: AppState
+    let transcriptStore: TranscriptStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button("Open Session Library") {
+                appState.openTranscriptHistory()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityHint("Opens the session library window.")
+
+            if transcriptStore.pendingTranscriptionSessionCount > 0 {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(pendingTranscriptionSummary)
+                        .font(.footnote.weight(.semibold))
+
+                    Text(
+                        appState.settingsStore.aiProvider.requiresAPIKey
+                            ? "Restore or replace the \(appState.settingsStore.aiProvider.displayName) API key in Settings if needed, then retry the saved session."
+                            : "Confirm the \(appState.settingsStore.aiProvider.displayName) setup in Settings if needed, then retry the saved session."
+                    )
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 10) {
+                        if appState.needsAPIKeySetup {
+                            Button("Open Settings") {
+                                appState.openSettings()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        } else if transcriptStore.pendingTranscriptionSessionCount == 1 {
+                            Button("Retry Transcription") {
+                                retryLatestPendingTranscription()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .controlSize(.small)
+                            .disabled(appState.retryingSessionID != nil)
+                            .help("Retry transcription for the saved session without opening the library.")
+                        } else {
+                            Button("Retry Latest") {
+                                retryLatestPendingTranscription()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(appState.retryingSessionID != nil)
+                            .help("Retry transcription for the most recent saved session.")
+
+                            Button("Open Retry Needed Session") {
+                                openPendingTranscriptionSession()
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        Button("View Library") {
+                            appState.openTranscriptHistory()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private var pendingTranscriptionSummary: String {
+        let count = transcriptStore.pendingTranscriptionSessionCount
+        return count == 1
+            ? "1 saved session is waiting for transcription retry."
+            : "\(count) saved sessions are waiting for transcription retry."
+    }
+
+    private func openPendingTranscriptionSession() {
+        if let sessionID = transcriptStore.latestPendingTranscriptionSession?.id {
+            appState.selectedTranscriptID = sessionID
+        }
+
+        appState.openTranscriptHistory()
+    }
+
+    private func retryLatestPendingTranscription() {
+        guard let sessionID = transcriptStore.latestPendingTranscriptionSession?.id else {
+            return
+        }
+
+        Task {
+            await appState.retryPendingTranscription(for: sessionID)
+        }
+    }
+}

--- a/Sources/BugNarrator/Views/Menu/MenuSessionLibraryCardView.swift
+++ b/Sources/BugNarrator/Views/Menu/MenuSessionLibraryCardView.swift
@@ -5,9 +5,10 @@ import SwiftUI
 ///
 /// Extracted from `MenuBarView` as a focused section split for #433.
 /// Behavior is unchanged; every action delegates to `AppState`.
+@MainActor
 struct MenuSessionLibraryCardView: View {
-    let appState: AppState
-    let transcriptStore: TranscriptStore
+    @ObservedObject var appState: AppState
+    @ObservedObject var transcriptStore: TranscriptStore
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/Sources/BugNarrator/Views/MenuBarView.swift
+++ b/Sources/BugNarrator/Views/MenuBarView.swift
@@ -32,7 +32,7 @@ struct MenuBarView: View {
             controlsSection
 
             if !transcriptStore.libraryEntries.isEmpty {
-                sessionLibraryCard
+                MenuSessionLibraryCardView(appState: appState, transcriptStore: transcriptStore)
             }
 
             MenuProductInfoView(appState: appState, isOptionKeyPressed: isOptionKeyPressed)
@@ -589,75 +589,6 @@ struct MenuBarView: View {
         }
     }
 
-    private var sessionLibraryCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Button("Open Session Library") {
-                appState.openTranscriptHistory()
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityHint("Opens the session library window.")
-
-            if transcriptStore.pendingTranscriptionSessionCount > 0 {
-                Divider()
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(pendingTranscriptionSummary)
-                        .font(.footnote.weight(.semibold))
-
-                    Text(
-                        appState.settingsStore.aiProvider.requiresAPIKey
-                            ? "Restore or replace the \(appState.settingsStore.aiProvider.displayName) API key in Settings if needed, then retry the saved session."
-                            : "Confirm the \(appState.settingsStore.aiProvider.displayName) setup in Settings if needed, then retry the saved session."
-                    )
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: 10) {
-                        if appState.needsAPIKeySetup {
-                            Button("Open Settings") {
-                                appState.openSettings()
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        } else if transcriptStore.pendingTranscriptionSessionCount == 1 {
-                            Button("Retry Transcription") {
-                                retryLatestPendingTranscription()
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                            .disabled(appState.retryingSessionID != nil)
-                            .help("Retry transcription for the saved session without opening the library.")
-                        } else {
-                            Button("Retry Latest") {
-                                retryLatestPendingTranscription()
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                            .disabled(appState.retryingSessionID != nil)
-                            .help("Retry transcription for the most recent saved session.")
-
-                            Button("Open Retry Needed Session") {
-                                openPendingTranscriptionSession()
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-
-                        Button("View Library") {
-                            appState.openTranscriptHistory()
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-                }
-            }
-        }
-        .padding(14)
-        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-    }
-
     private var footerSection: some View {
         HStack(spacing: 10) {
             Button("Settings") {
@@ -724,31 +655,6 @@ struct MenuBarView: View {
             return "Use the control window to start the next session when you are ready."
         case .error:
             return "Fix the current issue, then continue from the control window."
-        }
-    }
-
-    private var pendingTranscriptionSummary: String {
-        let count = transcriptStore.pendingTranscriptionSessionCount
-        return count == 1
-            ? "1 saved session is waiting for transcription retry."
-            : "\(count) saved sessions are waiting for transcription retry."
-    }
-
-    private func openPendingTranscriptionSession() {
-        if let sessionID = transcriptStore.latestPendingTranscriptionSession?.id {
-            appState.selectedTranscriptID = sessionID
-        }
-
-        appState.openTranscriptHistory()
-    }
-
-    private func retryLatestPendingTranscription() {
-        guard let sessionID = transcriptStore.latestPendingTranscriptionSession?.id else {
-            return
-        }
-
-        Task {
-            await appState.retryPendingTranscription(for: sessionID)
         }
     }
 


### PR DESCRIPTION
## Summary
Second focused-section split for #433 (follows #457). Extracts the **Session Library** card — the open-library button plus the pending-transcription retry controls — out of `MenuBarView` into a new `MenuSessionLibraryCardView` under `Sources/BugNarrator/Views/Menu/`.

Pure UI extraction — behavior-preserving:
- `sessionLibraryCard` + helpers (`pendingTranscriptionSummary`, `openPendingTranscriptionSession`, `retryLatestPendingTranscription`) moved verbatim into `MenuSessionLibraryCardView(appState:transcriptStore:)`.
- `MenuBarView` body renders it in the same `if !transcriptStore.libraryEntries.isEmpty` gate; no behavior change.
- Matches the `let`-dependency style established by `MenuProductInfoView`.

## Validation (local)
- `xcodebuild … build` → **BUILD SUCCEEDED**
- `xcodebuild … -only-testing:BugNarratorTests test` → **TEST SUCCEEDED**
- `./scripts/validate.sh origin/main` → all PASS (semgrep, swift parse 110 files, effort-leak, docs)

Closes #459
Part of #433 (umbrella stays open; remaining cuts: setup banner, status card).