### PR TITLE
fix: surface failed Keychain credential deletions instead of swallowing them (#471)

### DIFF
--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -1510,16 +1510,61 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    /// Best-effort removal of a secret from a slot's legacy service names.
+    /// Missing items are not an error (KeychainService treats not-found as
+    /// success); a genuine failure is logged but does not block the primary
+    /// operation, since the canonical service-name delete is what matters.
+    private func deleteLegacySecrets(for slot: SecretSlot) {
+        for service in slot.legacyServices {
+            do {
+                try keychainService.deleteValue(service: service, account: slot.account)
+            } catch {
+                logger.warning(
+                    "secret_legacy_clear_failed",
+                    "A legacy secure value could not be removed from Keychain.",
+                    metadata: [
+                        "slot": slot.redactionSafeName,
+                        "error": Self.redactedKeychainErrorDetail(error)
+                    ]
+                )
+            }
+        }
+    }
+
+    /// Renders a Keychain error for diagnostics without including any secret
+    /// material (only the error type / OSStatus code).
+    private static func redactedKeychainErrorDetail(_ error: Error) -> String {
+        if case KeychainError.unhandledStatus(let status) = error {
+            return "osstatus_\(status)"
+        }
+        return String(describing: type(of: error))
+    }
+
     @discardableResult
     private func persistSecret(_ value: String, for slot: SecretSlot) -> APIKeyPersistenceState {
         let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if trimmedValue.isEmpty {
-            try? keychainService.deleteValue(service: slot.service, account: slot.account)
-            slot.legacyServices.forEach { service in
-                try? keychainService.deleteValue(service: service, account: slot.account)
-            }
             sessionOnlySecrets.removeValue(forKey: slot)
+            do {
+                try keychainService.deleteValue(service: slot.service, account: slot.account)
+            } catch {
+                // KeychainService maps "item not found" to success, so any thrown
+                // error means the secret is still resident. Surface it instead of
+                // reporting the credential as cleared — otherwise the UI/state
+                // would diverge from what is actually in the Keychain.
+                logger.warning(
+                    "secret_clear_failed",
+                    "A secure value could not be removed from Keychain.",
+                    metadata: [
+                        "slot": slot.redactionSafeName,
+                        "error": Self.redactedKeychainErrorDetail(error)
+                    ]
+                )
+                committedSecretStates[slot] = .keychain
+                return .keychain
+            }
+            deleteLegacySecrets(for: slot)
             logger.info(
                 "secret_cleared",
                 "A secure value was cleared from persistent storage.",
@@ -1535,9 +1580,7 @@ final class SettingsStore: ObservableObject {
 
         do {
             try keychainService.setString(trimmedValue, service: slot.service, account: slot.account)
-            slot.legacyServices.forEach { service in
-                try? keychainService.deleteValue(service: service, account: slot.account)
-            }
+            deleteLegacySecrets(for: slot)
             sessionOnlySecrets.removeValue(forKey: slot)
             logger.info(
                 "secret_persisted",

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -266,6 +266,28 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.apiKeyPersistenceState, .keychain)
     }
 
+    func testRemovingAPIKeyReportsKeychainStillPresentWhenDeleteFails() {
+        let suiteName = "BugNarrator-SettingsDeleteFailTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let keychain = MockKeychainService()
+        let store = SettingsStore(defaults: defaults, keychainService: keychain)
+        store.apiKey = "saved-in-keychain"
+        store.refreshOpenAISecretForUserInitiatedAccess()
+        XCTAssertEqual(store.apiKeyPersistenceState, .keychain)
+        XCTAssertFalse(keychain.values.isEmpty)
+
+        // The Keychain delete fails (e.g. errSecInteractionNotAllowed). The
+        // secret is therefore still resident and must not be reported cleared.
+        keychain.deleteError = KeychainError.unhandledStatus(-25308)
+        store.removeAPIKey()
+
+        XCTAssertEqual(store.apiKeyPersistenceState, .keychain)
+        XCTAssertFalse(keychain.values.isEmpty)
+    }
+
     func testJiraEmailStaysOutOfUserDefaultsWhenKeychainSucceeds() {
         let suiteName = "BugNarrator-SettingsJiraEmailNoDefaultsTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -681,6 +681,7 @@ final class MockScreenCapturePermissionAccess: ScreenCapturePermissionAccessing 
 final class MockKeychainService: KeychainServicing {
     var values: [String: String] = [:]
     var setError: Error?
+    var deleteError: Error?
     var interactionRequiredKeys: Set<String> = []
     private(set) var readRequests: [(service: String, account: String, allowInteraction: Bool)] = []
 
@@ -704,6 +705,9 @@ final class MockKeychainService: KeychainServicing {
     }
 
     func deleteValue(service: String, account: String) throws {
+        if let deleteError {
+            throw deleteError
+        }
         values.removeValue(forKey: key(forService: service, account: account))
     }
 


### PR DESCRIPTION
Closes #471.

## What
Clearing/rotating an API key, GitHub token, or Jira token used `try?` on the Keychain delete, silently discarding failures. Now a non-benign primary-delete failure is logged (no secret material) and the persistence state stays `.keychain` so the UI matches reality. Legacy-service deletes remain best-effort but log genuine failures.

## Why
Per the codex review on #471: `KeychainService.deleteValue` already maps `errSecItemNotFound` to success, so any thrown error is non-benign and means the secret is still resident. Reporting it as cleared was a real security-expectation violation (a "revoked" token still sitting in the login Keychain).

## Tests
- New `testRemovingAPIKeyReportsKeychainStillPresentWhenDeleteFails`: with a failing delete, state stays `.keychain` and the secret remains in the mock Keychain.
- Added `deleteError` to `MockKeychainService`.
- Full `BugNarratorTests` suite green locally (583 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)