### PR TITLE
fix: make GitHub/Jira issue export retries dup-safe (#502)

### DIFF
--- a/Sources/BugNarrator/Services/ExportService.swift
+++ b/Sources/BugNarrator/Services/ExportService.swift
@@ -182,6 +182,41 @@ enum TrackerExportSupport {
         }
         return " Wait a moment and try again."
     }
+
+    /// Whether an HTTP status warrants a retry (secondary rate limit / server error).
+    static func isTransientStatus(_ status: Int) -> Bool {
+        status == 429 || (500...599).contains(status)
+    }
+
+    /// Backoff before the next retry: honor `Retry-After` if present, else
+    /// exponential on the configured base (attempt is 1-based for the attempt
+    /// that just failed).
+    static func retryDelay(attempt: Int, retryAfterSeconds: Int?, base: Duration) -> Duration {
+        if let retryAfterSeconds, retryAfterSeconds > 0 {
+            return .seconds(retryAfterSeconds)
+        }
+        let multiplier = 1 << max(0, attempt - 1)
+        return base * multiplier
+    }
+}
+
+/// Bounds retry of a single per-issue tracker create. POST issue-creation is not
+/// blindly idempotent, so retries are only safe because the export loop reconciles
+/// by the `bugnarrator-export-id` marker before re-creating (#502).
+struct ExportRetryConfiguration: Sendable {
+    let maxAttempts: Int
+    let baseDelay: Duration
+
+    static let `default` = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .milliseconds(500))
+    /// No real backoff — for tests that simulate transient-then-success.
+    static let immediate = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .zero)
+}
+
+/// Outcome of a single create attempt, classified for the retry loop.
+enum ExportCreateOutcome {
+    case success(remoteIdentifier: String, remoteURL: URL?)
+    case transient(AppError, retryAfterSeconds: Int?)
+    case permanent(AppError)
 }
 
 actor SimilarIssueReviewService {

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -3,12 +3,14 @@ import Foundation
 actor GitHubExportProvider {
     private let session: URLSession
     private let receiptStore: any ExportReceiptStoring
+    private let retryConfiguration: ExportRetryConfiguration
     private let logger = DiagnosticsLogger(category: .export)
     private let annotationRenderer = IssueScreenshotAnnotationRenderer()
 
     init(
         session: URLSession? = nil,
-        receiptStore: any ExportReceiptStoring = ExportReceiptStore()
+        receiptStore: any ExportReceiptStoring = ExportReceiptStore(),
+        retryConfiguration: ExportRetryConfiguration = .default
     ) {
         if let session {
             self.session = session
@@ -19,6 +21,7 @@ actor GitHubExportProvider {
             self.session = URLSession(configuration: configuration)
         }
         self.receiptStore = receiptStore
+        self.retryConfiguration = retryConfiguration
     }
 
     func fetchRepositories(token: String) async throws -> [GitHubRepositoryOption] {
@@ -139,81 +142,14 @@ actor GitHubExportProvider {
                 exportFingerprint: fingerprint
             )
 
-            do {
-                let (data, response) = try await session.data(for: request)
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw AppError.exportFailure("GitHub returned an invalid response.")
-                }
-
-                guard (200...299).contains(httpResponse.statusCode) else {
-                    throw mapGitHubError(
-                        statusCode: httpResponse.statusCode,
-                        data: data,
-                        configuration: configuration,
-                        retryAfterSeconds: TrackerExportSupport.retryAfterSeconds(from: httpResponse)
-                    )
-                }
-
-                let payload = try JSONDecoder().decode(GitHubIssueResponse.self, from: data)
-                try await receiptStore.markSucceeded(
-                    fingerprint: fingerprint,
-                    sourceIssueID: issue.id,
-                    destination: .github,
-                    targetIdentity: configuration.targetIdentity,
-                    remoteIdentifier: "#\(payload.number)",
-                    remoteURL: payload.htmlURL
-                )
-                let result = ExportResult(
-                    sourceIssueID: issue.id,
-                    destination: .github,
-                    remoteIdentifier: "#\(payload.number)",
-                    remoteURL: payload.htmlURL
-                )
-                results.append(result)
-                logger.info(
-                    "github_issue_exported",
-                    "Exported one issue to GitHub.",
-                    metadata: [
-                        "source_issue_id": issue.id.uuidString,
-                        "remote_identifier": "#\(payload.number)"
-                    ]
-                )
-            } catch {
-                logger.error(
-                    "github_export_failed",
-                    (error as? AppError)?.userMessage ?? error.localizedDescription,
-                    metadata: [
-                        "successful_count": "\(results.count)",
-                        "source_issue_id": issue.id.uuidString
-                    ]
-                )
-                do {
-                    if let reconciledResult = try await reconcilePendingExport(
-                        fingerprint: fingerprint,
-                        sourceIssueID: issue.id,
-                        configuration: configuration
-                    ) {
-                        results.append(reconciledResult)
-                        continue
-                    }
-                } catch {
-                    logger.warning(
-                        "github_export_reconciliation_failed",
-                        (error as? AppError)?.userMessage ?? error.localizedDescription,
-                        metadata: ["source_issue_id": issue.id.uuidString]
-                    )
-                }
-
-                if error is AppError {
-                    try? await receiptStore.clearReceipt(for: fingerprint)
-                }
-                let mappedError = OpenAIErrorMapper.mapTransportError(error, fallback: AppError.exportFailure)
-                throw TrackerExportSupport.partialExportError(
-                    mappedError,
-                    providerName: "GitHub",
-                    successfulCount: results.count
-                )
-            }
+            let result = try await createWithRetry(
+                issue: issue,
+                fingerprint: fingerprint,
+                request: request,
+                configuration: configuration,
+                successfulCount: results.count
+            )
+            results.append(result)
         }
 
         logger.info(
@@ -532,6 +468,156 @@ actor GitHubExportProvider {
             lines.joined(separator: "\n"),
             maxCharacters: TrackerExportPayloadBudget.gitHubBodyLimit - footer.count
         ) + footer
+    }
+
+    /// Creates one issue with bounded retry. Transient failures (network / 5xx /
+    /// 429) are retried with backoff, but ONLY after a marker reconciliation
+    /// confirms the issue was not already created — so a created-but-unacked issue
+    /// is never duplicated. The pending receipt is kept across transient retries;
+    /// it is cleared only on a confirmed permanent failure.
+    private func createWithRetry(
+        issue: ExtractedIssue,
+        fingerprint: String,
+        request: URLRequest,
+        configuration: GitHubExportConfiguration,
+        successfulCount: Int
+    ) async throws -> ExportResult {
+        for attempt in 1...retryConfiguration.maxAttempts {
+            switch await attemptCreate(request, configuration: configuration) {
+            case .success(let remoteIdentifier, let remoteURL):
+                try await receiptStore.markSucceeded(
+                    fingerprint: fingerprint,
+                    sourceIssueID: issue.id,
+                    destination: .github,
+                    targetIdentity: configuration.targetIdentity,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+                logger.info(
+                    "github_issue_exported",
+                    "Exported one issue to GitHub.",
+                    metadata: ["source_issue_id": issue.id.uuidString, "remote_identifier": remoteIdentifier]
+                )
+                return ExportResult(
+                    sourceIssueID: issue.id,
+                    destination: .github,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+
+            case .transient(let createError, let retryAfterSeconds):
+                logger.error(
+                    "github_export_failed",
+                    createError.userMessage,
+                    metadata: [
+                        "source_issue_id": issue.id.uuidString,
+                        "attempt": "\(attempt)",
+                        "transient": "true"
+                    ]
+                )
+                // Did the issue actually get created despite the error? If the
+                // reconcile search itself fails we cannot verify, so we must NOT
+                // retry (which could duplicate) — abort and keep the pending
+                // receipt for a future reconcile.
+                do {
+                    if let reconciled = try await reconcilePendingExport(
+                        fingerprint: fingerprint,
+                        sourceIssueID: issue.id,
+                        configuration: configuration
+                    ) {
+                        return reconciled
+                    }
+                } catch {
+                    logger.warning(
+                        "github_export_reconciliation_failed",
+                        (error as? AppError)?.userMessage ?? error.localizedDescription,
+                        metadata: ["source_issue_id": issue.id.uuidString]
+                    )
+                    throw TrackerExportSupport.partialExportError(createError, providerName: "GitHub", successfulCount: successfulCount)
+                }
+
+                if attempt < retryConfiguration.maxAttempts {
+                    let delay = TrackerExportSupport.retryDelay(
+                        attempt: attempt,
+                        retryAfterSeconds: retryAfterSeconds,
+                        base: retryConfiguration.baseDelay
+                    )
+                    if delay > .zero {
+                        try? await Task.sleep(for: delay)
+                    }
+                    continue
+                }
+                // Retries exhausted — keep the pending receipt (do not clear).
+                throw TrackerExportSupport.partialExportError(createError, providerName: "GitHub", successfulCount: successfulCount)
+
+            case .permanent(let error):
+                logger.error(
+                    "github_export_failed",
+                    error.userMessage,
+                    metadata: ["source_issue_id": issue.id.uuidString, "transient": "false"]
+                )
+                if let reconciled = try? await reconcilePendingExport(
+                    fingerprint: fingerprint,
+                    sourceIssueID: issue.id,
+                    configuration: configuration
+                ) {
+                    return reconciled
+                }
+                // A permanent rejection means the issue was not created; clear the
+                // pending receipt so a corrected re-export can proceed cleanly.
+                try? await receiptStore.clearReceipt(for: fingerprint)
+                throw TrackerExportSupport.partialExportError(error, providerName: "GitHub", successfulCount: successfulCount)
+            }
+        }
+
+        // Unreachable (the loop returns or throws), but the compiler requires it.
+        throw TrackerExportSupport.partialExportError(
+            .exportFailure("GitHub export did not complete."),
+            providerName: "GitHub",
+            successfulCount: successfulCount
+        )
+    }
+
+    private func attemptCreate(
+        _ request: URLRequest,
+        configuration: GitHubExportConfiguration
+    ) async -> ExportCreateOutcome {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .permanent(.exportFailure("GitHub returned an invalid response."))
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let retryAfter = TrackerExportSupport.retryAfterSeconds(from: httpResponse)
+                let mapped = mapGitHubError(
+                    statusCode: httpResponse.statusCode,
+                    data: data,
+                    configuration: configuration,
+                    retryAfterSeconds: retryAfter
+                )
+                return TrackerExportSupport.isTransientStatus(httpResponse.statusCode)
+                    ? .transient(mapped, retryAfterSeconds: retryAfter)
+                    : .permanent(mapped)
+            }
+
+            do {
+                let payload = try JSONDecoder().decode(GitHubIssueResponse.self, from: data)
+                return .success(remoteIdentifier: "#\(payload.number)", remoteURL: payload.htmlURL)
+            } catch {
+                // A 2xx whose body we cannot read is a created-but-unacknowledged
+                // issue: GitHub accepted the create, but we could not parse the
+                // identifier. Treat it as ambiguous/transient — NOT permanent — so
+                // the pending receipt is preserved and reconciliation-by-marker
+                // resolves it, instead of clearing the receipt and risking a
+                // duplicate on a later export.
+                return .transient(.exportFailure("GitHub returned an unreadable response."), retryAfterSeconds: nil)
+            }
+        } catch {
+            // Network/transport failure — retryable.
+            let mapped = OpenAIErrorMapper.mapTransportError(error, fallback: AppError.exportFailure)
+            return .transient(mapped, retryAfterSeconds: nil)
+        }
     }
 
     private func existingExportResult(

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -3,12 +3,14 @@ import Foundation
 actor JiraExportProvider {
     private let session: URLSession
     private let receiptStore: any ExportReceiptStoring
+    private let retryConfiguration: ExportRetryConfiguration
     private let logger = DiagnosticsLogger(category: .export)
     private let annotationRenderer = IssueScreenshotAnnotationRenderer()
 
     init(
         session: URLSession? = nil,
-        receiptStore: any ExportReceiptStoring = ExportReceiptStore()
+        receiptStore: any ExportReceiptStoring = ExportReceiptStore(),
+        retryConfiguration: ExportRetryConfiguration = .default
     ) {
         if let session {
             self.session = session
@@ -19,6 +21,7 @@ actor JiraExportProvider {
             self.session = URLSession(configuration: configuration)
         }
         self.receiptStore = receiptStore
+        self.retryConfiguration = retryConfiguration
     }
 
     func export(
@@ -75,82 +78,14 @@ actor JiraExportProvider {
                 exportFingerprint: fingerprint
             )
 
-            do {
-                let (data, response) = try await session.data(for: request)
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw AppError.exportFailure("Jira returned an invalid response.")
-                }
-
-                guard (200...299).contains(httpResponse.statusCode) else {
-                    throw mapJiraError(
-                        statusCode: httpResponse.statusCode,
-                        data: data,
-                        configuration: configuration,
-                        retryAfterSeconds: TrackerExportSupport.retryAfterSeconds(from: httpResponse)
-                    )
-                }
-
-                let payload = try JSONDecoder().decode(JiraIssueResponse.self, from: data)
-                let remoteURL = configuration.baseURL.appending(path: "browse/\(payload.key)")
-                try await receiptStore.markSucceeded(
-                    fingerprint: fingerprint,
-                    sourceIssueID: issue.id,
-                    destination: .jira,
-                    targetIdentity: configuration.targetIdentity,
-                    remoteIdentifier: payload.key,
-                    remoteURL: remoteURL
-                )
-                let result = ExportResult(
-                    sourceIssueID: issue.id,
-                    destination: .jira,
-                    remoteIdentifier: payload.key,
-                    remoteURL: remoteURL
-                )
-                results.append(result)
-                logger.info(
-                    "jira_issue_exported",
-                    "Exported one issue to Jira.",
-                    metadata: [
-                        "source_issue_id": issue.id.uuidString,
-                        "remote_identifier": payload.key
-                    ]
-                )
-            } catch {
-                logger.error(
-                    "jira_export_failed",
-                    (error as? AppError)?.userMessage ?? error.localizedDescription,
-                    metadata: [
-                        "successful_count": "\(results.count)",
-                        "source_issue_id": issue.id.uuidString
-                    ]
-                )
-                do {
-                    if let reconciledResult = try await reconcilePendingExport(
-                        fingerprint: fingerprint,
-                        sourceIssueID: issue.id,
-                        configuration: configuration
-                    ) {
-                        results.append(reconciledResult)
-                        continue
-                    }
-                } catch {
-                    logger.warning(
-                        "jira_export_reconciliation_failed",
-                        (error as? AppError)?.userMessage ?? error.localizedDescription,
-                        metadata: ["source_issue_id": issue.id.uuidString]
-                    )
-                }
-
-                if error is AppError {
-                    try? await receiptStore.clearReceipt(for: fingerprint)
-                }
-                let mappedError = OpenAIErrorMapper.mapTransportError(error, fallback: AppError.exportFailure)
-                throw TrackerExportSupport.partialExportError(
-                    mappedError,
-                    providerName: "Jira",
-                    successfulCount: results.count
-                )
-            }
+            let result = try await createWithRetry(
+                issue: issue,
+                fingerprint: fingerprint,
+                request: request,
+                configuration: configuration,
+                successfulCount: results.count
+            )
+            results.append(result)
         }
 
         logger.info(
@@ -634,6 +569,148 @@ actor JiraExportProvider {
         }
         request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
         return request
+    }
+
+    /// Creates one issue with bounded retry. Transient failures (network / 5xx /
+    /// 429) are retried with backoff, but only after a marker reconciliation
+    /// confirms the issue was not already created — so a created-but-unacked issue
+    /// is never duplicated. The pending receipt is kept across transient retries;
+    /// cleared only on a confirmed permanent failure.
+    private func createWithRetry(
+        issue: ExtractedIssue,
+        fingerprint: String,
+        request: URLRequest,
+        configuration: JiraExportConfiguration,
+        successfulCount: Int
+    ) async throws -> ExportResult {
+        for attempt in 1...retryConfiguration.maxAttempts {
+            switch await attemptCreate(request, configuration: configuration) {
+            case .success(let remoteIdentifier, let remoteURL):
+                try await receiptStore.markSucceeded(
+                    fingerprint: fingerprint,
+                    sourceIssueID: issue.id,
+                    destination: .jira,
+                    targetIdentity: configuration.targetIdentity,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+                logger.info(
+                    "jira_issue_exported",
+                    "Exported one issue to Jira.",
+                    metadata: ["source_issue_id": issue.id.uuidString, "remote_identifier": remoteIdentifier]
+                )
+                return ExportResult(
+                    sourceIssueID: issue.id,
+                    destination: .jira,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+
+            case .transient(let createError, let retryAfterSeconds):
+                logger.error(
+                    "jira_export_failed",
+                    createError.userMessage,
+                    metadata: [
+                        "source_issue_id": issue.id.uuidString,
+                        "attempt": "\(attempt)",
+                        "transient": "true"
+                    ]
+                )
+                do {
+                    if let reconciled = try await reconcilePendingExport(
+                        fingerprint: fingerprint,
+                        sourceIssueID: issue.id,
+                        configuration: configuration
+                    ) {
+                        return reconciled
+                    }
+                } catch {
+                    logger.warning(
+                        "jira_export_reconciliation_failed",
+                        (error as? AppError)?.userMessage ?? error.localizedDescription,
+                        metadata: ["source_issue_id": issue.id.uuidString]
+                    )
+                    throw TrackerExportSupport.partialExportError(createError, providerName: "Jira", successfulCount: successfulCount)
+                }
+
+                if attempt < retryConfiguration.maxAttempts {
+                    let delay = TrackerExportSupport.retryDelay(
+                        attempt: attempt,
+                        retryAfterSeconds: retryAfterSeconds,
+                        base: retryConfiguration.baseDelay
+                    )
+                    if delay > .zero {
+                        try? await Task.sleep(for: delay)
+                    }
+                    continue
+                }
+                throw TrackerExportSupport.partialExportError(createError, providerName: "Jira", successfulCount: successfulCount)
+
+            case .permanent(let error):
+                logger.error(
+                    "jira_export_failed",
+                    error.userMessage,
+                    metadata: ["source_issue_id": issue.id.uuidString, "transient": "false"]
+                )
+                if let reconciled = try? await reconcilePendingExport(
+                    fingerprint: fingerprint,
+                    sourceIssueID: issue.id,
+                    configuration: configuration
+                ) {
+                    return reconciled
+                }
+                try? await receiptStore.clearReceipt(for: fingerprint)
+                throw TrackerExportSupport.partialExportError(error, providerName: "Jira", successfulCount: successfulCount)
+            }
+        }
+
+        throw TrackerExportSupport.partialExportError(
+            .exportFailure("Jira export did not complete."),
+            providerName: "Jira",
+            successfulCount: successfulCount
+        )
+    }
+
+    private func attemptCreate(
+        _ request: URLRequest,
+        configuration: JiraExportConfiguration
+    ) async -> ExportCreateOutcome {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .permanent(.exportFailure("Jira returned an invalid response."))
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                let retryAfter = TrackerExportSupport.retryAfterSeconds(from: httpResponse)
+                let mapped = mapJiraError(
+                    statusCode: httpResponse.statusCode,
+                    data: data,
+                    configuration: configuration,
+                    retryAfterSeconds: retryAfter
+                )
+                return TrackerExportSupport.isTransientStatus(httpResponse.statusCode)
+                    ? .transient(mapped, retryAfterSeconds: retryAfter)
+                    : .permanent(mapped)
+            }
+
+            do {
+                let payload = try JSONDecoder().decode(JiraIssueResponse.self, from: data)
+                let remoteURL = configuration.baseURL.appending(path: "browse/\(payload.key)")
+                return .success(remoteIdentifier: payload.key, remoteURL: remoteURL)
+            } catch {
+                // A 2xx whose body we cannot read is a created-but-unacknowledged
+                // issue: Jira accepted the create, but we could not parse the key.
+                // Treat it as ambiguous/transient — NOT permanent — so the pending
+                // receipt is preserved and reconciliation-by-marker resolves it,
+                // instead of clearing the receipt and risking a duplicate on a
+                // later export.
+                return .transient(.exportFailure("Jira returned an unreadable response."), retryAfterSeconds: nil)
+            }
+        } catch {
+            let mapped = OpenAIErrorMapper.mapTransportError(error, fallback: AppError.exportFailure)
+            return .transient(mapped, retryAfterSeconds: nil)
+        }
     }
 
     private func existingExportResult(

--- a/Tests/BugNarratorTests/GitHubExportProviderTests.swift
+++ b/Tests/BugNarratorTests/GitHubExportProviderTests.swift
@@ -615,6 +615,234 @@ final class GitHubExportProviderTests: XCTestCase {
         XCTAssertEqual(succeededCalls.count, 1)
         XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "#77")
     }
+
+    func testExportRetriesTransientFailureThenSucceedsWithExactlyOneCreate() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = GitHubExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        var postCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                if postCount == 1 {
+                    // First create attempt fails transiently (server error).
+                    let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 503, httpVersion: nil, headerFields: nil)!
+                    return (response, Data(#"{"message":"Service Unavailable"}"#.utf8))
+                }
+                // The retry create succeeds.
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"number":88,"html_url":"https://github.com/acme/bugnarrator/issues/88"}"#.utf8))
+            }
+
+            // Reconciliation search between attempts finds no existing issue, so a
+            // retry create is warranted.
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"items":[]}"#.utf8))
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.remoteIdentifier, "#88")
+        XCTAssertEqual(postCount, 2, "the transient failure should be retried exactly once")
+
+        // Exactly one issue was actually created and recorded as succeeded.
+        let succeededCalls = await receiptStore.markSucceededCalls
+        XCTAssertEqual(succeededCalls.count, 1)
+        XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "#88")
+    }
+
+    func testExportTransientFailureReconcilesCreatedIssueWithoutDuplicateCreate() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = GitHubExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        // The issue WAS created on the server, but the create response never
+        // reached us (transient transport/5xx). Reconciliation must locate it by
+        // marker and stop — never POST a duplicate.
+        let fingerprint = TrackerExportFingerprint.make(
+            destination: .github,
+            targetIdentity: configuration.targetIdentity,
+            sessionID: session.id,
+            issueID: issue.id
+        )
+        let marker = TrackerExportFingerprint.marker(for: fingerprint)
+
+        var postCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 503, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"message":"Service Unavailable"}"#.utf8))
+            }
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data(
+                #"{"items":[{"number":77,"title":"Created issue","body":"Tracked \#(marker)","html_url":"https://github.com/acme/bugnarrator/issues/77"}]}"#.utf8
+            )
+            return (response, data)
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.remoteIdentifier, "#77")
+        XCTAssertEqual(postCount, 1, "a created-but-unacked issue must not be duplicated by a retry create")
+
+        let succeededCalls = await receiptStore.markSucceededCalls
+        XCTAssertEqual(succeededCalls.count, 1)
+        XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "#77")
+    }
+
+    func testExportPermanentFailureFailsWithoutRetrying() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let provider = GitHubExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: StubExportReceiptStore(),
+            retryConfiguration: .immediate
+        )
+
+        var postCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 422, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"message":"Validation Failed"}"#.utf8))
+            }
+
+            // Any reconciliation search finds nothing.
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"items":[]}"#.utf8))
+        }
+
+        do {
+            _ = try await provider.export(issues: [issue], session: session, configuration: configuration)
+            XCTFail("Expected a permanent failure to surface.")
+        } catch let error as AppError {
+            guard case .exportFailure(let message) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("Validation Failed"))
+            XCTAssertEqual(postCount, 1, "a permanent (non-transient) failure must not be retried")
+        }
+    }
+
+    func testExportTreatsUnreadable2xxBodyAsAmbiguousAndReconcilesWithoutDuplicate() async throws {
+        // GitHub accepted the create (2xx) but the body is unreadable. This is a
+        // created-but-unacknowledged issue: it must be reconciled by marker, never
+        // re-created, and the pending receipt must not be cleared.
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = GitHubExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        let fingerprint = TrackerExportFingerprint.make(
+            destination: .github,
+            targetIdentity: configuration.targetIdentity,
+            sessionID: session.id,
+            issueID: issue.id
+        )
+        let marker = TrackerExportFingerprint.marker(for: fingerprint)
+
+        var postCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if request.httpMethod == "POST" {
+                postCount += 1
+                // 2xx with a body we cannot decode into a GitHubIssueResponse.
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!
+                return (response, Data("not json".utf8))
+            }
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data(
+                #"{"items":[{"number":91,"title":"Created issue","body":"Tracked \#(marker)","html_url":"https://github.com/acme/bugnarrator/issues/91"}]}"#.utf8
+            )
+            return (response, data)
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.first?.remoteIdentifier, "#91")
+        XCTAssertEqual(postCount, 1, "an unreadable 2xx body must not trigger a duplicate create")
+
+        // The pending receipt was reconciled to succeeded — not cleared.
+        let receipt = await receiptStore.receipts[fingerprint]
+        XCTAssertEqual(receipt?.state, .succeeded)
+        XCTAssertEqual(receipt?.remoteIdentifier, "#91")
+    }
+
+    func testRetryDelayHonorsRetryAfterAndOtherwiseBacksOffExponentially() {
+        // An explicit Retry-After wins over the configured backoff.
+        XCTAssertEqual(
+            TrackerExportSupport.retryDelay(attempt: 1, retryAfterSeconds: 30, base: .zero),
+            .seconds(30)
+        )
+        // Without Retry-After, the base delay doubles each attempt.
+        XCTAssertEqual(
+            TrackerExportSupport.retryDelay(attempt: 1, retryAfterSeconds: nil, base: .milliseconds(500)),
+            .milliseconds(500)
+        )
+        XCTAssertEqual(
+            TrackerExportSupport.retryDelay(attempt: 2, retryAfterSeconds: nil, base: .milliseconds(500)),
+            .milliseconds(1000)
+        )
+        XCTAssertEqual(
+            TrackerExportSupport.retryDelay(attempt: 3, retryAfterSeconds: nil, base: .milliseconds(500)),
+            .milliseconds(2000)
+        )
+    }
+
+    private func makeRetryFixtureIssue() -> ExtractedIssue {
+        ExtractedIssue(
+            title: "Retry fixture issue",
+            category: .bug,
+            summary: "Summary",
+            evidenceExcerpt: "Evidence",
+            timestamp: nil
+        )
+    }
+
+    private func makeRetryFixtureSession(issue: ExtractedIssue) -> TranscriptSession {
+        TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+    }
+
+    private func makeRetryFixtureConfiguration() -> GitHubExportConfiguration {
+        GitHubExportConfiguration(
+            token: "fixture-github-token",
+            owner: "acme",
+            repository: "bugnarrator",
+            labels: []
+        )
+    }
 }
 
 private struct GitHubIssueRequestPayload: Decodable {

--- a/Tests/BugNarratorTests/JiraExportProviderTests.swift
+++ b/Tests/BugNarratorTests/JiraExportProviderTests.swift
@@ -673,6 +673,213 @@ final class JiraExportProviderTests: XCTestCase {
             XCTAssertTrue(message.contains("Issue type is invalid"))
         }
     }
