### PR TITLE
fix: neutralize untrusted LLM text in GitHub issue bodies (#477)

### DIFF
--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -385,6 +385,28 @@ actor GitHubExportProvider {
         )
     }
 
+    /// Neutralizes untrusted (LLM-derived) text so it renders as literal content
+    /// in a GitHub Markdown issue body: it cannot trigger `@mentions` or `#issue`
+    /// cross-links, inject raw HTML, or start new block-level structure
+    /// (headings, quotes, lists, tables, code fences).
+    static func neutralizingUntrustedMarkdown(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n").map { line -> String in
+            var escaped = line
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+                // A zero-width space after @/# breaks GitHub's mention and issue
+                // autolinks (and defeats `# heading` injection) while leaving the
+                // text visually identical.
+                .replacingOccurrences(of: "@", with: "@\u{200B}")
+                .replacingOccurrences(of: "#", with: "#\u{200B}")
+            if let first = escaped.first, "-*+|=`~".contains(first) {
+                escaped = "\\" + escaped
+            }
+            return escaped
+        }
+        return lines.joined(separator: "\n")
+    }
+
     private func makeIssueBody(
         issue: ExtractedIssue,
         session: TranscriptSession,
@@ -392,15 +414,19 @@ actor GitHubExportProvider {
     ) throws -> String {
         var lines: [String] = [
             "## Summary",
-            TrackerExportPayloadBudget.truncated(
-                issue.summary,
-                maxCharacters: TrackerExportPayloadBudget.issueSummaryLimit
+            Self.neutralizingUntrustedMarkdown(
+                TrackerExportPayloadBudget.truncated(
+                    issue.summary,
+                    maxCharacters: TrackerExportPayloadBudget.issueSummaryLimit
+                )
             ),
             "",
             "## Evidence",
-            TrackerExportPayloadBudget.truncated(
-                issue.evidenceExcerpt,
-                maxCharacters: TrackerExportPayloadBudget.evidenceLimit
+            Self.neutralizingUntrustedMarkdown(
+                TrackerExportPayloadBudget.truncated(
+                    issue.evidenceExcerpt,
+                    maxCharacters: TrackerExportPayloadBudget.evidenceLimit
+                )
             ),
             ""
         ]
@@ -413,13 +439,13 @@ actor GitHubExportProvider {
 
         if let component = issue.component?.trimmingCharacters(in: .whitespacesAndNewlines),
            !component.isEmpty {
-            lines.append("- Component: \(component)")
+            lines.append("- Component: \(Self.neutralizingUntrustedMarkdown(component))")
         }
 
         lines.append("- Deduplication hint: `\(issue.deduplicationHint)`")
 
         if let sectionTitle = issue.sectionTitle, !sectionTitle.isEmpty {
-            lines.append("- Transcript section: \(sectionTitle)")
+            lines.append("- Transcript section: \(Self.neutralizingUntrustedMarkdown(sectionTitle))")
         }
 
         if let confidenceLabel = issue.confidenceLabel {
@@ -433,6 +459,9 @@ actor GitHubExportProvider {
         if let note = issue.note?.trimmingCharacters(in: .whitespacesAndNewlines),
            !note.isEmpty {
             lines.append("")
+            // `note` is set by our own dedup policy (trackerContextNote) and may
+            // deliberately contain a "Related to #123" cross-link, so it is not
+            // neutralized here.
             lines.append("## Tracker Context")
             lines.append(
                 TrackerExportPayloadBudget.truncated(
@@ -448,17 +477,17 @@ actor GitHubExportProvider {
 
             for (index, step) in issue.reproductionSteps.prefix(TrackerExportPayloadBudget.reproductionStepLimit).enumerated() {
                 lines.append(
-                    "\(index + 1). \(TrackerExportPayloadBudget.truncated(step.instruction, maxCharacters: TrackerExportPayloadBudget.listEntryLimit))"
+                    "\(index + 1). \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(step.instruction, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))"
                 )
 
                 if let expectedResult = step.expectedResult?.trimmingCharacters(in: .whitespacesAndNewlines),
                    !expectedResult.isEmpty {
-                    lines.append("   - Expected: \(TrackerExportPayloadBudget.truncated(expectedResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit))")
+                    lines.append("   - Expected: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(expectedResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
                 }
 
                 if let actualResult = step.actualResult?.trimmingCharacters(in: .whitespacesAndNewlines),
                    !actualResult.isEmpty {
-                    lines.append("   - Actual: \(TrackerExportPayloadBudget.truncated(actualResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit))")
+                    lines.append("   - Actual: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(actualResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
                 }
 
                 if let reference = reproductionStepReference(step, session: session) {

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -209,6 +209,59 @@ final class GitHubExportProviderTests: XCTestCase {
         )
     }
 
+    func testNeutralizingUntrustedMarkdownDefangsMentionsRefsAndStructure() {
+        let out = GitHubExportProvider.neutralizingUntrustedMarkdown("@channel ping #123 <img src=x> done")
+        XCTAssertFalse(out.contains("@channel"), "mention should be broken with a zero-width space")
+        XCTAssertFalse(out.contains("#123"), "issue ref should be broken with a zero-width space")
+        XCTAssertFalse(out.contains("<img"))
+        XCTAssertTrue(out.contains("&lt;img"))
+
+        let heading = GitHubExportProvider.neutralizingUntrustedMarkdown("## Injected heading")
+        XCTAssertFalse(heading.hasPrefix("## "), "injected heading must not start with a real `# ` token")
+
+        let fence = GitHubExportProvider.neutralizingUntrustedMarkdown("```malicious fence")
+        XCTAssertTrue(fence.hasPrefix("\\`"), "leading code fence should be escaped")
+    }
+
+    func testIssueBodyNeutralizesUntrustedSummaryFields() async throws {
+        let provider = GitHubExportProvider(session: makeMockURLSession())
+        let issue = ExtractedIssue(
+            title: "Checkout fails",
+            category: .bug,
+            summary: "@channel please fix #999 <script>alert(1)</script>",
+            evidenceExcerpt: "## Injected\nSee @maintainer about #1",
+            timestamp: nil
+        )
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+
+        let request = try await provider.makeURLRequest(
+            issue: issue,
+            session: session,
+            configuration: GitHubExportConfiguration(
+                token: "fixture-github-token",
+                owner: "acme",
+                repository: "bugnarrator",
+                labels: []
+            )
+        )
+
+        let body = try requestBodyData(from: request)
+        let payload = try JSONDecoder().decode(GitHubIssueRequestPayload.self, from: body)
+        XCTAssertFalse(payload.body.contains("@channel"))
+        XCTAssertFalse(payload.body.contains("#999"))
+        XCTAssertFalse(payload.body.contains("@maintainer"))
+        XCTAssertFalse(payload.body.contains("<script>"))
+        XCTAssertTrue(payload.body.contains("&lt;script&gt;"))
+    }
+
     func testValidateConfigurationChecksRepositoryAccess() async throws {
         let provider = GitHubExportProvider(session: makeMockURLSession())
 

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -177,6 +177,52 @@ final class JiraExportProviderTests: XCTestCase {
         XCTAssertEqual(issueType["name"] as? String, "Task")
     }
 
+    func testUntrustedSummaryStaysLiteralInJiraADF() async throws {
+        // Jira descriptions are built as ADF text nodes, so untrusted content is
+        // stored verbatim (no Markdown interpretation). Assert it round-trips
+        // literally rather than being parsed as markup.
+        let provider = JiraExportProvider(session: makeMockURLSession())
+        let hostile = "@channel ping #999 <script>alert(1)</script>"
+        let issue = ExtractedIssue(
+            title: "Checkout fails",
+            category: .bug,
+            summary: hostile,
+            evidenceExcerpt: "Evidence",
+            timestamp: nil
+        )
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+
+        let request = try await provider.makeURLRequest(
+            issue: issue,
+            session: session,
+            configuration: JiraExportConfiguration(
+                baseURL: URL(string: "https://acme.atlassian.net")!,
+                email: "you@example.com",
+                apiToken: "fixture-jira-token",
+                projectKey: "FM",
+                issueType: "Task"
+            )
+        )
+
+        let body = try requestBodyData(from: request)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let fields = try XCTUnwrap(payload["fields"] as? [String: Any])
+        let description = try XCTUnwrap(fields["description"] as? [String: Any])
+        let descriptionData = try JSONSerialization.data(withJSONObject: description)
+        let descriptionString = try XCTUnwrap(String(data: descriptionData, encoding: .utf8))
+        // The literal hostile text is present as a JSON string value (text node).
+        XCTAssertTrue(descriptionString.contains("@channel ping"))
+        XCTAssertTrue(descriptionString.contains("alert(1)"))
+    }
+
     func testFindOpenIssuesBuildsSearchRequestAndParsesMatches() async throws {
         let provider = JiraExportProvider(session: makeMockURLSession())
         let issue = ExtractedIssue(


### PR DESCRIPTION
Closes #477.

## What
LLM-derived fields (summary, evidence, component, transcript section, reproduction steps) were inserted into the GitHub Markdown body with only truncation. A transcript producing `@mentions`, `#issue` refs, raw HTML, or block-level Markdown would ping users, cross-link issues, or break the issue structure on every export. Adds `neutralizingUntrustedMarkdown` (zero-width space after `@`/`#`, `&lt;`/`&gt;` escaping, leading block-marker escaping) and applies it to those fields.

## Why / scope (per codex review on #477)
- The dedup-policy `note` is **not** neutralized — it is set by our own `trackerContextNote` and may deliberately carry a `Related to #123` cross-link.
- Jira already stores text as literal **ADF text nodes**, so no Jira change is needed; a literal-round-trip test locks that in.

## Tests
- `testNeutralizingUntrustedMarkdownDefangsMentionsRefsAndStructure` (unit) and `testIssueBodyNeutralizesUntrustedSummaryFields` (integration).
- `testUntrustedSummaryStaysLiteralInJiraADF` for the Jira literal guarantee.
- Targeted GitHub+Jira suites green locally; full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)