### PR TITLE
feat(windows): warn on plaintext-HTTP remote AI base URL (parity with #472) (#479)

### DIFF
--- a/windows/src/BugNarrator.Windows.Services/Http/OpenAiCompatibleEndpoint.cs
+++ b/windows/src/BugNarrator.Windows.Services/Http/OpenAiCompatibleEndpoint.cs
@@ -25,6 +25,90 @@ public static class OpenAiCompatibleEndpoint
         return NormalizeBaseUri(configuredBaseUrl).ToString().TrimEnd('/');
     }
 
+    /// <summary>
+    /// Whether <paramref name="host"/> denotes a loopback / private / link-local /
+    /// .local endpoint, for which plaintext HTTP is acceptable because the traffic
+    /// stays on the machine or the trusted local network.
+    /// </summary>
+    public static bool IsLocalEndpointHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return false;
+        }
+
+        var lowered = host.Trim().Trim('[', ']').ToLowerInvariant();
+
+        if (lowered == "localhost" || lowered.EndsWith(".localhost", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (lowered.EndsWith(".local", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Single-label hostnames (e.g. "lmstudio") never resolve on public DNS.
+        if (!lowered.Contains('.') && !lowered.Contains(':'))
+        {
+            return true;
+        }
+
+        // IPv6 loopback / link-local.
+        if (lowered == "::1" || lowered.StartsWith("fe80:", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var parts = lowered.Split('.');
+        if (parts.Length == 4 && parts.All(part => byte.TryParse(part, out _)))
+        {
+            var first = byte.Parse(parts[0]);
+            var second = byte.Parse(parts[1]);
+            return first switch
+            {
+                127 => true,                       // loopback 127.0.0.0/8
+                10 => true,                        // private 10.0.0.0/8
+                192 when second == 168 => true,    // private 192.168.0.0/16
+                169 when second == 254 => true,    // link-local 169.254.0.0/16
+                172 when second >= 16 && second <= 31 => true, // private 172.16.0.0/12
+                _ => false,
+            };
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// A user-facing warning when the configured base URL would transmit the API
+    /// key and transcript content to a non-local host over plaintext HTTP. Remote
+    /// HTTPS and local HTTP (loopback/private/.local) return null so enterprise-proxy
+    /// and local-provider workflows are not nagged. Mirrors the macOS app (#472).
+    /// </summary>
+    public static string? PlaintextRemoteWarning(string? configuredBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(configuredBaseUrl))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(configuredBaseUrl.Trim(), UriKind.Absolute, out var parsed))
+        {
+            return null;
+        }
+
+        if (!string.Equals(parsed.Scheme, "http", StringComparison.OrdinalIgnoreCase)
+            || IsLocalEndpointHost(parsed.Host))
+        {
+            return null;
+        }
+
+        return $"This endpoint uses plaintext HTTP to a remote host ({parsed.Host}). "
+            + "Your API key and transcript text would be sent unencrypted. Use "
+            + "https:// unless this is a trusted local endpoint.";
+    }
+
     private static Uri NormalizeBaseUri(string? configuredBaseUrl)
     {
         if (string.IsNullOrWhiteSpace(configuredBaseUrl))

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
@@ -96,6 +96,14 @@ public sealed record WindowsAppSettings(
             ? null
             : OpenAiCompatibleEndpoint.NormalizeForStorage(AiProviderBaseUrl);
 
+    /// <summary>
+    /// Non-blocking warning to surface near the base-URL field when the endpoint
+    /// would send the API key + transcript text over plaintext HTTP to a remote
+    /// host. Null for remote HTTPS and local HTTP. Mirrors the macOS app (#472).
+    /// </summary>
+    public string? AiProviderBaseUrlSecurityWarning =>
+        OpenAiCompatibleEndpoint.PlaintextRemoteWarning(AiProviderBaseUrl);
+
     public string? AiProviderCompatibilityIssue
     {
         get

--- a/windows/tests/BugNarrator.Windows.Tests/OpenAiCompatibleEndpointTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/OpenAiCompatibleEndpointTests.cs
@@ -28,4 +28,52 @@ public sealed class OpenAiCompatibleEndpointTests
 
         Assert.Equal("http://localhost:11434/v1/models", endpoint.AbsoluteUri);
     }
+
+    [Theory]
+    [InlineData("https://api.example.com/v1")]   // remote HTTPS
+    [InlineData("http://localhost:1234/v1")]      // loopback HTTP
+    [InlineData("http://127.0.0.1:8422")]
+    [InlineData("http://192.168.1.50:1234")]      // private network
+    [InlineData("http://10.0.0.5:8080")]
+    [InlineData("http://lmstudio:1234")]          // single-label host
+    [InlineData("http://nas.local:1234")]
+    [InlineData("")]
+    public void PlaintextRemoteWarning_AllowsHttpsAndLocalHttp(string baseUrl)
+    {
+        Assert.Null(OpenAiCompatibleEndpoint.PlaintextRemoteWarning(baseUrl));
+    }
+
+    [Theory]
+    [InlineData("http://api.example.com/v1")]
+    [InlineData("http://203.0.113.10:8080")]
+    public void PlaintextRemoteWarning_WarnsForPlaintextRemoteHost(string baseUrl)
+    {
+        Assert.NotNull(OpenAiCompatibleEndpoint.PlaintextRemoteWarning(baseUrl));
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("10.1.2.3")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.1")]
+    [InlineData("192.168.0.1")]
+    [InlineData("169.254.1.1")]
+    [InlineData("myserver.local")]
+    [InlineData("lmstudio")]
+    [InlineData("::1")]
+    public void IsLocalEndpointHost_DetectsLocalHosts(string host)
+    {
+        Assert.True(OpenAiCompatibleEndpoint.IsLocalEndpointHost(host));
+    }
+
+    [Theory]
+    [InlineData("api.openai.com")]
+    [InlineData("8.8.8.8")]
+    [InlineData("172.32.0.1")]
+    [InlineData("example.com")]
+    public void IsLocalEndpointHost_RejectsRemoteHosts(string host)
+    {
+        Assert.False(OpenAiCompatibleEndpoint.IsLocalEndpointHost(host));
+    }
 }


### PR DESCRIPTION
Closes #479.

## What
Windows parity for the macOS base-URL guardrail (#472). `OpenAiCompatibleEndpoint` accepted any absolute http/https URL with no check, so a plaintext remote endpoint would silently send the API key + transcript text unencrypted. Adds `IsLocalEndpointHost` and `PlaintextRemoteWarning`, surfaced via `WindowsAppSettings.AiProviderBaseUrlSecurityWarning`. Remote HTTPS and local HTTP (loopback/private/`.local`/single-label) stay friction-free.

## Validation
The Windows Services project requires the Windows-desktop SDK and can't build on the macOS dev host, and there is no Windows PR CI. The platform-agnostic `OpenAiCompatibleEndpoint` logic was instead validated by compiling it into an isolated `net8.0` xUnit project and running the full test set: **27 passed, 0 failed** (3 existing + 24 new, covering loopback/private/link-local/`.local`/single-label vs remote-https/remote-http/malformed). The `WindowsAppSettings` change is a one-line delegating property identical in shape to the adjacent `EffectiveAiProviderBaseUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)