+
+    func testExportRetriesTransientFailureThenSucceedsWithExactlyOneCreate() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = JiraExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        var createCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if Self.isJiraCreateRequest(request) {
+                createCount += 1
+                if createCount == 1 {
+                    let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 503, httpVersion: nil, headerFields: nil)!
+                    return (response, Data(#"{"errorMessages":["Service Unavailable"]}"#.utf8))
+                }
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"id":"10001","key":"FM-88"}"#.utf8))
+            }
+
+            // Reconciliation JQL search finds no existing issue between attempts.
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"issues":[]}"#.utf8))
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.remoteIdentifier, "FM-88")
+        XCTAssertEqual(
+            results.first?.remoteURL,
+            URL(string: "https://acme.atlassian.net/browse/FM-88")
+        )
+        XCTAssertEqual(createCount, 2, "the transient failure should be retried exactly once")
+
+        let succeededCalls = await receiptStore.markSucceededCalls
+        XCTAssertEqual(succeededCalls.count, 1)
+        XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "FM-88")
+    }
+
+    func testExportTransientFailureReconcilesCreatedIssueWithoutDuplicateCreate() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = JiraExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        let fingerprint = TrackerExportFingerprint.make(
+            destination: .jira,
+            targetIdentity: configuration.targetIdentity,
+            sessionID: session.id,
+            issueID: issue.id
+        )
+        let marker = TrackerExportFingerprint.marker(for: fingerprint)
+
+        var createCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if Self.isJiraCreateRequest(request) {
+                createCount += 1
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 503, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"errorMessages":["Service Unavailable"]}"#.utf8))
+            }
+
+            // The issue was actually created; reconciliation locates it by marker.
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data(
+                #"{"issues":[{"key":"FM-77","fields":{"summary":"Created issue","description":{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Tracked \#(marker)"}]}]}}}]}"#.utf8
+            )
+            return (response, data)
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.remoteIdentifier, "FM-77")
+        XCTAssertEqual(createCount, 1, "a created-but-unacked issue must not be duplicated by a retry create")
+
+        let succeededCalls = await receiptStore.markSucceededCalls
+        XCTAssertEqual(succeededCalls.count, 1)
+        XCTAssertEqual(succeededCalls.first?.remoteIdentifier, "FM-77")
+    }
+
+    func testExportPermanentFailureFailsWithoutRetrying() async throws {
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let provider = JiraExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: StubExportReceiptStore(),
+            retryConfiguration: .immediate
+        )
+
+        var createCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if Self.isJiraCreateRequest(request) {
+                createCount += 1
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 400, httpVersion: nil, headerFields: nil)!
+                return (response, Data(#"{"errorMessages":["Issue type is invalid"],"errors":{}}"#.utf8))
+            }
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"issues":[]}"#.utf8))
+        }
+
+        do {
+            _ = try await provider.export(issues: [issue], session: session, configuration: configuration)
+            XCTFail("Expected a permanent failure to surface.")
+        } catch let error as AppError {
+            guard case .exportFailure(let message) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("Issue type is invalid"))
+            XCTAssertEqual(createCount, 1, "a permanent (non-transient) failure must not be retried")
+        }
+    }
+
+    func testExportTreatsUnreadable2xxBodyAsAmbiguousAndReconcilesWithoutDuplicate() async throws {
+        // Jira accepted the create (2xx) but the body is unreadable. This is a
+        // created-but-unacknowledged issue: it must be reconciled by marker, never
+        // re-created, and the pending receipt must not be cleared.
+        let issue = makeRetryFixtureIssue()
+        let session = makeRetryFixtureSession(issue: issue)
+        let configuration = makeRetryFixtureConfiguration()
+        let receiptStore = StubExportReceiptStore()
+        let provider = JiraExportProvider(
+            session: makeMockURLSession(),
+            receiptStore: receiptStore,
+            retryConfiguration: .immediate
+        )
+
+        let fingerprint = TrackerExportFingerprint.make(
+            destination: .jira,
+            targetIdentity: configuration.targetIdentity,
+            sessionID: session.id,
+            issueID: issue.id
+        )
+        let marker = TrackerExportFingerprint.marker(for: fingerprint)
+
+        var createCount = 0
+        MockURLProtocol.requestHandler = { request in
+            if Self.isJiraCreateRequest(request) {
+                createCount += 1
+                let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!
+                return (response, Data("not json".utf8))
+            }
+
+            let response = HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data(
+                #"{"issues":[{"key":"FM-91","fields":{"summary":"Created issue","description":{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Tracked \#(marker)"}]}]}}}]}"#.utf8
+            )
+            return (response, data)
+        }
+
+        let results = try await provider.export(issues: [issue], session: session, configuration: configuration)
+
+        XCTAssertEqual(results.first?.remoteIdentifier, "FM-91")
+        XCTAssertEqual(createCount, 1, "an unreadable 2xx body must not trigger a duplicate create")
+
+        let receipt = await receiptStore.receipts[fingerprint]
+        XCTAssertEqual(receipt?.state, .succeeded)
+        XCTAssertEqual(receipt?.remoteIdentifier, "FM-91")
+    }
+
+    private static func isJiraCreateRequest(_ request: URLRequest) -> Bool {
+        request.httpMethod == "POST" && request.url?.path == "/rest/api/3/issue"
+    }
+
+    private func makeRetryFixtureIssue() -> ExtractedIssue {
+        ExtractedIssue(
+            title: "Retry fixture issue",
+            category: .bug,
+            summary: "Summary",
+            evidenceExcerpt: "Evidence",
+            timestamp: nil
+        )
+    }
+
+    private func makeRetryFixtureSession(issue: ExtractedIssue) -> TranscriptSession {
+        TranscriptSession(
+            createdAt: Date(),
+            transcript: "Transcript",
+            duration: 6,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(summary: "Summary", issues: [issue])
+        )
+    }
+
+    private func makeRetryFixtureConfiguration() -> JiraExportConfiguration {
+        JiraExportConfiguration(
+            baseURL: URL(string: "https://acme.atlassian.net")!,
+            email: "you@example.com",
+            apiToken: "fixture-jira-token",
+            projectKey: "FM",
+            issueType: "Task"
+        )
+    }
 }
 
 private func makeScreenshotFileURL(named fileName: String) -> URL {


### PR DESCRIPTION
## Summary

Issue export to GitHub and Jira previously had no bounded retry: a transient network blip, a `429`, or a `5xx` would surface as a hard failure, and a *created-but-unacknowledged* issue (the server accepted the POST but the response never reached us) had no guard against being re-created on a later export. This change makes export retries **dup-safe**.

### What changed

- **Shared retry contract** in `TrackerExportSupport` / `ExportService`: `ExportRetryConfiguration`, `ExportCreateOutcome`, `isTransientStatus`, `retryDelay` (honors `Retry-After`, otherwise exponential backoff).
- Both providers route their per-issue create through a `createWithRetry` / `attemptCreate` pair:
  - **Transient** failures (transport errors, `429`, `5xx`) are retried — but **only after reconciliation-by-marker** confirms the issue was not already created, so a created-but-unacked issue is never duplicated.
  - The **pending receipt is preserved** across transient retries and cleared only on a confirmed **permanent** failure.
  - A **`2xx` with an unreadable body** is treated as ambiguous/transient (the create likely succeeded server-side), so the pending receipt survives and reconciliation resolves it — rather than clearing the receipt and risking a duplicate. *(Caught by codex review of the build.)*
  - **Permanent** (non-transient `4xx`) failures fail fast, no retry.
- GitHub and Jira kept at parity.

### Testing

- `xcodebuild ... test` — full suite green (622 tests, 0 failures).
- New retry/reconcile coverage on both provider suites: transient-then-success (exactly one create), created-but-unacked reconcile (no duplicate POST), permanent-no-retry, `retryDelay` backoff/Retry-After unit test, and the unreadable-`2xx` regression.

Reviewed by codex (subscription); the one finding (unreadable-`2xx` misclassified as permanent) is fixed here.

Closes #502