### PR TITLE
docs: document thread-safety invariant for each @unchecked Sendable (#469)

### DIFF
--- a/Sources/BugNarrator/Services/MixedAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/MixedAudioRecorder.swift
@@ -366,6 +366,12 @@ struct MixedAudioTrackInsertionOffsets: Equatable {
     }
 }
 
+// Thread-safety invariant: a bridge instance wraps one AVAssetExportSession used
+// by exactly one mixed-audio export. The session is fully configured before
+// `exportAsynchronously` starts; thereafter the only concurrent touch is
+// `cancelExport()` from the 30s timeout task, which Apple documents as safe to
+// call while an export is in flight. No other aliasing exists, so `@unchecked`
+// holds.
 private final class MixedAssetExportSessionBridge: @unchecked Sendable {
     let session: AVAssetExportSession
 

--- a/Sources/BugNarrator/Services/PrivacyDataExporter.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExporter.swift
@@ -152,6 +152,11 @@ struct PrivacyDataExporter {
 
 extension PrivacyDataExporter: PrivacyDataExporting {}
 
+// Thread-safety invariant: all stored properties are immutable `let`s, so the
+// value carries no mutable shared state. The `@unchecked` only suppresses the
+// non-Sendable `FileManager`/recorder/store members; each of those is either
+// independently thread-safe or confined to the store's own actor/queue, so
+// sharing this value across tasks introduces no data race.
 struct LocalPrivacyDataManager: @unchecked Sendable {
     private let fileManager: FileManager
     private let appSupportURL: URL

--- a/Sources/BugNarrator/Services/SystemAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/SystemAudioRecorder.swift
@@ -513,6 +513,10 @@ private final class SystemAudioTapSession {
     }
 }
 
+// Thread-safety invariant: every access to the mutable state (`file`,
+// `writeError`, `formatInvalidated`) is serialized through `lock`, so this type
+// is safe to share across the CoreAudio callback thread and the recording actor
+// despite `AVAudioFile` not being Sendable. Hence the `@unchecked` is sound.
 final class SystemAudioFileWriter: @unchecked Sendable {
     private let lock = NSLock()
     private let format: AVAudioFormat

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -734,6 +734,11 @@ struct DefaultTranscriptionChunker: TranscriptionChunking {
     private static let chunkExportTimeoutMultiplier: Double = 3
 }
 
+// Thread-safety invariant: a bridge instance wraps one AVAssetExportSession used
+// by exactly one `exportChunk` call. The session is fully configured before
+// `exportAsynchronously` starts; thereafter the only concurrent touch is
+// `cancelExport()` from the timeout task, which Apple documents as safe to call
+// while an export is in flight. No other aliasing exists, so `@unchecked` holds.
 private final class AssetExportSessionBridge: @unchecked Sendable {
     let session: AVAssetExportSession
 

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -395,6 +395,9 @@ enum BugNarratorDiagnostics {
     }
 }
 
+// Thread-safety invariant: the only mutable state (`debugModeEnabled`) is read
+// and written exclusively under `lock`, so concurrent access from any thread is
+// serialized. The `@unchecked` is therefore sound.
 private final class DiagnosticsConfiguration: @unchecked Sendable {
     private let lock = NSLock()
     private var debugModeEnabled = false


### PR DESCRIPTION
Closes #469.

## What
Audited all five `@unchecked Sendable` conformances and added a precise comment stating the invariant that makes each sound.

## Why (per codex review on #469)
The risk was not uniform — codex found two sites already `NSLock`-guarded and one immutable, with only the two `AVAssetExportSession` bridges genuinely needing reasoning. Rather than churn the safe ones, each site now documents the concrete invariant:
- `SystemAudioFileWriter` / `DiagnosticsConfiguration` — all mutable state serialized through an `NSLock`.
- `LocalPrivacyDataManager` — immutable value; non-Sendable members are thread-safe or actor/queue-confined.
- `AssetExportSessionBridge` / `MixedAssetExportSessionBridge` — single-shot wrapper; only concurrent touch is `cancelExport()`, documented safe during an in-flight export.

No behaviour change; build verified locally, full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)