### PR TITLE
fix: drop reserved search keywords from tracker dedup query terms (#467)

### DIFF
--- a/Sources/BugNarrator/Services/ExportService.swift
+++ b/Sources/BugNarrator/Services/ExportService.swift
@@ -118,8 +118,22 @@ struct TrackerIssueCandidate: Equatable {
 /// Helpers shared by the tracker export providers (Jira, GitHub) whose
 /// implementations are byte-identical apart from the provider's display name.
 enum TrackerExportSupport {
+    /// Reserved words that act as operators/keywords in GitHub issue search and
+    /// in Jira's JQL. The term tokenizer already strips all non-alphanumeric
+    /// characters (so quotes, colons, and slashes can never reach the query),
+    /// but a 3+ character keyword like `AND`/`NOT`/`ORDER` would otherwise
+    /// survive as a bare token and subtly broaden or alter the duplicate search.
+    /// These are common stop-words in prose, so dropping them does not weaken
+    /// the keyword match for real issue text.
+    private static let reservedSearchWords: Set<String> = [
+        "and", "or", "not", "in", "is", "was", "null", "empty",
+        "order", "by", "changed", "during", "before", "after", "on"
+    ]
+
     /// Builds a short search phrase from an issue's most significant terms, used
-    /// to look for potential duplicate issues before exporting.
+    /// to look for potential duplicate issues before exporting. The phrase is a
+    /// space-separated list of literal keyword terms; it must never be able to
+    /// introduce a search operator/qualifier.
     static func searchTerms(for issue: ExtractedIssue) -> String {
         let source = [issue.title, issue.component, issue.summary]
             .compactMap { $0 }
@@ -127,7 +141,7 @@ enum TrackerExportSupport {
         let significantTerms = source
             .components(separatedBy: CharacterSet.alphanumerics.inverted)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { $0.count >= 3 }
+            .filter { $0.count >= 3 && !reservedSearchWords.contains($0.lowercased()) }
 
         return significantTerms.prefix(6).joined(separator: " ")
     }

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -166,6 +166,49 @@ final class GitHubExportProviderTests: XCTestCase {
         XCTAssertEqual(matches.first?.title, "Login form validation broken")
     }
 
+    func testFindOpenIssuesKeepsSearchScopeWhenTermsContainReservedWordsAndOperators() async throws {
+        let provider = GitHubExportProvider(session: makeMockURLSession())
+        // A hostile/awkward title that, before hardening, could try to smuggle
+        // GitHub search qualifiers and boolean operators into the dedup query.
+        let issue = ExtractedIssue(
+            title: #"repo:other/private AND NOT "secret" is:closed"#,
+            category: .bug,
+            summary: "Checkout button broken",
+            evidenceExcerpt: "Checkout button never enabled.",
+            timestamp: nil
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false))
+            let query = try XCTUnwrap(components.queryItems?.first(where: { $0.name == "q" })?.value)
+
+            // Our fixed scope qualifiers are present exactly once...
+            XCTAssertTrue(query.hasPrefix("repo:acme/bugnarrator is:issue is:open"))
+            XCTAssertEqual(query.components(separatedBy: "repo:").count - 1, 1)
+            // ...and no foreign qualifier or boolean operator survived as a bare token.
+            let terms = query
+                .replacingOccurrences(of: "repo:acme/bugnarrator is:issue is:open", with: "")
+                .split(separator: " ")
+                .map(String.init)
+            XCTAssertFalse(terms.contains("AND"))
+            XCTAssertFalse(terms.contains("NOT"))
+            XCTAssertFalse(terms.contains { $0.contains(":") })
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"items":[]}"#.utf8))
+        }
+
+        _ = try await provider.findOpenIssues(
+            matching: issue,
+            configuration: GitHubExportConfiguration(
+                token: "fixture-github-token",
+                owner: "acme",
+                repository: "bugnarrator",
+                labels: []
+            )
+        )
+    }
+
     func testValidateConfigurationChecksRepositoryAccess() async throws {
         let provider = GitHubExportProvider(session: makeMockURLSession())
 


### PR DESCRIPTION
Closes #467.

## What
Harden the shared `TrackerExportSupport.searchTerms` so reserved keywords (`AND`, `NOT`, `ORDER`, …) cannot survive as bare tokens in the GitHub/JQL duplicate-detection search.

## Why
Per the codex review on #467: the tokenizer already strips every non-alphanumeric character, so punctuation/qualifier injection was never possible. The residual issue is that 3+ char reserved words survived as bare tokens and could subtly broaden/alter the dedup search. These words are prose stop-words, so dropping them does not weaken keyword matching for real issue text. The whole phrase is **not** quoted (that would convert keyword search into exact-phrase search).

## Tests
- New `testFindOpenIssuesKeepsSearchScopeWhenTermsContainReservedWordsAndOperators` asserts a hostile title produces a query with only our fixed `repo:`/`is:` qualifiers plus literal keywords, with no surviving `AND`/`NOT`/foreign qualifier.
- Full `BugNarratorTests` suite green locally (578 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)