### PR TITLE
docs: fix Docusaurus identity drift and lock agent-rules trio against drift

### DIFF
--- a/scripts/check-agent-rules-sync.sh
+++ b/scripts/check-agent-rules-sync.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Verify that CLAUDE.md, AGENTS.md, and .agent/rules.md share an identical
+# body. The first line of each is allowed (and expected) to differ — it names
+# the agent the file is addressed to, e.g. "# Local AI Adapter (Claude)".
+# Every line after the first must match across all three, so updates to the
+# ORC adapter contract are never lost on one tool while another stays current.
+#
+# Exits 0 with a one-line PASS message when in sync; exits 1 with a diff
+# preview when any pair drifts.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+files=(
+  "$ROOT/CLAUDE.md"
+  "$ROOT/AGENTS.md"
+  "$ROOT/.agent/rules.md"
+)
+
+for f in "${files[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    printf 'FAIL: missing agent rules file: %s\n' "${f#"$ROOT/"}" >&2
+    exit 1
+  fi
+done
+
+reference="${files[0]}"
+for f in "${files[@]:1}"; do
+  if ! diff -q <(tail -n +2 "$reference") <(tail -n +2 "$f") >/dev/null 2>&1; then
+    printf 'FAIL: %s body drift vs %s\n' \
+      "${f#"$ROOT/"}" "${reference#"$ROOT/"}" >&2
+    printf -- '--- %s\n+++ %s\n' \
+      "${reference#"$ROOT/"}" "${f#"$ROOT/"}" >&2
+    diff <(tail -n +2 "$reference") <(tail -n +2 "$f") | head -30 >&2
+    exit 1
+  fi
+done
+
+printf 'PASS: CLAUDE.md, AGENTS.md, and .agent/rules.md share identical bodies (only line 1 differs).\n'

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -171,6 +171,12 @@ if [[ -x "$ROOT/scripts/repo-docs-audit.sh" ]]; then
   fi
 fi
 
+if [[ -x "$ROOT/scripts/check-agent-rules-sync.sh" ]]; then
+  if ! "$ROOT/scripts/check-agent-rules-sync.sh"; then
+    exit 1
+  fi
+fi
+
 if [[ -f "$ROOT/local-transcription/server.py" ]]; then
   if command -v python3 >/dev/null 2>&1; then
     python3 -m py_compile \

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -5,10 +5,10 @@ const config = {
   title: 'BugNarrator Docs',
   tagline: 'User, release, and roadmap documentation for BugNarrator',
   favicon: 'img/favicon.png',
-  url: 'https://deffenda.github.io',
+  url: 'https://abd-enterprises.github.io',
   baseUrl: '/bug-narrator/',
   trailingSlash: true,
-  organizationName: 'deffenda',
+  organizationName: 'ABD-Enterprises',
   projectName: 'bug-narrator',
   onBrokenLinks: 'throw',
   markdown: {


### PR DESCRIPTION
## Summary

Two small documentation-hardening cleanups bundled together.

### 1. `site/docusaurus.config.js` — identity drift

GitHub Pages publishes the site at `https://abd-enterprises.github.io/bug-narrator/` (verified via `gh api repos/ABD-Enterprises/bug-narrator/pages`), but the config still pointed at `https://deffenda.github.io` with `organizationName: 'deffenda'`. Every absolute URL Docusaurus generates (sitemap, canonical `<link>`, social previews, deploy target) was wrong. The recent identity-canonicalization passes (#302, #305) caught the Swift sources and markdown but missed this file.

### 2. Agent-rules trio drift guard

`CLAUDE.md`, `AGENTS.md`, and `.agent/rules.md` are the per-tool copies of the ORC adapter contract for Claude Code, Codex, and Antigravity respectively. They intentionally differ only on line 1 (the title naming the addressed agent); the body must stay identical so contract updates aren't silently lost on whichever tool the editor didn't touch.

Adds `scripts/check-agent-rules-sync.sh` and wires it into `scripts/validate.sh`, so the existing CI `runtime-guardrails` job catches any future divergence past line 1. The script prints a `--- / +++` diff preview pointing at the drifted lines.

## Test plan

- [x] `scripts/validate.sh` passes locally (the new check prints `PASS: CLAUDE.md, AGENTS.md, and .agent/rules.md share identical bodies (only line 1 differs).`).
- [x] Manually verified Docusaurus config diff is minimal (2 lines changed).
- [ ] CI `runtime-guardrails` green on this PR (the new check fires on every PR via `validate.sh`).
- [ ] CI `macos-build-and-test` skips (path filter — no Swift touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)