### PR TITLE
refactor: extract shared dup-safe export retry runner (#397)

### DIFF
--- a/Sources/BugNarrator/Services/ExportService.swift
+++ b/Sources/BugNarrator/Services/ExportService.swift
@@ -219,6 +219,136 @@ enum ExportCreateOutcome {
     case permanent(AppError)
 }
 
+/// The provider-specific naming the shared retry runner needs. Everything else
+/// in the retry state machine is identical across providers, so only the display
+/// name, destination, and the provider-prefixed log-event keys vary here.
+struct TrackerExportRetryContext: Sendable {
+    /// Human-facing provider name, e.g. "GitHub" / "Jira".
+    let displayName: String
+    let destination: ExportDestination
+    /// Log event emitted on a successful create, e.g. "github_issue_exported".
+    let exportedLogEvent: String
+    /// Log event emitted on a failed create attempt, e.g. "github_export_failed".
+    let failedLogEvent: String
+    /// Log event emitted when reconciliation itself fails, e.g.
+    /// "github_export_reconciliation_failed".
+    let reconciliationFailedLogEvent: String
+}
+
+extension TrackerExportSupport {
+    /// The shared, dup-safe create-with-retry state machine for tracker exports
+    /// (#502). The two providers ran byte-identical copies of this; it now lives
+    /// in one place so the dup-safety invariant is maintained once.
+    ///
+    /// Provider-specific work is injected:
+    /// - `attemptCreate` performs a single create POST and classifies the result
+    ///   as success / transient / permanent.
+    /// - `reconcile` searches for an already-created issue by its export marker.
+    ///
+    /// Invariant: a created-but-unacknowledged issue is never duplicated. On a
+    /// transient failure, reconciliation runs *before* any retry create; the
+    /// pending receipt is preserved across transient retries and cleared only on a
+    /// confirmed permanent failure.
+    ///
+    /// Runs in the *caller's* isolation domain (`isolation: #isolation`), so when
+    /// a provider actor delegates here the state machine stays on that actor — the
+    /// receipt transitions (`markPending` set by the caller, then `markSucceeded`
+    /// here) keep the exact ordering they had when this code lived inline in each
+    /// provider, with no new interleaving window.
+    static func runCreateWithRetry(
+        issueID: UUID,
+        fingerprint: String,
+        targetIdentity: String,
+        successfulCount: Int,
+        configuration retryConfiguration: ExportRetryConfiguration,
+        receiptStore: any ExportReceiptStoring,
+        logger: DiagnosticsLogger,
+        context: TrackerExportRetryContext,
+        isolation: isolated (any Actor)? = #isolation,
+        attemptCreate: () async -> ExportCreateOutcome,
+        reconcile: () async throws -> ExportResult?
+    ) async throws -> ExportResult {
+        for attempt in 1...retryConfiguration.maxAttempts {
+            switch await attemptCreate() {
+            case .success(let remoteIdentifier, let remoteURL):
+                try await receiptStore.markSucceeded(
+                    fingerprint: fingerprint,
+                    sourceIssueID: issueID,
+                    destination: context.destination,
+                    targetIdentity: targetIdentity,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+                logger.info(
+                    context.exportedLogEvent,
+                    "Exported one issue to \(context.displayName).",
+                    metadata: ["source_issue_id": issueID.uuidString, "remote_identifier": remoteIdentifier]
+                )
+                return ExportResult(
+                    sourceIssueID: issueID,
+                    destination: context.destination,
+                    remoteIdentifier: remoteIdentifier,
+                    remoteURL: remoteURL
+                )
+
+            case .transient(let createError, let retryAfterSeconds):
+                logger.error(
+                    context.failedLogEvent,
+                    createError.userMessage,
+                    metadata: [
+                        "source_issue_id": issueID.uuidString,
+                        "attempt": "\(attempt)",
+                        "transient": "true"
+                    ]
+                )
+                do {
+                    if let reconciled = try await reconcile() {
+                        return reconciled
+                    }
+                } catch {
+                    logger.warning(
+                        context.reconciliationFailedLogEvent,
+                        (error as? AppError)?.userMessage ?? error.localizedDescription,
+                        metadata: ["source_issue_id": issueID.uuidString]
+                    )
+                    throw partialExportError(createError, providerName: context.displayName, successfulCount: successfulCount)
+                }
+
+                if attempt < retryConfiguration.maxAttempts {
+                    let delay = retryDelay(
+                        attempt: attempt,
+                        retryAfterSeconds: retryAfterSeconds,
+                        base: retryConfiguration.baseDelay
+                    )
+                    if delay > .zero {
+                        try? await Task.sleep(for: delay)
+                    }
+                    continue
+                }
+                throw partialExportError(createError, providerName: context.displayName, successfulCount: successfulCount)
+
+            case .permanent(let error):
+                logger.error(
+                    context.failedLogEvent,
+                    error.userMessage,
+                    metadata: ["source_issue_id": issueID.uuidString, "transient": "false"]
+                )
+                if let reconciled = try? await reconcile() {
+                    return reconciled
+                }
+                try? await receiptStore.clearReceipt(for: fingerprint)
+                throw partialExportError(error, providerName: context.displayName, successfulCount: successfulCount)
+            }
+        }
+
+        throw partialExportError(
+            .exportFailure("\(context.displayName) export did not complete."),
+            providerName: context.displayName,
+            successfulCount: successfulCount
+        )
+    }
+}
+
 actor SimilarIssueReviewService {
     private let session: URLSession
 

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -475,6 +475,14 @@ actor GitHubExportProvider {
     /// confirms the issue was not already created — so a created-but-unacked issue
     /// is never duplicated. The pending receipt is kept across transient retries;
     /// it is cleared only on a confirmed permanent failure.
+    private static let retryContext = TrackerExportRetryContext(
+        displayName: "GitHub",
+        destination: .github,
+        exportedLogEvent: "github_issue_exported",
+        failedLogEvent: "github_export_failed",
+        reconciliationFailedLogEvent: "github_export_reconciliation_failed"
+    )
+
     private func createWithRetry(
         issue: ExtractedIssue,
         fingerprint: String,
@@ -482,99 +490,23 @@ actor GitHubExportProvider {
         configuration: GitHubExportConfiguration,
         successfulCount: Int
     ) async throws -> ExportResult {
-        for attempt in 1...retryConfiguration.maxAttempts {
-            switch await attemptCreate(request, configuration: configuration) {
-            case .success(let remoteIdentifier, let remoteURL):
-                try await receiptStore.markSucceeded(
-                    fingerprint: fingerprint,
-                    sourceIssueID: issue.id,
-                    destination: .github,
-                    targetIdentity: configuration.targetIdentity,
-                    remoteIdentifier: remoteIdentifier,
-                    remoteURL: remoteURL
-                )
-                logger.info(
-                    "github_issue_exported",
-                    "Exported one issue to GitHub.",
-                    metadata: ["source_issue_id": issue.id.uuidString, "remote_identifier": remoteIdentifier]
-                )
-                return ExportResult(
-                    sourceIssueID: issue.id,
-                    destination: .github,
-                    remoteIdentifier: remoteIdentifier,
-                    remoteURL: remoteURL
-                )
-
-            case .transient(let createError, let retryAfterSeconds):
-                logger.error(
-                    "github_export_failed",
-                    createError.userMessage,
-                    metadata: [
-                        "source_issue_id": issue.id.uuidString,
-                        "attempt": "\(attempt)",
-                        "transient": "true"
-                    ]
-                )
-                // Did the issue actually get created despite the error? If the
-                // reconcile search itself fails we cannot verify, so we must NOT
-                // retry (which could duplicate) — abort and keep the pending
-                // receipt for a future reconcile.
-                do {
-                    if let reconciled = try await reconcilePendingExport(
-                        fingerprint: fingerprint,
-                        sourceIssueID: issue.id,
-                        configuration: configuration
-                    ) {
-                        return reconciled
-                    }
-                } catch {
-                    logger.warning(
-                        "github_export_reconciliation_failed",
-                        (error as? AppError)?.userMessage ?? error.localizedDescription,
-                        metadata: ["source_issue_id": issue.id.uuidString]
-                    )
-                    throw TrackerExportSupport.partialExportError(createError, providerName: "GitHub", successfulCount: successfulCount)
-                }
-
-                if attempt < retryConfiguration.maxAttempts {
-                    let delay = TrackerExportSupport.retryDelay(
-                        attempt: attempt,
-                        retryAfterSeconds: retryAfterSeconds,
-                        base: retryConfiguration.baseDelay
-                    )
-                    if delay > .zero {
-                        try? await Task.sleep(for: delay)
-                    }
-                    continue
-                }
-                // Retries exhausted — keep the pending receipt (do not clear).
-                throw TrackerExportSupport.partialExportError(createError, providerName: "GitHub", successfulCount: successfulCount)
-
-            case .permanent(let error):
-                logger.error(
-                    "github_export_failed",
-                    error.userMessage,
-                    metadata: ["source_issue_id": issue.id.uuidString, "transient": "false"]
-                )
-                if let reconciled = try? await reconcilePendingExport(
+        try await TrackerExportSupport.runCreateWithRetry(
+            issueID: issue.id,
+            fingerprint: fingerprint,
+            targetIdentity: configuration.targetIdentity,
+            successfulCount: successfulCount,
+            configuration: retryConfiguration,
+            receiptStore: receiptStore,
+            logger: logger,
+            context: Self.retryContext,
+            attemptCreate: { await self.attemptCreate(request, configuration: configuration) },
+            reconcile: {
+                try await self.reconcilePendingExport(
                     fingerprint: fingerprint,
                     sourceIssueID: issue.id,
                     configuration: configuration
-                ) {
-                    return reconciled
-                }
-                // A permanent rejection means the issue was not created; clear the
-                // pending receipt so a corrected re-export can proceed cleanly.
-                try? await receiptStore.clearReceipt(for: fingerprint)
-                throw TrackerExportSupport.partialExportError(error, providerName: "GitHub", successfulCount: successfulCount)
+                )
             }
-        }
-
-        // Unreachable (the loop returns or throws), but the compiler requires it.
-        throw TrackerExportSupport.partialExportError(
-            .exportFailure("GitHub export did not complete."),
-            providerName: "GitHub",
-            successfulCount: successfulCount
         )
     }
 

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -576,6 +576,14 @@ actor JiraExportProvider {
     /// confirms the issue was not already created — so a created-but-unacked issue
     /// is never duplicated. The pending receipt is kept across transient retries;
     /// cleared only on a confirmed permanent failure.
+    private static let retryContext = TrackerExportRetryContext(
+        displayName: "Jira",
+        destination: .jira,
+        exportedLogEvent: "jira_issue_exported",
+        failedLogEvent: "jira_export_failed",
+        reconciliationFailedLogEvent: "jira_export_reconciliation_failed"
+    )
+
     private func createWithRetry(
         issue: ExtractedIssue,
         fingerprint: String,
@@ -583,91 +591,23 @@ actor JiraExportProvider {
         configuration: JiraExportConfiguration,
         successfulCount: Int
     ) async throws -> ExportResult {
-        for attempt in 1...retryConfiguration.maxAttempts {
-            switch await attemptCreate(request, configuration: configuration) {
-            case .success(let remoteIdentifier, let remoteURL):
-                try await receiptStore.markSucceeded(
-                    fingerprint: fingerprint,
-                    sourceIssueID: issue.id,
-                    destination: .jira,
-                    targetIdentity: configuration.targetIdentity,
-                    remoteIdentifier: remoteIdentifier,
-                    remoteURL: remoteURL
-                )
-                logger.info(
-                    "jira_issue_exported",
-                    "Exported one issue to Jira.",
-                    metadata: ["source_issue_id": issue.id.uuidString, "remote_identifier": remoteIdentifier]
-                )
-                return ExportResult(
-                    sourceIssueID: issue.id,
-                    destination: .jira,
-                    remoteIdentifier: remoteIdentifier,
-                    remoteURL: remoteURL
-                )
-
-            case .transient(let createError, let retryAfterSeconds):
-                logger.error(
-                    "jira_export_failed",
-                    createError.userMessage,
-                    metadata: [
-                        "source_issue_id": issue.id.uuidString,
-                        "attempt": "\(attempt)",
-                        "transient": "true"
-                    ]
-                )
-                do {
-                    if let reconciled = try await reconcilePendingExport(
-                        fingerprint: fingerprint,
-                        sourceIssueID: issue.id,
-                        configuration: configuration
-                    ) {
-                        return reconciled
-                    }
-                } catch {
-                    logger.warning(
-                        "jira_export_reconciliation_failed",
-                        (error as? AppError)?.userMessage ?? error.localizedDescription,
-                        metadata: ["source_issue_id": issue.id.uuidString]
-                    )
-                    throw TrackerExportSupport.partialExportError(createError, providerName: "Jira", successfulCount: successfulCount)
-                }
-
-                if attempt < retryConfiguration.maxAttempts {
-                    let delay = TrackerExportSupport.retryDelay(
-                        attempt: attempt,
-                        retryAfterSeconds: retryAfterSeconds,
-                        base: retryConfiguration.baseDelay
-                    )
-                    if delay > .zero {
-                        try? await Task.sleep(for: delay)
-                    }
-                    continue
-                }
-                throw TrackerExportSupport.partialExportError(createError, providerName: "Jira", successfulCount: successfulCount)
-
-            case .permanent(let error):
-                logger.error(
-                    "jira_export_failed",
-                    error.userMessage,
-                    metadata: ["source_issue_id": issue.id.uuidString, "transient": "false"]
-                )
-                if let reconciled = try? await reconcilePendingExport(
+        try await TrackerExportSupport.runCreateWithRetry(
+            issueID: issue.id,
+            fingerprint: fingerprint,
+            targetIdentity: configuration.targetIdentity,
+            successfulCount: successfulCount,
+            configuration: retryConfiguration,
+            receiptStore: receiptStore,
+            logger: logger,
+            context: Self.retryContext,
+            attemptCreate: { await self.attemptCreate(request, configuration: configuration) },
+            reconcile: {
+                try await self.reconcilePendingExport(
                     fingerprint: fingerprint,
                     sourceIssueID: issue.id,
                     configuration: configuration
-                ) {
-                    return reconciled
-                }
-                try? await receiptStore.clearReceipt(for: fingerprint)
-                throw TrackerExportSupport.partialExportError(error, providerName: "Jira", successfulCount: successfulCount)
+                )
             }
-        }
-
-        throw TrackerExportSupport.partialExportError(
-            .exportFailure("Jira export did not complete."),
-            providerName: "Jira",
-            successfulCount: successfulCount
         )
     }
 


### PR DESCRIPTION
## Summary

The dup-safe create-with-retry state machine introduced in #502 landed as **two byte-identical ~95-line copies** — one in `GitHubExportProvider`, one in `JiraExportProvider`. That is exactly the cross-provider duplication epic #397 tracks; its plan's slice 5 explicitly called for "#502 retry, once, in the coordinator".

This extracts that state machine into a single `TrackerExportSupport.runCreateWithRetry`. Each provider's `createWithRetry` now delegates to it, injecting the genuinely provider-specific seams as closures:

- `attemptCreate` — performs one create POST and classifies the outcome (success / transient / permanent)
- `reconcile` — searches for an already-created issue by its export marker

Provider-specific naming (display name, destination, the `github_*` / `jira_*` log-event keys) is carried in a small `TrackerExportRetryContext` value, so **every user-visible string and log key stays byte-identical per provider**.

### Concurrency

The runner takes `isolation: isolated (any Actor)? = #isolation`, so when a provider actor delegates in, the state machine **runs on that actor** — the receipt transitions (`markPending` → `markSucceeded`/`clearReceipt`) keep the exact ordering and interleaving behavior they had inline, with no new race window. *(This was caught and fixed during codex build review of the first cut, which used `@Sendable` closures on a nonisolated function.)*

### Why now (vs the epic's earlier "defer" note)

A prior comment recommended deferring the coordinator because there were only two conformers and the reconcile path had **no characterization test**. #502 changed both: the duplicated surface roughly doubled, and the retry/reconcile path now has full test coverage — so the ROI inverted. This also resolves the stale `ai/ready-for-execute` state the refinement comment flagged.

## Testing

- `xcodebuild ... test` — full suite green; `GitHubExportProviderTests` (20) and `JiraExportProviderTests` (20) pass **unchanged**, including the #502 retry / reconcile / unreadable-`2xx` regression coverage. No new Sendable/isolation warnings.
- Net ~170 duplicated lines removed from the two providers in favor of one shared implementation.

Reviewed by codex (subscription); its one finding (isolation of the extracted runner) is fixed here.

Closes #397