### PR TITLE
chore: gitignore runtime logs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ local-transcription/build/
 local-transcription/dist/
 .worktrees/
 
+# Runtime logs (e.g. the local Parakeet transcription server) — never committed.
+logs/
+
 # scripts/validate.sh and scripts/swift-parse-check.sh write status/output
 # files here on every run; they should never be committed.
 artifacts/validation/


### PR DESCRIPTION
Ignores the `logs/` directory (e.g. the local Parakeet server's `logs/parakeet.log`) so runtime logs never dirty the working tree or get committed.

Trivially scoped; closes no ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)