### PR TITLE
fix: log + flag screenshots that fail to attach during issue extraction (#494)

### DIFF
--- a/Sources/BugNarrator/Services/IssueExtractionService.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionService.swift
@@ -202,10 +202,12 @@ actor IssueExtractionService: IssueExtracting {
     }
 
     private static func makeUserMessageParts(for session: TranscriptSession) -> [ChatMessageInputPart] {
+        let logger = DiagnosticsLogger(category: .transcription)
         var parts: [ChatMessageInputPart] = [.text(makePrompt(for: session))]
 
         var includedScreenshotCount = 0
         var omittedScreenshotCount = 0
+        var failedToLoadCount = 0
         var totalScreenshotBytes = 0
 
         for screenshot in session.screenshots.prefix(IssueExtractionRequestBudget.maximumScreenshotCount) {
@@ -216,13 +218,19 @@ actor IssueExtractionService: IssueExtracting {
                 continue
             }
 
-            parts.append(.text("Screenshot reference: \(screenshot.fileName) at \(screenshot.timeLabel)."))
-
+            // Build the image part first: a referenced-but-unattached screenshot
+            // would otherwise tell the model an image exists that it never received.
             guard let imagePart = makeScreenshotContentPart(for: screenshot) else {
-                omittedScreenshotCount += 1
+                failedToLoadCount += 1
+                logger.warning(
+                    "extraction_screenshot_load_failed",
+                    "A referenced screenshot passed the size check but could not be read or encoded for the extraction request.",
+                    metadata: ["file_name": screenshot.fileName]
+                )
                 continue
             }
 
+            parts.append(.text("Screenshot reference: \(screenshot.fileName) at \(screenshot.timeLabel)."))
             parts.append(imagePart)
             includedScreenshotCount += 1
             totalScreenshotBytes += byteCount
@@ -234,6 +242,10 @@ actor IssueExtractionService: IssueExtracting {
 
         if omittedScreenshotCount > 0 {
             parts.append(.text("Screenshot budget note: \(omittedScreenshotCount) screenshot(s) were omitted from AI extraction to keep the request reliable. Use filenames and transcript context for any omitted screenshots."))
+        }
+
+        if failedToLoadCount > 0 {
+            parts.append(.text("Screenshot attachment note: \(failedToLoadCount) referenced screenshot image(s) failed to attach; do not infer visual details from those filenames."))
         }
 
         if includedScreenshotCount > 0 {

--- a/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionServiceTests.swift
@@ -315,6 +315,51 @@ final class IssueExtractionServiceTests: XCTestCase {
         XCTAssertEqual(result.summary, "Budgeted.")
     }
 
+    func testExtractIssuesNotesScreenshotsThatFailToAttach() async throws {
+        let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        // Exists and is non-empty (passes the size budget) but is an unsupported
+        // image type, so it cannot be encoded as an image part.
+        let unsupportedURL = directoryURL.appendingPathComponent("evidence.bmp")
+        try Data(repeating: 0x42, count: 64).write(to: unsupportedURL)
+        let screenshot = SessionScreenshot(elapsedTime: 5, filePath: unsupportedURL.path)
+        let session = TranscriptSession(
+            createdAt: Date(timeIntervalSince1970: 10),
+            transcript: "The save button is clipped.",
+            duration: 12,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            screenshots: [screenshot]
+        )
+
+        MockURLProtocol.requestHandler = { request in
+            let body = try requestBodyData(from: request)
+            let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let messages = try XCTUnwrap(payload["messages"] as? [[String: Any]])
+            let userContent = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
+            let textContent = userContent
+                .compactMap { $0["text"] as? String }
+                .joined(separator: "\n")
+
+            // No image attached, no dangling "Screenshot reference" line, and an
+            // explicit failed-to-attach note instead.
+            XCTAssertEqual(userContent.filter { ($0["type"] as? String) == "image_url" }.count, 0)
+            XCTAssertFalse(textContent.contains("Screenshot reference: evidence.bmp"))
+            XCTAssertTrue(textContent.contains("failed to attach"))
+
+            return (
+                self.successResponse(for: request),
+                self.makeChatCompletionData(content: #"{"summary":"ok","guidanceNote":"","issues":[]}"#)
+            )
+        }
+
+        let service = IssueExtractionService(session: makeMockURLSession())
+        _ = try await service.extractIssues(from: session, apiKey: "fixture-openai-key", model: "gpt-4.1-mini")
+    }
+
     func testExtractIssuesTimesOutAfterConfiguredBudget() async throws {
         let session = makeReviewSession()
 


### PR DESCRIPTION
Closes #494.

## What
A screenshot that passed the size budget but couldn't be read/encoded (unreadable or unsupported type) was silently dropped — and the prompt still appended a "Screenshot reference" line, telling the model an image existed that it never received.

Now the image part is built first; on failure the screenshot is counted separately, logged (file name only), and the reference line is omitted. A prompt note tells the model that N referenced screenshots failed to attach so it won't infer visual details from filenames.

## Per codex review on #494
- Missing files fail earlier at the size check; this targets the existing-but-unreadable / unsupported-type case.
- Distinguishes load-failed from budget-omitted in both logging and the prompt accounting.

## Tests
- New `testExtractIssuesNotesScreenshotsThatFailToAttach`: an unsupported-type screenshot yields no image part, no dangling reference line, and the failed-to-attach note.
- Full `BugNarratorTests` suite green locally (589 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)