### PR TITLE
fix(windows): redact email addresses in diagnostics (#507)

### DIFF
--- a/windows/src/BugNarrator.Windows.Services/Diagnostics/SensitiveDataRedactor.cs
+++ b/windows/src/BugNarrator.Windows.Services/Diagnostics/SensitiveDataRedactor.cs
@@ -24,6 +24,11 @@ internal static partial class SensitiveDataRedactor
     [GeneratedRegex(@"\bgithub_pat_[A-Za-z0-9_]{20,}\b")]
     private static partial Regex GitHubFineGrainedTokenRegex();
 
+    // Redacts the local-part of an email address (PII — e.g. the Jira account
+    // email used for Basic auth) while keeping the domain for debuggability.
+    [GeneratedRegex(@"(?i)\b[A-Za-z0-9._%+\-]+@([A-Za-z0-9.\-]+\.[A-Za-z]{2,})\b")]
+    private static partial Regex EmailRegex();
+
     public static string Redact(string? value)
     {
         if (string.IsNullOrEmpty(value))
@@ -37,6 +42,7 @@ internal static partial class SensitiveDataRedactor
         redactedValue = OpenAiKeyRegex().Replace(redactedValue, RedactionToken);
         redactedValue = GitHubClassicTokenRegex().Replace(redactedValue, RedactionToken);
         redactedValue = GitHubFineGrainedTokenRegex().Replace(redactedValue, RedactionToken);
+        redactedValue = EmailRegex().Replace(redactedValue, $"{RedactionToken}@$1");
         return redactedValue;
     }
 }


### PR DESCRIPTION
Closes #507.

## What
`SensitiveDataRedactor` redacted tokens and auth headers but not email addresses. The Jira account email (used for Basic auth) is PII that can surface in config dumps / error messages outside the already-redacted `Authorization` header. Adds an email regex that redacts the local-part while keeping the domain for debuggability (`[REDACTED]@example.com`).

## Validation
The Services project needs the Windows-desktop SDK and the class is `internal`, so the logic was validated in an isolated `net8.0` run: email local-part redacted, domain kept, token redaction preserved, plain text unchanged (4/4). CodeQL C# analyzes the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)