### PR TITLE
fix: preserve the recording when a transcript has high-confidence quality findings (#466)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -368,6 +368,39 @@ final class AppState: ObservableObject {
             cleanupPendingRecordedAudio: {
                 recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
             },
+            preserveRecordedAudioForReview: { session in
+                // A low-quality transcript "succeeded" but is likely unusable;
+                // preserve the recording into the session assets dir so it can be
+                // re-transcribed. Only remove the pending temp after preservation
+                // succeeds; on failure keep it so the recording is never lost (#466).
+                guard let artifactsDirectoryURL = session.artifactsDirectoryURL,
+                      let recordedAudio = recordingSessionController.pendingRecordedAudioSnapshot else {
+                    return
+                }
+
+                let logger = DiagnosticsLogger(category: .transcription)
+                do {
+                    let preservedURL = try artifactsService.preserveRecordedAudio(
+                        recordedAudio,
+                        in: artifactsDirectoryURL
+                    )
+                    recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: settingsStore.debugMode)
+                    logger.info(
+                        "low_quality_recording_preserved",
+                        "Preserved the recording for a low-quality transcript so it can be re-transcribed.",
+                        metadata: [
+                            "session_id": session.id.uuidString,
+                            "file_name": preservedURL.lastPathComponent
+                        ]
+                    )
+                } catch {
+                    logger.error(
+                        "low_quality_recording_preserve_failed",
+                        (error as? AppError)?.userMessage ?? error.localizedDescription,
+                        metadata: ["session_id": session.id.uuidString]
+                    )
+                }
+            },
             showSavedSessionReveal: { session in
                 guard let artifactsDirectoryURL = session.artifactsDirectoryURL else {
                     return

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -312,6 +312,23 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
         !Self.normalizedTranscriptBody(from: transcript).isEmpty
     }
 
+    /// High-confidence transcript quality problems (repeated or boilerplate text)
+    /// that indicate the transcript is likely unusable even though transcription
+    /// "succeeded". When present, the original recording must be preserved so the
+    /// user can re-transcribe instead of silently losing the audio (#466). Minor
+    /// warnings (short transcript, abrupt ending, unexpected script) do not
+    /// warrant retaining the full recording.
+    var hasHighConfidenceQualityFindings: Bool {
+        transcriptQualityFindings.contains { finding in
+            switch finding.kind {
+            case .repeatedText, .boilerplateText:
+                return true
+            case .unexpectedLanguageScript, .abruptEnding, .shortTranscript:
+                return false
+            }
+        }
+    }
+
     func transcriptionRecoveryMessage(for provider: AIProvider) -> String? {
         transcriptionRetryMessage(for: provider)
     }

--- a/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
+++ b/Sources/BugNarrator/Services/PostTranscriptionPipelineController.swift
@@ -144,6 +144,7 @@ final class FinishedRecordingPostTranscriptionResultHandler {
     private let postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter
     private let autoCopyTranscript: () -> Bool
     private let cleanupPendingRecordedAudio: () -> Void
+    private let preserveRecordedAudioForReview: (TranscriptSession) -> Void
     private let showSavedSessionReveal: (TranscriptSession) -> Void
 
     init(
@@ -154,6 +155,7 @@ final class FinishedRecordingPostTranscriptionResultHandler {
         postTranscriptionFailurePresenter: PostTranscriptionFailurePresenter,
         autoCopyTranscript: @escaping () -> Bool,
         cleanupPendingRecordedAudio: @escaping () -> Void,
+        preserveRecordedAudioForReview: @escaping (TranscriptSession) -> Void = { _ in },
         showSavedSessionReveal: @escaping (TranscriptSession) -> Void = { _ in }
     ) {
         self.sessionLibrary = sessionLibrary
@@ -163,13 +165,21 @@ final class FinishedRecordingPostTranscriptionResultHandler {
         self.postTranscriptionFailurePresenter = postTranscriptionFailurePresenter
         self.autoCopyTranscript = autoCopyTranscript
         self.cleanupPendingRecordedAudio = cleanupPendingRecordedAudio
+        self.preserveRecordedAudioForReview = preserveRecordedAudioForReview
         self.showSavedSessionReveal = showSavedSessionReveal
     }
 
     func handle(_ result: PostTranscriptionPipelineResult) {
         switch result {
         case .success(let session):
-            cleanupPendingRecordedAudio()
+            // A "successful" transcript with high-confidence quality findings is
+            // likely unusable; preserve the recording for re-transcription instead
+            // of deleting it (#466).
+            if session.hasHighConfidenceQualityFindings {
+                preserveRecordedAudioForReview(session)
+            } else {
+                cleanupPendingRecordedAudio()
+            }
             recordingSessionController.endActivity()
             statusPresenter.presentSuccess()
             showSavedSessionReveal(session)
@@ -231,8 +241,12 @@ final class RetryPostTranscriptionResultHandler {
         context: PendingTranscriptionRetryContext
     ) {
         switch result {
-        case .success:
-            cleanupPreservedRetryAudio(for: context)
+        case .success(let session):
+            // If the retried transcript is still low-quality, keep the preserved
+            // recording (already in the session assets dir) for another retry (#466).
+            if !session.hasHighConfidenceQualityFindings {
+                cleanupPreservedRetryAudio(for: context)
+            }
             transcriptionRecovery.finishRetry()
             statusPresenter.presentTranscriptWindow()
             recordingSessionController.endActivity()

--- a/Sources/BugNarrator/Services/SessionArtifactsService.swift
+++ b/Sources/BugNarrator/Services/SessionArtifactsService.swift
@@ -108,3 +108,33 @@ struct SessionArtifactsService: SessionArtifactsManaging {
         return standardizedDirectoryURL.path.hasPrefix(standardizedRootURL.path + "/")
     }
 }
+
+extension SessionArtifactsManaging {
+    /// Copies a finished recording from its temp location into a session artifacts
+    /// directory and returns the durable URL, so a successful-but-low-quality
+    /// transcript session keeps its audio available for re-transcription (#466).
+    /// The source is left untouched; the caller decides when to delete the temp.
+    func preserveRecordedAudio(_ recordedAudio: RecordedAudio, in directoryURL: URL) throws -> URL {
+        let fileManager = FileManager.default
+        let destinationURL = makeRecordedAudioURL(in: directoryURL, sourceFileURL: recordedAudio.fileURL)
+
+        if recordedAudio.fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
+            if !fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            }
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.copyItem(at: recordedAudio.fileURL, to: destinationURL)
+        }
+
+        let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            try? fileManager.removeItem(at: destinationURL)
+            throw AppError.recordingFailure("The preserved audio file was empty.")
+        }
+
+        return destinationURL
+    }
+}

--- a/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/FinishedRecordingPostTranscriptionResultHandlerTests.swift
@@ -18,7 +18,37 @@ final class FinishedRecordingPostTranscriptionResultHandlerTests: XCTestCase {
         XCTAssertEqual(harness.presentationState.status.phase, .success)
         XCTAssertEqual(harness.presentationState.status.detail, "Session saved. Transcript copied to the clipboard.")
         XCTAssertEqual(harness.revealSpy.sessionIDs, [session.id])
+        XCTAssertTrue(harness.preserveSpy.sessionIDs.isEmpty)
         XCTAssertFalse(harness.transcriptWindowSpy.didShow)
+    }
+
+    func testSuccessWithHighConfidenceQualityFindingsPreservesRecordingInsteadOfDeleting() async throws {
+        let harness = try FinishedRecordingPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let recordedAudio = try harness.makeRecordedAudio()
+        harness.audioRecorder.stopResults = [.success(recordedAudio)]
+        _ = try await harness.recordingSessionController.stopRecording()
+
+        let session = TranscriptSession(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 60),
+            transcript: "same same same same",
+            duration: 60,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            transcriptQualityFindings: [
+                TranscriptQualityFinding(kind: .repeatedText, severity: .error, message: "Repeated text detected.")
+            ]
+        )
+
+        harness.handler.handle(.success(session))
+
+        // Preservation is routed and cleanup is skipped, so the recording survives.
+        XCTAssertEqual(harness.preserveSpy.sessionIDs, [session.id])
+        XCTAssertNotNil(harness.recordingSessionController.pendingRecordedAudioSnapshot)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recordedAudio.fileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .success)
     }
 
     func testPersistenceFailureStagesTranscriptClearsActiveRecordingAndPresentsFailure() async throws {
@@ -75,6 +105,7 @@ private final class FinishedRecordingPostTranscriptionResultHandlerHarness {
     let transcriptWindowSpy = TranscriptWindowSpy()
     let settingsWindowSpy = SettingsWindowSpy()
     let revealSpy = SavedSessionRevealSpy()
+    let preserveSpy = SavedSessionRevealSpy()
     let handler: FinishedRecordingPostTranscriptionResultHandler
 
     init(debugMode: Bool = false) throws {
@@ -144,6 +175,9 @@ private final class FinishedRecordingPostTranscriptionResultHandlerHarness {
             autoCopyTranscript: { true },
             cleanupPendingRecordedAudio: { [recordingSessionController] in
                 recordingSessionController.cleanupPendingRecordedAudioIfNeeded(debugMode: debugMode)
+            },
+            preserveRecordedAudioForReview: { [preserveSpy] session in
+                preserveSpy.sessionIDs.append(session.id)
             },
             showSavedSessionReveal: { [revealSpy] session in
                 revealSpy.sessionIDs.append(session.id)

--- a/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
+++ b/Tests/BugNarratorTests/RetryPostTranscriptionResultHandlerTests.swift
@@ -19,6 +19,34 @@ final class RetryPostTranscriptionResultHandlerTests: XCTestCase {
         XCTAssertEqual(harness.presentationState.status.detail, "Session saved. Transcript copied to the clipboard.")
     }
 
+    func testSuccessKeepsPreservedAudioWhenRetriedTranscriptStillHasQualityFindings() throws {
+        let harness = try RetryPostTranscriptionResultHandlerHarness()
+        defer { harness.cleanup() }
+        let context = try harness.makeRetryContext(index: 5)
+
+        XCTAssertTrue(harness.transcriptionRecovery.beginRetry(for: context.session.id))
+
+        let lowQualitySession = TranscriptSession(
+            id: context.session.id,
+            createdAt: context.session.createdAt,
+            transcript: "same same same same",
+            duration: 4,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            transcriptQualityFindings: [
+                TranscriptQualityFinding(kind: .boilerplateText, severity: .error, message: "Boilerplate text detected.")
+            ]
+        )
+
+        harness.handler.handle(.success(lowQualitySession), context: context)
+
+        XCTAssertNil(harness.transcriptionRecovery.retryingSessionID)
+        // The preserved recording is kept so the user can retry transcription again.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: context.audioFileURL.path))
+        XCTAssertEqual(harness.presentationState.status.phase, .success)
+    }
+
     func testSuccessKeepsPreservedAudioWhenDebugModeIsEnabled() throws {
         let harness = try RetryPostTranscriptionResultHandlerHarness(debugMode: true)
         defer { harness.cleanup() }

--- a/Tests/BugNarratorTests/SessionArtifactsServiceTests.swift
+++ b/Tests/BugNarratorTests/SessionArtifactsServiceTests.swift
@@ -22,6 +22,45 @@ final class SessionArtifactsServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalDirectoryURL.path))
     }
 
+    func testPreserveRecordedAudioCopiesIntoDirectoryAndLeavesSource() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let managedRootURL = rootDirectoryURL.appendingPathComponent("SessionAssets", isDirectory: true)
+        let sessionDirectoryURL = managedRootURL.appendingPathComponent("session", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDirectoryURL, withIntermediateDirectories: true)
+
+        let sourceURL = rootDirectoryURL.appendingPathComponent("temp-recording.m4a")
+        try Data("audio-bytes".utf8).write(to: sourceURL)
+        let recordedAudio = RecordedAudio(fileURL: sourceURL, duration: 12)
+
+        let service = SessionArtifactsService(rootDirectoryURL: managedRootURL)
+        let preservedURL = try service.preserveRecordedAudio(recordedAudio, in: sessionDirectoryURL)
+
+        XCTAssertEqual(preservedURL.deletingLastPathComponent().standardizedFileURL, sessionDirectoryURL.standardizedFileURL)
+        XCTAssertEqual(preservedURL.pathExtension, "m4a")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: preservedURL.path))
+        // Source is left untouched — the caller decides when to remove the temp.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourceURL.path))
+        XCTAssertEqual(try Data(contentsOf: preservedURL), Data("audio-bytes".utf8))
+    }
+
+    func testPreserveRecordedAudioRejectsEmptySource() throws {
+        let rootDirectoryURL = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let managedRootURL = rootDirectoryURL.appendingPathComponent("SessionAssets", isDirectory: true)
+        let sessionDirectoryURL = managedRootURL.appendingPathComponent("session", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDirectoryURL, withIntermediateDirectories: true)
+
+        let sourceURL = rootDirectoryURL.appendingPathComponent("empty.m4a")
+        try Data().write(to: sourceURL)
+        let recordedAudio = RecordedAudio(fileURL: sourceURL, duration: 0)
+
+        let service = SessionArtifactsService(rootDirectoryURL: managedRootURL)
+        XCTAssertThrowsError(try service.preserveRecordedAudio(recordedAudio, in: sessionDirectoryURL))
+    }
+
     func testMakeScreenshotURLSanitizesPrefix() throws {
         let rootDirectoryURL = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }


### PR DESCRIPTION
Closes #466.

## What
A transcript that "succeeded" but contains **repeated/boilerplate** text is likely unusable, yet the success path deleted the only recording — silent data loss with no way to re-transcribe (the exact 2026-06-24 repro in the issue).

Now, when a completed session has high-confidence quality findings:
- The **finished-recording** success handler preserves the recording into the session assets directory instead of deleting it.
- The **retry-success** handler keeps the already-preserved audio for another retry.
- The pending temp audio is only removed **after** preservation succeeds; on failure it is kept so the recording is never lost.

Minor warnings (short transcript, abrupt ending, unexpected script) still clean up as before.

## Design (per codex review on #466)
- Confirmed `qualityFindings` are carried into the successful session (`TranscriptionClient` → `TranscriptionSessionBuilder`), so gating in the `.success` branch is correct and not double-preserving.
- Codex's catch applied: the **retry-success** path (`RetryPostTranscriptionResultHandler`) had the same bug and is now covered.
- Trigger narrowed to `repeatedText`/`boilerplateText` via `TranscriptSession.hasHighConfidenceQualityFindings`.
- Preservation centralized as a `SessionArtifactsManaging` extension (no protocol/mocks churn).

## Tests
- Finished handler: success-with-findings preserves & skips cleanup (audio retained); clean success still deletes.
- Retry handler: still-low-quality retry keeps the preserved audio.
- `SessionArtifactsService.preserveRecordedAudio`: copies into the dir, leaves the source, rejects an empty source.
- Full `BugNarratorTests` suite green locally (594 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)