### PR TITLE
fix: log swallowed TranscriptStore persistence/cleanup failures (#495)

### DIFF
--- a/Sources/BugNarrator/Services/TranscriptStore.swift
+++ b/Sources/BugNarrator/Services/TranscriptStore.swift
@@ -109,7 +109,18 @@ final class TranscriptStore: ObservableObject {
         do {
             try persistIndex(remainingEntries)
             for id in ids {
-                try? fileManager.removeItem(at: sessionFileURL(for: id))
+                let fileURL = sessionFileURL(for: id)
+                guard fileManager.fileExists(atPath: fileURL.path) else { continue }
+                do {
+                    try fileManager.removeItem(at: fileURL)
+                } catch {
+                    logStorageFailure(
+                        "session_file_delete_failed",
+                        "Failed to delete a session file during removal; it may be orphaned.",
+                        error: error,
+                        fileName: fileURL.lastPathComponent
+                    )
+                }
             }
             try cleanupUnreferencedSessionFiles(retainedIDs: Set(remainingEntries.map(\.id)))
             replaceState(
@@ -174,7 +185,15 @@ final class TranscriptStore: ObservableObject {
 
         if let backupState = loadPartitionedState(from: backupIndexURL) {
             replaceState(with: backupState.entries, loadedSessions: backupState.loadedSessions)
-            try? persistIndex(backupState.entries)
+            do {
+                try persistIndex(backupState.entries)
+            } catch {
+                logStorageFailure(
+                    "session_store_repair_failed",
+                    "Recovered from the backup index but could not re-persist the primary index; recovery will repeat on the next launch.",
+                    error: error
+                )
+            }
             lastLoadRecoveryEvent = TranscriptStoreRecoveryEvent(
                 source: .backup,
                 recoveredSessionCount: backupState.entries.count
@@ -190,7 +209,15 @@ final class TranscriptStore: ObservableObject {
         if let storedSessions = loadSessions(from: storageURL) {
             let normalizedStoredSessions = normalizedSessions(storedSessions)
             let entries = normalizedStoredSessions.map(SessionLibraryEntry.init(session:))
-            try? persist(normalizedStoredSessions)
+            do {
+                try persist(normalizedStoredSessions)
+            } catch {
+                logStorageFailure(
+                    "session_store_migration_failed",
+                    "Loaded legacy primary session history but could not migrate it to partitioned storage; migration will repeat on the next launch.",
+                    error: error
+                )
+            }
             replaceState(with: entries, loadedSessions: [])
             lastLoadRecoveryEvent = nil
             logger.info(
@@ -204,7 +231,15 @@ final class TranscriptStore: ObservableObject {
         if let backupSessions = loadSessions(from: backupStorageURL) {
             let normalizedBackupSessions = normalizedSessions(backupSessions)
             let entries = normalizedBackupSessions.map(SessionLibraryEntry.init(session:))
-            try? persist(normalizedBackupSessions)
+            do {
+                try persist(normalizedBackupSessions)
+            } catch {
+                logStorageFailure(
+                    "session_store_migration_failed",
+                    "Recovered legacy backup session history but could not migrate it to partitioned storage; migration will repeat on the next launch.",
+                    error: error
+                )
+            }
             replaceState(with: entries, loadedSessions: [])
             lastLoadRecoveryEvent = TranscriptStoreRecoveryEvent(
                 source: .backup,
@@ -290,7 +325,15 @@ final class TranscriptStore: ObservableObject {
 
             let normalizedStoredSessions = normalizedSessions(storedSessions)
             let entries = normalizedStoredSessions.map(SessionLibraryEntry.init(session:))
-            try? persistIndex(entries)
+            do {
+                try persistIndex(entries)
+            } catch {
+                logStorageFailure(
+                    "session_store_repair_failed",
+                    "Loaded partitioned session history but could not re-persist the index; recovery will repeat on the next launch.",
+                    error: error
+                )
+            }
             return (entries, [])
         } catch {
             logger.warning(
@@ -370,7 +413,31 @@ final class TranscriptStore: ObservableObject {
         let index = TranscriptStoreIndex(entries: normalizedEntries)
         let indexData = try encoder.encode(index)
         try indexData.write(to: indexURL, options: [.atomic])
-        try? indexData.write(to: backupIndexURL, options: [.atomic])
+        do {
+            try indexData.write(to: backupIndexURL, options: [.atomic])
+        } catch {
+            logStorageFailure(
+                "session_backup_index_write_failed",
+                "Wrote the primary session index but failed to write the backup index.",
+                error: error,
+                fileName: backupIndexURL.lastPathComponent
+            )
+        }
+    }
+
+    /// Logs a non-fatal storage failure (no PII beyond an optional file name) so
+    /// swallowed I/O errors are observable instead of silently dropped.
+    private func logStorageFailure(
+        _ event: String,
+        _ message: String,
+        error: Error,
+        fileName: String? = nil
+    ) {
+        var metadata: [String: String] = ["error": String(describing: type(of: error))]
+        if let fileName {
+            metadata["file_name"] = fileName
+        }
+        logger.warning(event, message, metadata: metadata)
     }
 
     private func persistSessionFile(for session: TranscriptSession) throws {
@@ -387,10 +454,18 @@ final class TranscriptStore: ObservableObject {
     }
 
     private func cleanupUnreferencedSessionFiles(retainedIDs: Set<UUID>) throws {
-        guard let fileURLs = try? fileManager.contentsOfDirectory(
-            at: sessionsDirectoryURL,
-            includingPropertiesForKeys: nil
-        ) else {
+        let fileURLs: [URL]
+        do {
+            fileURLs = try fileManager.contentsOfDirectory(
+                at: sessionsDirectoryURL,
+                includingPropertiesForKeys: nil
+            )
+        } catch {
+            logStorageFailure(
+                "session_cleanup_enumeration_failed",
+                "Could not enumerate the sessions directory to clean up unreferenced files.",
+                error: error
+            )
             return
         }
 
@@ -399,7 +474,16 @@ final class TranscriptStore: ObservableObject {
             guard let id = UUID(uuidString: rawID), !retainedIDs.contains(id) else {
                 continue
             }
-            try? fileManager.removeItem(at: fileURL)
+            do {
+                try fileManager.removeItem(at: fileURL)
+            } catch {
+                logStorageFailure(
+                    "session_orphan_delete_failed",
+                    "Failed to delete an unreferenced session file.",
+                    error: error,
+                    fileName: fileURL.lastPathComponent
+                )
+            }
         }
     }
 

--- a/Tests/BugNarratorTests/TranscriptStoreTests.swift
+++ b/Tests/BugNarratorTests/TranscriptStoreTests.swift
@@ -149,6 +149,34 @@ final class TranscriptStoreTests: XCTestCase {
         )
     }
 
+    func testTranscriptStoreStillSurfacesRecoveredSessionsWhenDurableRepairFails() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let storageURL = rootDirectoryURL.appendingPathComponent("sessions.json")
+        let backupURL = storageURL.deletingPathExtension().appendingPathExtension("backup.json")
+        let session = makeSampleTranscriptSession(index: 1)
+
+        try Data("not-json".utf8).write(to: storageURL, options: [.atomic])
+        try JSONEncoder().encode([session]).write(to: backupURL, options: [.atomic])
+
+        // Occupy the partitioned index path with a directory so the durable
+        // repair write during recovery fails. Previously this was swallowed with
+        // try?; now it is logged, but the recovered session must still be surfaced
+        // (not silently lost) for the rest of the run.
+        let indexURL = rootDirectoryURL.appendingPathComponent("sessions.index.json")
+        try FileManager.default.createDirectory(at: indexURL, withIntermediateDirectories: true)
+
+        let store = TranscriptStore(storageURL: storageURL)
+
+        XCTAssertEqual(store.libraryEntries.map(\.id), [session.id])
+        XCTAssertEqual(store.session(with: session.id), session)
+        XCTAssertEqual(
+            store.lastLoadRecoveryEvent,
+            TranscriptStoreRecoveryEvent(source: .backup, recoveredSessionCount: 1)
+        )
+    }
+
     func testTranscriptStoreReportsFailedRecoveryWhenPrimaryAndBackupAreCorrupt() throws {
         let rootDirectoryURL = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }


### PR DESCRIPTION
Closes #495.

## What
Index re-persist during backup recovery, legacy primary/backup migration, the backup-index write, session-file deletes, and orphan cleanup (incl. directory enumeration) all used `try?` and silently dropped failures. Replaces them with `do/catch` that logs a warning (no PII beyond an optional file name).

## Why / scope (per codex review on #495)
- The real risk is a **failed durable repair repeating recovery every launch** + unobservable orphan accumulation — not "invisible that run" (in-memory state is updated before the swallowed persist, so recovered sessions stay visible). Control flow is unchanged.
- Covers the codex-named extra sites: legacy migration persists (`:193`/`:207`) and the cleanup directory enumeration (`:390`).
- Benign already-absent deletes are skipped via an existence check rather than logged.

## Tests
- New `testTranscriptStoreStillSurfacesRecoveredSessionsWhenDurableRepairFails`: occupies the index path with a directory to force the repair write to fail, and asserts the recovered session is still surfaced.
- Full `BugNarratorTests` suite green locally (590 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)