### PR TITLE
fix: quote/escape Jira project key in dedup JQL (#468)

### DIFF
--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -564,7 +564,7 @@ actor JiraExportProvider {
         )
         request.httpBody = try JSONEncoder().encode(
             JiraSearchRequest(
-                jql: #"project = \#(configuration.projectKey) AND description ~ "\"\#(TrackerExportFingerprint.marker(for: fingerprint))\"" ORDER BY created DESC"#,
+                jql: #"\#(Self.jqlProjectClause(configuration.projectKey)) AND description ~ "\"\#(TrackerExportFingerprint.marker(for: fingerprint))\"" ORDER BY created DESC"#,
                 maxResults: 1,
                 fields: ["summary", "description"]
             )
@@ -941,8 +941,19 @@ actor JiraExportProvider {
             .replacingOccurrences(of: "\"", with: "\\\"")
 
         return """
-        project = \(projectKey) AND statusCategory != Done AND (summary ~ "\\"\(phrase)\\"" OR description ~ "\\"\(phrase)\\"") ORDER BY updated DESC
+        \(Self.jqlProjectClause(projectKey)) AND statusCategory != Done AND (summary ~ "\\"\(phrase)\\"" OR description ~ "\\"\(phrase)\\"") ORDER BY updated DESC
         """
+    }
+
+    /// Builds the `project = "KEY"` JQL clause with the project key quoted and
+    /// backslash/quote-escaped. Jira accepts a quoted project key, so quoting is
+    /// behaviour-preserving for normal keys while neutralizing a malformed or
+    /// operator-bearing key value before it reaches the JQL parser.
+    static func jqlProjectClause(_ projectKey: String) -> String {
+        let escaped = projectKey
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "project = \"\(escaped)\""
     }
 
 }

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -192,7 +192,7 @@ final class JiraExportProviderTests: XCTestCase {
             XCTAssertEqual(request.url?.absoluteString, "https://acme.atlassian.net/rest/api/3/search/jql")
             let body = try requestBodyData(from: request)
             let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
-            XCTAssertTrue((payload["jql"] as? String)?.contains("project = FM") == true)
+            XCTAssertTrue((payload["jql"] as? String)?.contains(#"project = "FM""#) == true)
             XCTAssertEqual(payload["maxResults"] as? Int, 5)
 
             let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
@@ -216,6 +216,45 @@ final class JiraExportProviderTests: XCTestCase {
         XCTAssertEqual(matches.count, 1)
         XCTAssertEqual(matches.first?.remoteIdentifier, "FM-142")
         XCTAssertEqual(matches.first?.title, "Existing modal close affordance issue")
+    }
+
+    func testFindOpenIssuesKeepsJQLScopeWhenTermsAndProjectKeyAreHostile() async throws {
+        let provider = JiraExportProvider(session: makeMockURLSession())
+        // Reserved words in the title (which the shared tokenizer now drops) and a
+        // malformed project key that, unquoted, would break out of the JQL.
+        let issue = ExtractedIssue(
+            title: #"checkout AND NOT broken ORDER"#,
+            category: .bug,
+            summary: "Checkout button broken",
+            evidenceExcerpt: "Checkout never enabled.",
+            timestamp: nil
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            let body = try requestBodyData(from: request)
+            let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let jql = try XCTUnwrap(payload["jql"] as? String)
+
+            // Project key is quoted/escaped, so an injected operator stays inert.
+            XCTAssertTrue(jql.hasPrefix(#"project = "FM\" OR project = ZZ""#))
+            // The reserved words from the title do not survive as bare match terms.
+            XCTAssertFalse(jql.contains("checkout AND NOT"))
+            XCTAssertTrue(jql.contains("checkout broken"))
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"issues":[]}"#.utf8))
+        }
+
+        _ = try await provider.findOpenIssues(
+            matching: issue,
+            configuration: JiraExportConfiguration(
+                baseURL: URL(string: "https://acme.atlassian.net")!,
+                email: "you@example.com",
+                apiToken: "fixture-jira-token",
+                projectKey: #"FM" OR project = ZZ"#,
+                issueType: "Task"
+            )
+        )
     }
 
     func testValidateConfigurationChecksProjectAndIssueType() async throws {


### PR DESCRIPTION
Closes #468.

## What
Quote and escape the Jira project key before interpolating it into the duplicate-detection and fingerprint JQL, via a shared `jqlProjectClause` helper.

## Why
Per the codex review on #468: the dedup phrase already passes through the alphanumeric tokenizer (and #467 now drops reserved words), so the original "JQL injection via the phrase" framing was overstated. The genuine residual gap is the **project key**, which was interpolated unquoted (`project = FM`) — a malformed/operator-bearing key could break out of the query. Jira accepts a quoted key, so `project = "FM"` is behaviour-preserving for normal keys.

## Tests
- New `testFindOpenIssuesKeepsJQLScopeWhenTermsAndProjectKeyAreHostile`: a malformed project key (`FM" OR project = ZZ`) stays quoted/escaped and inert, and reserved words from the title don't survive as bare match terms.
- Updated the existing search assertion to the quoted form.
- Full `BugNarratorTests` suite green locally (579 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)