### PR TITLE
fix: warn on plaintext-HTTP Jira base URL (email + API token exposure) (#504)

### DIFF
--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -722,6 +722,22 @@ final class SettingsStore: ObservableObject {
         openAIBaseURLValue.host
     }
 
+    /// Warning when the configured Jira base URL would send Basic-auth credentials
+    /// (email + API token) over plaintext HTTP to a remote host. Loopback/private/
+    /// `.local` HTTP and remote HTTPS return nil. Reuses the host classifier from
+    /// the AI base-URL guard (#472).
+    var jiraBaseURLPlaintextWarning: String? {
+        guard let url = jiraBaseURLValue,
+              url.scheme?.lowercased() == "http",
+              let host = url.host,
+              !Self.isLocalEndpointHost(host) else {
+            return nil
+        }
+        return "This Jira URL uses plaintext HTTP to a remote host (\(host)). "
+            + "Your email and API token would be sent unencrypted. Use https:// "
+            + "unless this is a trusted local server."
+    }
+
     var preferredModelValue: String {
         Self.normalizedTranscriptionModel(preferredModel, for: aiProvider)
     }

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -311,6 +311,14 @@ struct SettingsView: View {
                                 .accessibilityLabel("Jira Cloud URL")
                         }
 
+                        if let warning = settingsStore.jiraBaseURLPlaintextWarning {
+                            Label(warning, systemImage: "exclamationmark.triangle.fill")
+                                .font(.footnote)
+                                .foregroundStyle(.orange)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .accessibilityLabel("Insecure Jira endpoint warning")
+                        }
+
                         labeledField(title: "Email") {
                             TextField("you@example.com", text: $settingsStore.jiraEmail)
                                 .textFieldStyle(.roundedBorder)

--- a/Tests/BugNarratorTests/SettingsStoreTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTests.swift
@@ -386,6 +386,28 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertNotNil(SettingsStore.plaintextRemoteBaseURLWarning(from: "http://203.0.113.10:8080"))
     }
 
+    func testJiraBaseURLWarnsOnlyForPlaintextRemoteHost() {
+        let suiteName = "BugNarrator-JiraPlaintextTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = SettingsStore(defaults: defaults, keychainService: MockKeychainService())
+
+        for allowed in [
+            "https://acme.atlassian.net",   // remote HTTPS
+            "http://localhost:8080",         // loopback HTTP
+            "http://192.168.1.10",           // private network
+            "acme.atlassian.net",            // no scheme → defaults to https
+            ""
+        ] {
+            store.jiraBaseURL = allowed
+            XCTAssertNil(store.jiraBaseURLPlaintextWarning, "expected no warning for \(allowed)")
+        }
+
+        store.jiraBaseURL = "http://jira.example.com"
+        XCTAssertNotNil(store.jiraBaseURLPlaintextWarning)
+    }
+
     func testIsLocalEndpointHostClassification() {
         for local in ["localhost", "127.0.0.1", "10.1.2.3", "172.16.0.1", "172.31.255.1",
                       "192.168.0.1", "169.254.1.1", "myserver.local", "lmstudio", "::1"] {

--- a/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
+++ b/windows/src/BugNarrator.Windows.Services/Settings/WindowsAppSettings.cs
@@ -104,6 +104,29 @@ public sealed record WindowsAppSettings(
     public string? AiProviderBaseUrlSecurityWarning =>
         OpenAiCompatibleEndpoint.PlaintextRemoteWarning(AiProviderBaseUrl);
 
+    /// <summary>
+    /// Non-blocking warning when the Jira base URL would send Basic-auth
+    /// credentials (email + API token) over plaintext HTTP to a remote host.
+    /// Null for remote HTTPS and local HTTP. Mirrors the macOS app (#504).
+    /// </summary>
+    public string? JiraBaseUrlSecurityWarning
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(JiraBaseUrl)
+                || !Uri.TryCreate(JiraBaseUrl.Trim(), UriKind.Absolute, out var parsed)
+                || !string.Equals(parsed.Scheme, "http", StringComparison.OrdinalIgnoreCase)
+                || OpenAiCompatibleEndpoint.IsLocalEndpointHost(parsed.Host))
+            {
+                return null;
+            }
+
+            return $"This Jira URL uses plaintext HTTP to a remote host ({parsed.Host}). "
+                + "Your email and API token would be sent unencrypted. Use https:// "
+                + "unless this is a trusted local server.";
+        }
+    }
+
     public string? AiProviderCompatibilityIssue
     {
         get


### PR DESCRIPTION
Closes #504.

## What
Jira export uses HTTP **Basic auth** (`email:apiToken`), but the Jira base URL had no plaintext-HTTP warning like the AI base URL got in #472. A user pointed at a remote `http://` Jira host would send their email + token unencrypted.

- macOS: `SettingsStore.jiraBaseURLPlaintextWarning` reuses the existing `isLocalEndpointHost` classifier (loopback/private/`.local` HTTP and remote HTTPS are fine; remote plaintext HTTP warns), surfaced near the Jira URL field in Settings.
- Windows: `WindowsAppSettings.JiraBaseUrlSecurityWarning` mirrors it via `OpenAiCompatibleEndpoint.IsLocalEndpointHost`.

## Tests
- `testJiraBaseURLWarnsOnlyForPlaintextRemoteHost` (macOS).
- Full `BugNarratorTests` suite green locally (599 tests). Windows wrapper reuses the already-tested `IsLocalEndpointHost`; CodeQL C# analyzes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)