### PR TITLE
perf: debounce DiagnosticsLogStore persistence instead of rewriting per log (#505)

### DIFF
--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -603,6 +603,8 @@ final class AppState: ObservableObject {
                 self?.refreshPermissionRecoveryState()
             },
             willTerminate: {
+                // Best-effort: flush any debounced diagnostics before quitting.
+                Task { await BugNarratorDiagnostics.store.flush() }
                 applicationTerminationController.prepareForApplicationTermination()
             }
         )

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -142,14 +142,18 @@ actor DiagnosticsLogStore {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let storageURL: URL
+    private let flushInterval: Duration
     private var entries: [DiagnosticsLogEntry]
+    private var isDirty = false
+    private var pendingFlushTask: Task<Void, Never>?
 
-    init(fileManager: FileManager = .default, storageURL: URL? = nil) {
+    init(fileManager: FileManager = .default, storageURL: URL? = nil, flushInterval: Duration = .seconds(1)) {
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
         self.fileManager = fileManager
         self.encoder = encoder
         self.decoder = decoder
+        self.flushInterval = flushInterval
         self.storageURL = storageURL ?? Self.defaultStorageURL(fileManager: fileManager)
         self.entries = Self.loadEntries(
             from: self.storageURL,
@@ -163,6 +167,45 @@ actor DiagnosticsLogStore {
         if entries.count > StoragePolicy.maximumStoredEntries {
             entries.removeFirst(entries.count - StoragePolicy.maximumStoredEntries)
         }
+        // Coalesce writes: rewriting the whole (up to 500-entry) file on every log
+        // line is wasteful under bursty logging. Mark dirty and persist on a
+        // debounce; flush() forces an immediate write for shutdown/export.
+        isDirty = true
+        scheduleFlush()
+    }
+
+    /// Persists immediately if there are unwritten entries. Call on app
+    /// background/terminate so recent logs survive a quit between debounce ticks.
+    func flush() {
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        if isDirty {
+            isDirty = false
+            persist()
+        }
+    }
+
+    private func scheduleFlush() {
+        guard pendingFlushTask == nil else {
+            return
+        }
+        pendingFlushTask = Task { [weak self, flushInterval] in
+            try? await Task.sleep(for: flushInterval)
+            // If flush()/clear() cancelled this task, do not run: a stale task
+            // could otherwise clobber a newer pending task scheduled meanwhile.
+            if Task.isCancelled {
+                return
+            }
+            await self?.flushPending()
+        }
+    }
+
+    private func flushPending() {
+        pendingFlushTask = nil
+        guard isDirty else {
+            return
+        }
+        isDirty = false
         persist()
     }
 
@@ -180,6 +223,9 @@ actor DiagnosticsLogStore {
     }
 
     func clear() {
+        pendingFlushTask?.cancel()
+        pendingFlushTask = nil
+        isDirty = false
         entries = []
         try? fileManager.removeItem(at: storageURL)
     }

--- a/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
+++ b/Tests/BugNarratorTests/DiagnosticsLoggerTests.swift
@@ -55,6 +55,31 @@ final class DiagnosticsLoggerTests: XCTestCase {
         BugNarratorDiagnostics.setDebugModeEnabled(false)
     }
 
+    func testRecordDebouncesPersistenceUntilFlush() async throws {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticsDebounce-\(UUID().uuidString)")
+            .appendingPathExtension("json")
+        defer { try? FileManager.default.removeItem(at: storageURL) }
+
+        // A long interval so the debounce timer never fires during the test: only
+        // flush() should write, proving record() no longer persists per entry.
+        let store = DiagnosticsLogStore(storageURL: storageURL, flushInterval: .seconds(1000))
+
+        await store.record(DiagnosticsLogEntry(level: .info, category: .settings, event: "a", message: "m"))
+        await store.record(DiagnosticsLogEntry(level: .info, category: .settings, event: "b", message: "m"))
+
+        // Two records produced zero writes (debounced) — the file does not exist yet.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storageURL.path))
+
+        await store.flush()
+
+        // flush() persisted the latest entries durably.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: storageURL.path))
+        let reloaded = DiagnosticsLogStore(storageURL: storageURL, flushInterval: .seconds(1000))
+        let events = await reloaded.recentEntries().map(\.event)
+        XCTAssertEqual(events, ["a", "b"])
+    }
+
     func testDebugLogsAreSuppressedUnlessDebugModeIsEnabled() async {
         let storageURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("DiagnosticsLoggerTests-\(UUID().uuidString)")


### PR DESCRIPTION
Closes #505.

## What
`DiagnosticsLogStore.record()` rewrote the whole (≤500-entry) log file on every log line — wasteful O(n) JSON encode + atomic write under bursty logging. Now `record()` marks the store dirty and schedules a **single debounced flush** (default 1s); `flush()` forces an immediate write (invoked best-effort on terminate). In-memory `recentEntries()` is unchanged, so log reads and the privacy export (which reads in-memory) are unaffected.

## Codex build review
Codex reviewed the build and caught a real race: the debounce task swallowed `CancellationError` and still ran, so a stale cancelled task could clobber a newer pending flush. Fixed by checking `Task.isCancelled` after the sleep.

## Tests
- `testRecordDebouncesPersistenceUntilFlush`: with a long interval, two records produce **zero** writes; `flush()` then persists durably (reloadable).
- Existing diagnostics tests (in-memory reads) unaffected. Full suite green locally (606 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)