### PR TITLE
fix(windows): neutralize untrusted LLM text in GitHub issue bodies (#492)

### DIFF
--- a/windows/src/BugNarrator.Windows.Services/Export/GitHubExportProvider.cs
+++ b/windows/src/BugNarrator.Windows.Services/Export/GitHubExportProvider.cs
@@ -114,10 +114,10 @@ public sealed class GitHubExportProvider
         var lines = new List<string>
         {
             "## Summary",
-            issue.Summary,
+            UntrustedMarkdown.Neutralize(issue.Summary),
             string.Empty,
             "## Evidence",
-            issue.EvidenceExcerpt,
+            UntrustedMarkdown.Neutralize(issue.EvidenceExcerpt),
             string.Empty,
         };
 
@@ -128,7 +128,7 @@ public sealed class GitHubExportProvider
 
         if (!string.IsNullOrWhiteSpace(issue.SectionTitle))
         {
-            lines.Add($"- Transcript section: {issue.SectionTitle}");
+            lines.Add($"- Transcript section: {UntrustedMarkdown.Neutralize(issue.SectionTitle)}");
         }
 
         if (issue.ConfidenceLabel is not null)
@@ -143,7 +143,7 @@ public sealed class GitHubExportProvider
 
         if (!string.IsNullOrWhiteSpace(issue.Note))
         {
-            lines.Add($"- Note: {issue.Note}");
+            lines.Add($"- Note: {UntrustedMarkdown.Neutralize(issue.Note)}");
         }
 
         var screenshots = session.Screenshots

--- a/windows/src/BugNarrator.Windows.Services/Export/UntrustedMarkdown.cs
+++ b/windows/src/BugNarrator.Windows.Services/Export/UntrustedMarkdown.cs
@@ -1,0 +1,42 @@
+namespace BugNarrator.Windows.Services.Export;
+
+/// <summary>
+/// Neutralizes untrusted (LLM-derived) text so it renders as literal content in a
+/// GitHub Markdown issue body: it cannot trigger @mentions or #issue cross-links,
+/// inject raw HTML, or start new block-level structure (headings, quotes, lists,
+/// tables, code fences). Mirrors the macOS app's neutralizingUntrustedMarkdown (#477).
+/// </summary>
+public static class UntrustedMarkdown
+{
+    private const string ZeroWidthSpace = "\u200B";
+
+    public static string Neutralize(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text ?? string.Empty;
+        }
+
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            // A zero-width space after @/# breaks GitHub's mention and issue
+            // autolinks (and defeats `# heading` injection) while leaving the
+            // text visually identical; angle brackets become HTML entities.
+            var escaped = lines[i]
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("@", "@" + ZeroWidthSpace)
+                .Replace("#", "#" + ZeroWidthSpace);
+
+            if (escaped.Length > 0 && "-*+|=`~".IndexOf(escaped[0]) >= 0)
+            {
+                escaped = "\\" + escaped;
+            }
+
+            lines[i] = escaped;
+        }
+
+        return string.Join("\n", lines);
+    }
+}

--- a/windows/tests/BugNarrator.Windows.Tests/UntrustedMarkdownTests.cs
+++ b/windows/tests/BugNarrator.Windows.Tests/UntrustedMarkdownTests.cs
@@ -1,0 +1,63 @@
+using BugNarrator.Windows.Services.Export;
+using Xunit;
+
+namespace BugNarrator.Windows.Tests;
+
+public sealed class UntrustedMarkdownTests
+{
+    [Fact]
+    public void Neutralize_DefangsMentionsAndIssueReferences()
+    {
+        var output = UntrustedMarkdown.Neutralize("@channel ping #123 done");
+
+        // Ordinal comparison: a zero-width space is inserted after @/# (which
+        // breaks GitHub's byte/regex-based autolink parser). A culture-aware
+        // comparison would ignore the ZWSP, so assert ordinally.
+        Assert.DoesNotContain("@channel", output, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("#123", output, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Neutralize_EscapesRawHtml()
+    {
+        var output = UntrustedMarkdown.Neutralize("<script>alert(1)</script>");
+
+        Assert.DoesNotContain("<script>", output, System.StringComparison.Ordinal);
+        Assert.Contains("&lt;script&gt;", output, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Neutralize_DefeatsInjectedHeading()
+    {
+        var output = UntrustedMarkdown.Neutralize("## Injected heading");
+
+        Assert.False(output.StartsWith("## ", System.StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("```malicious fence")]
+    [InlineData("- injected list item")]
+    [InlineData("| injected | table |")]
+    public void Neutralize_EscapesLeadingBlockMarkers(string input)
+    {
+        var output = UntrustedMarkdown.Neutralize(input);
+
+        Assert.StartsWith("\\", output, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Neutralize_PreservesPlainText()
+    {
+        var output = UntrustedMarkdown.Neutralize("The login button stays disabled after valid input.");
+
+        Assert.Equal("The login button stays disabled after valid input.", output);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Neutralize_HandlesNullAndEmpty(string? input)
+    {
+        Assert.Equal(string.Empty, UntrustedMarkdown.Neutralize(input));
+    }
+}


### PR DESCRIPTION
Closes #492.

## What
Windows parity for macOS #477. Adds `UntrustedMarkdown.Neutralize` (zero-width space after `@`/`#`, `&lt;`/`&gt;` escaping, leading block-marker escaping) and applies it to the LLM-derived GitHub body fields: **Summary, EvidenceExcerpt, SectionTitle, Note**.

## Scope (per codex review on #492)
- Limited to the fields the Windows `ExtractedIssue` actually has — no Component/dedup-hint/reproduction-steps on Windows.
- Windows `Note` is model-derived (not a trusted dedup annotation like macOS), so it **is** neutralized.
- Jira already emits literal **ADF text nodes** (`JiraExportProvider.cs`), so no Jira change is required.

## Validation
The Windows Services project needs the Windows-desktop SDK and can't build on the macOS host, and there's no Windows PR CI. The platform-agnostic `UntrustedMarkdown` was validated in an isolated `net8.0` xUnit run: **9 passed**. (Assertions use `StringComparison.Ordinal` because xUnit's default culture-aware comparison ignores the zero-width space — GitHub's autolink parser is byte/regex-based and does break on it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)