### PR TITLE
feat: warn on plaintext-HTTP remote AI base URL (key + transcript exfiltration risk) (#472)

### DIFF
--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -662,6 +662,66 @@ final class SettingsStore: ObservableObject {
         return components.url ?? fallback
     }
 
+    /// Whether `host` denotes a loopback / private / link-local / `.local`
+    /// endpoint. Plaintext HTTP to such a host is acceptable because the traffic
+    /// stays on the machine or the trusted local network; plaintext HTTP to any
+    /// other host would send the API key and transcript text over the public
+    /// internet unencrypted.
+    static func isLocalEndpointHost(_ host: String) -> Bool {
+        let lowered = host
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+
+        if lowered == "localhost" || lowered.hasSuffix(".localhost") { return true }
+        if lowered.hasSuffix(".local") { return true }
+        // Single-label hostnames (e.g. "lmstudio") never resolve on public DNS.
+        if !lowered.contains(".") && !lowered.contains(":") { return true }
+        // IPv6 loopback / link-local.
+        if lowered == "::1" || lowered.hasPrefix("fe80:") { return true }
+
+        let octets = lowered.split(separator: ".").compactMap { UInt8($0) }
+        if octets.count == 4, lowered.allSatisfy({ $0.isNumber || $0 == "." }) {
+            switch (octets[0], octets[1]) {
+            case (127, _): return true        // loopback 127.0.0.0/8
+            case (10, _): return true         // private 10.0.0.0/8
+            case (192, 168): return true      // private 192.168.0.0/16
+            case (169, 254): return true      // link-local 169.254.0.0/16
+            case (172, 16...31): return true  // private 172.16.0.0/12
+            default: return false
+            }
+        }
+        return false
+    }
+
+    /// A user-facing warning when the configured base URL would transmit the API
+    /// key and transcript content to a non-local host over plaintext HTTP. Remote
+    /// HTTPS and local HTTP (loopback/private/`.local`) return `nil` so legitimate
+    /// enterprise-proxy and local-provider workflows are not nagged.
+    static func plaintextRemoteBaseURLWarning(
+        from rawValue: String,
+        provider: AIProvider = .openAI
+    ) -> String? {
+        let url = normalizedOpenAIBaseURL(from: rawValue, provider: provider)
+        guard url.scheme?.lowercased() == "http",
+              let host = url.host,
+              !isLocalEndpointHost(host) else {
+            return nil
+        }
+        return "This endpoint uses plaintext HTTP to a remote host (\(host)). "
+            + "Your API key and transcript text would be sent unencrypted. Use "
+            + "https:// unless this is a trusted local endpoint."
+    }
+
+    /// Warning to surface near the base-URL field for the active provider, or nil.
+    var aiBaseURLPlaintextWarning: String? {
+        Self.plaintextRemoteBaseURLWarning(from: openAIBaseURL, provider: aiProvider)
+    }
+
+    /// The host the configured base URL resolves to, for display near the field.
+    var effectiveAIBaseURLHost: String? {
+        openAIBaseURLValue.host
+    }
+
     var preferredModelValue: String {
         Self.normalizedTranscriptionModel(preferredModel, for: aiProvider)
     }

--- a/Sources/BugNarrator/Views/AISetupSectionsView.swift
+++ b/Sources/BugNarrator/Views/AISetupSectionsView.swift
@@ -80,6 +80,19 @@ struct AISetupSectionsView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
+                if let warning = settingsStore.aiBaseURLPlaintextWarning {
+                    Label(warning, systemImage: "exclamationmark.triangle.fill")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityLabel("Insecure endpoint warning")
+                } else if let host = settingsStore.effectiveAIBaseURLHost {
+                    Text("Requests go to: \(host)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel("Requests go to \(host)")
+                }
+
                 HStack(spacing: 12) {
                     Text(settingsStore.maskedSelectedAIProviderCredential)
                         .font(.subheadline.monospaced())

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -370,6 +370,32 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testBaseURLWarnsOnlyForPlaintextRemoteHost() {
+        // Remote HTTPS and local HTTP must not warn (supported workflows).
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "https://api.example.com/v1"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://localhost:1234/v1"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://127.0.0.1:8422"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://192.168.1.50:1234"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://10.0.0.5:8080"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://lmstudio:1234"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://nas.local:1234"))
+        XCTAssertNil(SettingsStore.plaintextRemoteBaseURLWarning(from: ""))
+
+        // Plaintext HTTP to a public host must warn.
+        XCTAssertNotNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://api.example.com/v1"))
+        XCTAssertNotNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://203.0.113.10:8080"))
+    }
+
+    func testIsLocalEndpointHostClassification() {
+        for local in ["localhost", "127.0.0.1", "10.1.2.3", "172.16.0.1", "172.31.255.1",
+                      "192.168.0.1", "169.254.1.1", "myserver.local", "lmstudio", "::1"] {
+            XCTAssertTrue(SettingsStore.isLocalEndpointHost(local), "expected \(local) to be local")
+        }
+        for remote in ["api.openai.com", "8.8.8.8", "172.32.0.1", "example.com"] {
+            XCTAssertFalse(SettingsStore.isLocalEndpointHost(remote), "expected \(remote) to be remote")
+        }
+    }
+
     func testTranscriptionRequestUsesNormalizedTranscriptionSettings() {
         let suiteName = "BugNarrator-TranscriptionRequestSettingsTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
Closes #472.

## What
`normalizedOpenAIBaseURL` accepted any host/scheme with no guardrail, so a user pointed at a plaintext remote endpoint would silently POST their API key and transcript text unencrypted. This adds:
- `isLocalEndpointHost` — classifies loopback / private (RFC1918) / link-local / `.local` / single-label hosts.
- `plaintextRemoteBaseURLWarning` — returns a warning only for plaintext HTTP to a public host.
- A warning callout + the effective request host shown near the base-URL field in `AISetupSectionsView`.

## Why
Per the codex review on #472: the fix must not nag legitimate workflows. Remote **HTTPS** (enterprise proxy) and **local HTTP** (loopback/private/`.local` — LM Studio / Ollama / Parakeet) stay friction-free; only plaintext HTTP to a public host is surfaced. I chose a prominent warning + effective-host display over a hard block to avoid breaking enterprise HTTP proxies.

## Tests
- `testBaseURLWarnsOnlyForPlaintextRemoteHost` and `testIsLocalEndpointHostClassification`.
- Full `BugNarratorTests` suite green locally (584 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)