### PR TITLE
fix: remove HotkeyManager's Carbon event handler in deinit (#503)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */; };
 		E5C5391682011DD604C60825 /* AudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CB27F6773CD9753A00DB79 /* AudioRecorderTests.swift */; };
 		E7512039897A180D1EC9DF3D /* RecordingSessionDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */; };
+		E7F9190637C0AE98A0164B39 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */; };
 		E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */; };
 		EA159F21E891A76BE6A4E825 /* RecordingSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */; };
 		EB26330B3289473ED7361280 /* BugNarratorDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */; };
@@ -331,6 +332,7 @@
 		92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
 		97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporter.swift; sourceTree = "<group>"; };
+		98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		9AFA7A7FD4F1B6ACB5E3D70F /* AsyncTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimeoutTests.swift; sourceTree = "<group>"; };
 		9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 				FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */,
 				3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
+				98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */,
 				FCF1EE5E9EEE1A5D22F7A647 /* HotkeyShortcutTests.swift */,
 				E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */,
 				4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */,
@@ -847,6 +850,7 @@
 				58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */,
 				A6922E228A52ADAA89226ED4 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
+				E7F9190637C0AE98A0164B39 /* HotkeyManagerTests.swift in Sources */,
 				DA186645807A441A35F08A44 /* HotkeyShortcutTests.swift in Sources */,
 				09B048166CEEFA50BD278F7D /* IssueExportControllerTests.swift in Sources */,
 				58E53F2092F34D45456CE5DF /* IssueExtractionControllerTests.swift in Sources */,

--- a/Sources/BugNarrator/Services/HotkeyManager.swift
+++ b/Sources/BugNarrator/Services/HotkeyManager.swift
@@ -98,6 +98,7 @@ final class HotkeyManager: HotkeyManaging {
 
     deinit {
         unregisterAll()
+        removeEventHandler()
     }
 
     func register(shortcut: HotkeyShortcut, for action: HotkeyAction) {
@@ -139,6 +140,19 @@ final class HotkeyManager: HotkeyManaging {
         }
 
         UnregisterEventHotKey(hotKeyRef)
+    }
+
+    /// Removes the application-global Carbon event handler. Must be paired with
+    /// `installEventHandlerIfNeeded()`: the handler's `userData` is an unretained
+    /// pointer to `self`, so leaving it installed after deinit would let a global
+    /// hotkey fire the C callback against freed memory.
+    private func removeEventHandler() {
+        guard let eventHandler else {
+            return
+        }
+
+        RemoveEventHandler(eventHandler)
+        self.eventHandler = nil
     }
 
     private func installEventHandlerIfNeeded() {

--- a/Tests/BugNarratorTests/HotkeyManagerTests.swift
+++ b/Tests/BugNarratorTests/HotkeyManagerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import BugNarrator
+
+final class HotkeyManagerTests: XCTestCase {
+    func testInstallAndRemoveEventHandlerAcrossLifecyclesDoesNotCrash() {
+        // Each HotkeyManager installs an application-global Carbon event handler in
+        // init and must remove it in deinit. The handler's userData is an unretained
+        // pointer to the manager, so leaving it installed across deallocs would let a
+        // global hotkey fire against freed memory. Repeated create/dealloc cycles
+        // exercise the install/remove pairing.
+        for _ in 0..<5 {
+            autoreleasepool {
+                _ = HotkeyManager()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #503.

## What
`HotkeyManager` installed an application-global Carbon event handler in `init` but never removed it; `deinit` only unregistered the hot-key refs. The handler's `userData` is `Unmanaged.passUnretained(self)`, so if a manager is deallocated and a global hotkey later fires, the C callback dereferences freed memory.

Now `deinit` calls a new `removeEventHandler()` that `RemoveEventHandler(...)`s and clears the ref, pairing it with `installEventHandlerIfNeeded()`.

## Tests
- `HotkeyManagerTests.testInstallAndRemoveEventHandlerAcrossLifecyclesDoesNotCrash` exercises repeated create/dealloc cycles (the install/remove pairing).
- Full `BugNarratorTests` suite green locally (598 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)