### PR TITLE
fix: fail closed when the export receipt store is corrupt (#496)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */; };
 		09B048166CEEFA50BD278F7D /* IssueExportControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */; };
 		0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */; };
+		0D3E82C811F386795DBE5D82 /* ExportReceiptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
@@ -271,6 +272,7 @@
 		4DFCA03B8104C84F3B6BFDF1 /* IssueExtractionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionControllerTests.swift; sourceTree = "<group>"; };
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
 		51C800B9028E34058B3B1544 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
+		527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStoreTests.swift; sourceTree = "<group>"; };
 		52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
 		52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationStateTests.swift; sourceTree = "<group>"; };
 		54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureService.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 				40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */,
 				0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */,
 				FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */,
+				527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */,
 				3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */,
 				AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */,
 				98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */,
@@ -848,6 +851,7 @@
 				FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */,
 				C90F9957B3AC369A5CD49C26 /* ElapsedTimeFormatterTests.swift in Sources */,
 				58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */,
+				0D3E82C811F386795DBE5D82 /* ExportReceiptStoreTests.swift in Sources */,
 				A6922E228A52ADAA89226ED4 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */,
 				594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */,
 				E7F9190637C0AE98A0164B39 /* HotkeyManagerTests.swift in Sources */,

