### PR TITLE
test: make the issue-extraction timeout test deterministic (#476)

### DIFF
--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -318,8 +318,13 @@ final class IssueExtractionServiceTests: XCTestCase {
     func testExtractIssuesTimesOutAfterConfiguredBudget() async throws {
         let session = makeReviewSession()
 
+        // Block the request until the test releases it, so the configured timeout
+        // is guaranteed to win the race. This removes the flaky dependency on a
+        // real Thread.sleep being longer than the timeout under CI load.
+        let release = DispatchSemaphore(value: 0)
+        defer { release.signal() }
         MockURLProtocol.requestHandler = { request in
-            Thread.sleep(forTimeInterval: 0.3)
+            release.wait()
             return (self.successResponse(for: request), self.makeChatCompletionData(content: #"{"summary":"","guidanceNote":"","issues":[]}"#))
         }
 


### PR DESCRIPTION
Closes #476.

## What
Replaced the real `Thread.sleep(0.3)` in `testExtractIssuesTimesOutAfterConfiguredBudget` with a `DispatchSemaphore` that blocks the mocked request until the test releases it, so the configured 250ms timeout deterministically wins the race.

## Why (per codex review on #476)
Codex flagged this as the worst offender — a real sleep being marginally longer than the timeout (300ms vs 250ms) is inherently flaky under CI load. The semaphore removes the timing dependence entirely. Remaining sleep/poll sites are noted on the issue for follow-up.

## Tests
- `IssueExtractionServiceTests` green locally (9 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)