### PR TITLE
feat: add an explicit schemaVersion to persisted sessions (#506)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */; };
 		5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */; };
 		5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49B2B79731E3A62B083174 /* IssueExportController.swift */; };
+		5C17FA63D1493FA685263384 /* TranscriptSessionSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E500A980171E57FE562FBB7C /* TranscriptSessionSchemaTests.swift */; };
 		5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */; };
 		5CB8DACFD986D905D03D0E6A /* ChangelogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */; };
 		5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */; };
@@ -386,6 +387,7 @@
 		DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilderTests.swift; sourceTree = "<group>"; };
 		DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorApp.swift; sourceTree = "<group>"; };
 		E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
+		E500A980171E57FE562FBB7C /* TranscriptSessionSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSessionSchemaTests.swift; sourceTree = "<group>"; };
 		E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
 		E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
 		E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
@@ -497,6 +499,7 @@
 				EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */,
 				8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */,
 				58645DF704D4244897938E77 /* TranscriptSectionTests.swift */,
+				E500A980171E57FE562FBB7C /* TranscriptSessionSchemaTests.swift */,
 				BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */,
 				B3AE33EE76F55AE456924849 /* TransientToastControllerTests.swift */,
 				1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */,
@@ -898,6 +901,7 @@
 				D7D868701BE0B53E59DD6DFD /* TranscriptQualityFindingTests.swift in Sources */,
 				3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */,
 				A4E7DAB84ECCC217C655A67C /* TranscriptSectionTests.swift in Sources */,
+				5C17FA63D1493FA685263384 /* TranscriptSessionSchemaTests.swift in Sources */,
 				38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */,
 				0C27546CA8851DF57ECF8C6E /* TranscriptionClientTests.swift in Sources */,
 				3CE176593C0130AB6B4A12BA /* TranscriptionRecoveryControllerTests.swift in Sources */,

--- a/Sources/BugNarrator/Models/TranscriptSession.swift
+++ b/Sources/BugNarrator/Models/TranscriptSession.swift
@@ -162,6 +162,14 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
     var transcriptQualityFindings: [TranscriptQualityFinding]
     var recoveredSourceFileName: String?
     let artifactsDirectoryPath: String?
+    /// Persisted-format version. Absent in files written before this field
+    /// existed, which decode as `legacySchemaVersion`. A future required-field
+    /// change can branch on this to migrate old sessions instead of failing to
+    /// decode and silently dropping them.
+    let schemaVersion: Int
+
+    static let currentSchemaVersion = 1
+    static let legacySchemaVersion = 1
 
     init(
         id: UUID = UUID(),
@@ -179,8 +187,10 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
         transcriptQualityFindings: [TranscriptQualityFinding] = [],
         recoveredSourceFileName: String? = nil,
         updatedAt: Date? = nil,
-        artifactsDirectoryPath: String? = nil
+        artifactsDirectoryPath: String? = nil,
+        schemaVersion: Int = TranscriptSession.currentSchemaVersion
     ) {
+        self.schemaVersion = schemaVersion
         self.id = id
         self.createdAt = createdAt
         self.updatedAt = updatedAt ?? createdAt
@@ -201,6 +211,7 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? TranscriptSession.legacySchemaVersion
         let createdAt = try container.decode(Date.self, forKey: .createdAt)
 
         self.id = try container.decode(UUID.self, forKey: .id)
@@ -226,6 +237,7 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
 
     func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
         try container.encode(id, forKey: .id)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
@@ -261,6 +273,7 @@ struct TranscriptSession: SessionLibraryItem, Codable, Equatable {
         case transcriptQualityFindings
         case recoveredSourceFileName
         case artifactsDirectoryPath
+        case schemaVersion
     }
 
     var title: String {

--- a/Tests/BugNarratorTests/TranscriptSessionSchemaTests.swift
+++ b/Tests/BugNarratorTests/TranscriptSessionSchemaTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import XCTest
+@testable import BugNarrator
+
+final class TranscriptSessionSchemaTests: XCTestCase {
+    func testEncodesAndRoundTripsSchemaVersion() throws {
+        let session = TranscriptSession(
+            createdAt: Date(timeIntervalSince1970: 1),
+            transcript: "hello",
+            duration: 3,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil
+        )
+        XCTAssertEqual(session.schemaVersion, TranscriptSession.currentSchemaVersion)
+
+        let data = try JSONEncoder().encode(session)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["schemaVersion"] as? Int, TranscriptSession.currentSchemaVersion)
+
+        let decoded = try JSONDecoder().decode(TranscriptSession.self, from: data)
+        XCTAssertEqual(decoded.schemaVersion, TranscriptSession.currentSchemaVersion)
+        XCTAssertEqual(decoded, session)
+    }
+
+    func testLegacyJSONWithoutSchemaVersionDecodesAsLegacyVersion() throws {
+        // A session file written before the schemaVersion field existed.
+        let legacyJSON = """
+        {
+          "id": "\(UUID().uuidString)",
+          "createdAt": 0,
+          "updatedAt": 0,
+          "transcript": "legacy session",
+          "duration": 2,
+          "model": "whisper-1",
+          "markers": [],
+          "screenshots": [],
+          "sections": [],
+          "transcriptQualityFindings": []
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(TranscriptSession.self, from: Data(legacyJSON.utf8))
+        XCTAssertEqual(decoded.schemaVersion, TranscriptSession.legacySchemaVersion)
+        XCTAssertEqual(decoded.transcript, "legacy session")
+    }
+}


### PR DESCRIPTION
Closes #506.

## What
`TranscriptSession` had no schema version, so a future required-field change would fail to decode old session files and silently drop history. Adds a `schemaVersion` field — encoded always; absent in legacy files decodes as `legacySchemaVersion` — so a future migration can branch on it rather than losing sessions.

(The decode-failure log added in #495 already keeps an un-decodable file from being dropped without a trace; a heavier quarantine path was intentionally avoided here because it would orphan lightweight index entries.)

## Tests
- `TranscriptSessionSchemaTests`: encodes/round-trips the version; a legacy JSON without the field decodes as `legacySchemaVersion`.
- Full `BugNarratorTests` suite green locally (601 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)