--- a/Sources/BugNarrator/Services/ExportReceiptStore.swift
+++ b/Sources/BugNarrator/Services/ExportReceiptStore.swift
@@ -31,8 +31,8 @@ struct ExportReceipt: Codable, Equatable {
 }
 
 protocol ExportReceiptStoring: Sendable {
-    func receipt(for fingerprint: String) async -> ExportReceipt?
-    func allReceipts() async -> [ExportReceipt]
+    func receipt(for fingerprint: String) async throws -> ExportReceipt?
+    func allReceipts() async throws -> [ExportReceipt]
     func markPending(
         fingerprint: String,
         sourceIssueID: UUID,
@@ -58,6 +58,7 @@ actor ExportReceiptStore: ExportReceiptStoring {
     private let storageURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    private let logger = DiagnosticsLogger(category: .export)
     private var cache: [String: ExportReceipt]?
 
     init(
@@ -69,12 +70,12 @@ actor ExportReceiptStore: ExportReceiptStoring {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     }
 
-    func receipt(for fingerprint: String) async -> ExportReceipt? {
-        await loadCacheIfNeeded()[fingerprint]
+    func receipt(for fingerprint: String) async throws -> ExportReceipt? {
+        try await loadCacheIfNeeded()[fingerprint]
     }
 
-    func allReceipts() async -> [ExportReceipt] {
-        await loadCacheIfNeeded()
+    func allReceipts() async throws -> [ExportReceipt] {
+        try await loadCacheIfNeeded()
             .values
             .sorted { $0.updatedAt > $1.updatedAt }
     }
@@ -85,7 +86,7 @@ actor ExportReceiptStore: ExportReceiptStoring {
         destination: ExportDestination,
         targetIdentity: String
     ) async throws {
-        var receipts = await loadCacheIfNeeded()
+        var receipts = try await loadCacheIfNeeded()
         receipts[fingerprint] = ExportReceipt(
             fingerprint: fingerprint,
             sourceIssueID: sourceIssueID,
@@ -107,7 +108,7 @@ actor ExportReceiptStore: ExportReceiptStoring {
         remoteIdentifier: String,
         remoteURL: URL?
     ) async throws {
-        var receipts = await loadCacheIfNeeded()
+        var receipts = try await loadCacheIfNeeded()
         receipts[fingerprint] = ExportReceipt(
             fingerprint: fingerprint,
             sourceIssueID: sourceIssueID,
@@ -122,12 +123,12 @@ actor ExportReceiptStore: ExportReceiptStoring {
     }
 
     func clearReceipt(for fingerprint: String) async throws {
-        var receipts = await loadCacheIfNeeded()
+        var receipts = try await loadCacheIfNeeded()
         receipts.removeValue(forKey: fingerprint)
         try await persist(receipts)
     }
 
-    private func loadCacheIfNeeded() async -> [String: ExportReceipt] {
+    private func loadCacheIfNeeded() async throws -> [String: ExportReceipt] {
         if let cache {
             return cache
         }
@@ -137,14 +138,58 @@ actor ExportReceiptStore: ExportReceiptStoring {
             return [:]
         }
 
+        // Fail closed on any read/decode failure. Treating a corrupt or unreadable
+        // receipt store as "no receipts" would forget prior successful exports and
+        // silently re-create duplicate issues, so we stop export instead and leave
+        // a clear, actionable error. We do NOT cache an empty dict here, so the
+        // store keeps failing closed until the file is repaired or cleared.
+        let data: Data
         do {
-            let data = try Data(contentsOf: storageURL)
+            data = try Data(contentsOf: storageURL)
+        } catch {
+            logger.error(
+                "export_receipt_store_unreadable",
+                "Could not read the export receipt store; exports are paused to avoid duplicate issues.",
+                metadata: ["error": String(describing: type(of: error))]
+            )
+            throw AppError.exportFailure(
+                "BugNarrator could not read its export history, so exports are paused to avoid creating duplicate issues. Try again, or clear local data in Settings if this persists."
+            )
+        }
+
+        do {
             let receipts = try decoder.decode([String: ExportReceipt].self, from: data)
             cache = receipts
             return receipts
         } catch {
-            cache = [:]
-            return [:]
+            backUpCorruptReceiptStore()
+            logger.error(
+                "export_receipt_store_corrupt",
+                "The export receipt store is corrupt; exports are paused to avoid duplicate issues.",
+                metadata: ["error": String(describing: type(of: error))]
+            )
+            throw AppError.exportFailure(
+                "BugNarrator's export history file is corrupt, so exports are paused to avoid creating duplicate issues. Clear local data in Settings to reset it."
+            )
+        }
+    }
+
+    /// Preserves the first corrupt snapshot for forensics without overwriting a
+    /// previously-captured one (copy only if absent).
+    private func backUpCorruptReceiptStore() {
+        let backupURL = storageURL.deletingLastPathComponent()
+            .appendingPathComponent("export-receipts.corrupt.json")
+        guard !fileManager.fileExists(atPath: backupURL.path) else {
+            return
+        }
+        do {
+            try fileManager.copyItem(at: storageURL, to: backupURL)
+        } catch {
+            logger.warning(
+                "export_receipt_backup_failed",
+                "Could not back up the corrupt export receipt store.",
+                metadata: ["error": String(describing: type(of: error))]
+            )
         }
     }
 

--- a/Sources/BugNarrator/Services/ExportService.swift
+++ b/Sources/BugNarrator/Services/ExportService.swift
@@ -104,7 +104,7 @@ actor ExportService: IssueExporting {
     }
 
     func exportHistory() async throws -> [ExportReceipt] {
-        await ExportReceiptStore().allReceipts()
+        try await ExportReceiptStore().allReceipts()
     }
 }
 

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -539,12 +539,12 @@ actor GitHubExportProvider {
         sourceIssueID: UUID,
         configuration: GitHubExportConfiguration
     ) async throws -> ExportResult? {
-        if let receipt = await receiptStore.receipt(for: fingerprint),
+        if let receipt = try await receiptStore.receipt(for: fingerprint),
            let exportResult = receipt.asExportResult() {
             return exportResult
         }
 
-        guard await receiptStore.receipt(for: fingerprint)?.state == .pending else {
+        guard try await receiptStore.receipt(for: fingerprint)?.state == .pending else {
             return nil
         }
 

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -641,12 +641,12 @@ actor JiraExportProvider {
         sourceIssueID: UUID,
         configuration: JiraExportConfiguration
     ) async throws -> ExportResult? {
-        if let receipt = await receiptStore.receipt(for: fingerprint),
+        if let receipt = try await receiptStore.receipt(for: fingerprint),
            let exportResult = receipt.asExportResult() {
             return exportResult
         }
 
-        guard let receipt = await receiptStore.receipt(for: fingerprint),
+        guard let receipt = try await receiptStore.receipt(for: fingerprint),
               receipt.state == .pending else {
             return nil
         }

--- a/Sources/BugNarrator/Services/PrivacyDataExporter.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExporter.swift
@@ -181,7 +181,8 @@ struct LocalPrivacyDataManager: @unchecked Sendable {
 
         let removableURLs = [
             appSupportURL.appendingPathComponent("RecoveredRecordings", isDirectory: true),
-            appSupportURL.appendingPathComponent("export-receipts.json", isDirectory: false)
+            appSupportURL.appendingPathComponent("export-receipts.json", isDirectory: false),
+            appSupportURL.appendingPathComponent("export-receipts.corrupt.json", isDirectory: false)
         ]
 
         for url in removableURLs where fileManager.fileExists(atPath: url.path) {

--- a/Tests/BugNarratorTests/ExportReceiptStoreTests.swift
+++ b/Tests/BugNarratorTests/ExportReceiptStoreTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+@testable import BugNarrator
+
+final class ExportReceiptStoreTests: XCTestCase {
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExportReceiptStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func testAbsentFileReturnsNoReceipts() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ExportReceiptStore(storageURL: dir.appendingPathComponent("export-receipts.json"))
+
+        let receipts = try await store.allReceipts()
+        XCTAssertTrue(receipts.isEmpty)
+    }
+
+    func testCorruptFileFailsClosedAndPreservesCorruptSnapshot() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storageURL = dir.appendingPathComponent("export-receipts.json")
+        try Data("{ this is not valid json".utf8).write(to: storageURL)
+
+        let store = ExportReceiptStore(storageURL: storageURL)
+
+        // Reads fail closed rather than reporting "no receipts" (which would let an
+        // already-exported issue be duplicated).
+        do {
+            _ = try await store.receipt(for: "bnexp-deadbeef")
+            XCTFail("Expected the corrupt store to fail closed")
+        } catch is AppError {
+            // expected
+        }
+
+        // The corrupt bytes are preserved for forensics, and the original is untouched.
+        let backupURL = dir.appendingPathComponent("export-receipts.corrupt.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backupURL.path))
+        XCTAssertEqual(try Data(contentsOf: backupURL), try Data(contentsOf: storageURL))
+    }
+
+    func testValidFileLoadsReceipts() async throws {
+        let dir = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storageURL = dir.appendingPathComponent("export-receipts.json")
+        let store = ExportReceiptStore(storageURL: storageURL)
+
+        try await store.markSucceeded(
+            fingerprint: "bnexp-1",
+            sourceIssueID: UUID(),
+            destination: .github,
+            targetIdentity: "acme/bugnarrator",
+            remoteIdentifier: "#1",
+            remoteURL: URL(string: "https://github.com/acme/bugnarrator/issues/1")
+        )
+
+        let reloaded = ExportReceiptStore(storageURL: storageURL)
+        let receipts = try await reloaded.allReceipts()
+        XCTAssertEqual(receipts.count, 1)
+        XCTAssertEqual(receipts.first?.remoteIdentifier, "#1")
+    }
+}

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -8,6 +8,58 @@ final class GitHubExportProviderTests: XCTestCase {
         super.tearDown()
     }
 
+    func testExportFailsClosedWithoutCreatingWhenReceiptStoreIsCorrupt() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let storageURL = directoryURL.appendingPathComponent("export-receipts.json")
+        try Data("{ corrupt receipts".utf8).write(to: storageURL)
+
+        MockURLProtocol.requestHandler = { request in
+            XCTFail("No remote request may be made when the receipt store is corrupt; method=\(request.httpMethod ?? "?")")
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let provider = GitHubExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: ExportReceiptStore(storageURL: storageURL)
+        )
+        let issue = ExtractedIssue(
+            title: "Checkout fails",
+            category: .bug,
+            summary: "Checkout button broken",
+            evidenceExcerpt: "Checkout never enabled.",
+            timestamp: nil
+        )
+        let session = TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+
+        do {
+            _ = try await provider.export(
+                issues: [issue],
+                session: session,
+                configuration: GitHubExportConfiguration(
+                    token: "fixture-github-token",
+                    owner: "acme",
+                    repository: "bugnarrator",
+                    labels: []
+                )
+            )
+            XCTFail("Expected a fail-closed export error")
+        } catch is AppError {
+            // expected — and no remote request was made (the handler would XCTFail)
+        }
+    }
+
     func testMakeURLRequestIncludesAuthorizationAndIssueBody() async throws {
         let provider = GitHubExportProvider(session: makeMockURLSession())
         let screenshotURL = makeScreenshotFileURL(named: "review-shot.png")

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -962,11 +962,11 @@ actor StubExportReceiptStore: ExportReceiptStoring {
         )
     }
 
-    func receipt(for fingerprint: String) async -> ExportReceipt? {
+    func receipt(for fingerprint: String) async throws -> ExportReceipt? {
         receipts[fingerprint]
     }
 
-    func allReceipts() async -> [ExportReceipt] {
+    func allReceipts() async throws -> [ExportReceipt] {
         Array(receipts.values)
     }
 


### PR DESCRIPTION
Closes #496.

## What
A corrupt/unreadable `export-receipts.json` was silently treated as "no receipts", so the store forgot prior successful exports and re-created **duplicate** GitHub/Jira issues. `ExportReceiptStore` now **fails closed** on any read or decode failure: it logs, non-destructively backs up the corrupt bytes (copy-only-if-absent), and throws — so export stops *before* `markPending` / any remote create rather than duplicating. `receipt(for:)`/`allReceipts` become throwing; all call sites updated. Local data deletion also removes the corrupt backup.

## Design (per codex review)
Codex's review flagged that an in-memory "degraded" flag is insufficient (multiple store instances; a future launch re-decodes the overwritten file as healthy). Fail-closed is the simplest fully-correct fix — no duplicate is possible because no remote create happens while the store is unreadable. The user clears it via Settings → local data.

## Tests
- `ExportReceiptStoreTests`: absent file ⇒ empty; corrupt file ⇒ throws + preserves the corrupt snapshot; valid file ⇒ loads.
- `GitHubExportProviderTests.testExportFailsClosedWithoutCreatingWhenReceiptStoreIsCorrupt`: the mock URL handler XCTFails on **any** request, proving no remote create.
- Full `BugNarratorTests` suite green locally (603 tests). **Codex reviewed the build: no findings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)