### PR TITLE
perf: stream privacy/support export instead of loading all sessions (#508)

### DIFF
--- a/Sources/BugNarrator/Services/PrivacyDataExporter.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExporter.swift
@@ -57,6 +57,30 @@ struct PrivacyDataExportDiagnosticsSnapshot: Codable, Equatable {
     let exportHistory: [ExportReceipt]
 }
 
+/// A lazy source of stored sessions for export. The exporter pulls sessions one
+/// at a time via `forEach`, so the whole library never has to be materialized in
+/// memory simultaneously (#508). `count` is the number of sessions `forEach` will
+/// yield, known up front from the lightweight library index.
+struct PrivacyDataSessionStream {
+    let count: Int
+    let forEach: (_ body: (TranscriptSession) throws -> Void) throws -> Void
+
+    /// Convenience for callers (and tests) that already hold a materialized array.
+    init(sessions: [TranscriptSession]) {
+        count = sessions.count
+        forEach = { body in
+            for session in sessions {
+                try body(session)
+            }
+        }
+    }
+
+    init(count: Int, forEach: @escaping (_ body: (TranscriptSession) throws -> Void) throws -> Void) {
+        self.count = count
+        self.forEach = forEach
+    }
+}
+
 struct PrivacyDataExporter {
     private let fileManager: FileManager
     private let bundleWriter: AtomicBundleDirectoryWriter
@@ -69,7 +93,7 @@ struct PrivacyDataExporter {
 
     @MainActor
     func export(
-        sessions: [TranscriptSession],
+        sessions: PrivacyDataSessionStream,
         settings: PrivacyDataExportSettingsSnapshot,
         diagnostics: PrivacyDataExportDiagnosticsSnapshot
     ) throws -> URL? {
@@ -93,8 +117,24 @@ struct PrivacyDataExporter {
         )
     }
 
+    /// Convenience overload for callers (and tests) that already hold a
+    /// materialized session array.
     func writeBundle(
         sessions: [TranscriptSession],
+        settings: PrivacyDataExportSettingsSnapshot,
+        diagnostics: PrivacyDataExportDiagnosticsSnapshot,
+        to destinationRoot: URL
+    ) throws -> URL {
+        try writeBundle(
+            sessions: PrivacyDataSessionStream(sessions: sessions),
+            settings: settings,
+            diagnostics: diagnostics,
+            to: destinationRoot
+        )
+    }
+
+    func writeBundle(
+        sessions: PrivacyDataSessionStream,
         settings: PrivacyDataExportSettingsSnapshot,
         diagnostics: PrivacyDataExportDiagnosticsSnapshot,
         to destinationRoot: URL
@@ -106,9 +146,19 @@ struct PrivacyDataExporter {
             in: destinationRoot,
             suggestedName: suggestedBundleName()
         ) { bundleDirectoryURL in
+            // Stream sessions first so the manifest's `sessionCount` reflects the
+            // number actually written. Sessions whose body can no longer be
+            // decoded are skipped, so this can be fewer than the library entry
+            // count — matching the pre-streaming behavior, where `allStored-
+            // Sessions()` had already filtered out undecodable bodies.
+            let writtenSessionCount = try writeSessionsArray(
+                sessions,
+                to: bundleDirectoryURL.appendingPathComponent("sessions.json")
+            )
+
             let manifest = PrivacyDataExportManifest(
                 generatedAt: Date(),
-                sessionCount: sessions.count,
+                sessionCount: writtenSessionCount,
                 includesSecrets: false,
                 exportedFiles: [
                     "manifest.json",
@@ -128,10 +178,6 @@ struct PrivacyDataExporter {
                 to: bundleDirectoryURL.appendingPathComponent("manifest.json"),
                 options: [.atomic]
             )
-            try encoder.encode(sessions).write(
-                to: bundleDirectoryURL.appendingPathComponent("sessions.json"),
-                options: [.atomic]
-            )
             try encoder.encode(settings).write(
                 to: bundleDirectoryURL.appendingPathComponent("settings.json"),
                 options: [.atomic]
@@ -141,6 +187,56 @@ struct PrivacyDataExporter {
                 options: [.atomic]
             )
         }
+    }
+
+    /// Streams the session array to `sessions.json` one element at a time so the
+    /// whole library is never encoded into a single in-memory buffer. The output
+    /// is byte-identical to `encoder.encode([TranscriptSession])` with the same
+    /// `[.prettyPrinted, .sortedKeys]` formatting — each element is encoded on its
+    /// own, re-indented one level, and joined exactly as the array encoder would.
+    /// Returns the number of sessions actually written.
+    @discardableResult
+    private func writeSessionsArray(_ sessions: PrivacyDataSessionStream, to url: URL) throws -> Int {
+        guard fileManager.createFile(atPath: url.path, contents: nil) else {
+            throw AppError.storageFailure("Could not create the sessions export file.")
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        var didThrow = false
+        defer {
+            if didThrow { try? fileManager.removeItem(at: url) }
+            try? handle.close()
+        }
+
+        do {
+            var index = 0
+            try sessions.forEach { session in
+                let elementData = try encoder.encode(session)
+                // First element follows `[\n`; subsequent elements follow `,\n`.
+                try handle.write(contentsOf: Data((index == 0 ? "[\n" : ",\n").utf8))
+                try handle.write(contentsOf: Self.indentedArrayElement(elementData))
+                index += 1
+            }
+            // Match JSONEncoder's pretty output: an empty array is `[\n\n]`;
+            // a non-empty one closes with `\n]`.
+            try handle.write(contentsOf: Data((index == 0 ? "[\n\n]" : "\n]").utf8))
+            return index
+        } catch {
+            didThrow = true
+            throw error
+        }
+    }
+
+    /// Re-indents a standalone pretty-printed JSON object by one level (two
+    /// spaces) so it matches how the array encoder nests each element. Genuinely
+    /// empty lines (which `JSONEncoder` emits inside empty containers) are left
+    /// unindented, exactly as the array encoder leaves them.
+    private static func indentedArrayElement(_ data: Data) -> Data {
+        let text = String(decoding: data, as: UTF8.self)
+        let indented = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.isEmpty ? "" : "  " + $0 }
+            .joined(separator: "\n")
+        return Data(indented.utf8)
     }
 
     private func suggestedBundleName() -> String {

--- a/Sources/BugNarrator/Services/ServiceProtocols.swift
+++ b/Sources/BugNarrator/Services/ServiceProtocols.swift
@@ -249,7 +249,7 @@ protocol DebugBundleExporting {
 @MainActor
 protocol PrivacyDataExporting {
     func export(
-        sessions: [TranscriptSession],
+        sessions: PrivacyDataSessionStream,
         settings: PrivacyDataExportSettingsSnapshot,
         diagnostics: PrivacyDataExportDiagnosticsSnapshot
     ) throws -> URL?

--- a/Sources/BugNarrator/Services/SupportDataController.swift
+++ b/Sources/BugNarrator/Services/SupportDataController.swift
@@ -222,7 +222,7 @@ final class SupportDataController {
         let diagnostics = await makePrivacyDataExportDiagnosticsSnapshot(
             exportHistoryFallback: exportHistoryFallback
         )
-        let sessions = transcriptStore.allStoredSessions()
+        let sessions = transcriptStore.privacyExportSessionStream()
 
         guard let bundleURL = try privacyDataExporter.export(
             sessions: sessions,

--- a/Sources/BugNarrator/Services/TranscriptStore.swift
+++ b/Sources/BugNarrator/Services/TranscriptStore.swift
@@ -171,6 +171,29 @@ final class TranscriptStore: ObservableObject {
         libraryEntries.compactMap { session(with: $0.id) }
     }
 
+    /// Streams every stored session for export, loading each body lazily and
+    /// WITHOUT populating the in-memory cache, so peak memory stays bounded by a
+    /// single session rather than the whole library (#508). Already-cached
+    /// sessions are reused as-is; uncached ones are read from disk, handed to
+    /// `body`, and released. Sessions whose body can no longer be decoded are
+    /// skipped, matching `allStoredSessions()`.
+    func forEachStoredSessionForExport(_ body: (TranscriptSession) throws -> Void) rethrows {
+        for entry in libraryEntries {
+            let session = sessionLookup[entry.id] ?? loadSessionFile(with: entry.id)
+            if let session {
+                try body(session)
+            }
+        }
+    }
+
+    /// A lazy export source over the stored sessions; see
+    /// `forEachStoredSessionForExport`.
+    func privacyExportSessionStream() -> PrivacyDataSessionStream {
+        PrivacyDataSessionStream(count: libraryEntries.count) { body in
+            try self.forEachStoredSessionForExport(body)
+        }
+    }
+
     private func load() {
         if let state = loadPartitionedState(from: indexURL) {
             replaceState(with: state.entries, loadedSessions: state.loadedSessions)

--- a/Tests/BugNarratorTests/PrivacyDataExporterTests.swift
+++ b/Tests/BugNarratorTests/PrivacyDataExporterTests.swift
@@ -72,6 +72,147 @@ final class PrivacyDataExporterTests: XCTestCase {
         XCTAssertFalse(combinedText.contains("apiKey"))
     }
 
+    func testStreamedSessionsJSONIsByteIdenticalToArrayEncoding() throws {
+        // The streaming writer must produce exactly the same bytes as encoding the
+        // whole array at once, for empty / single / multi-session libraries.
+        for sessionCount in [0, 1, 3] {
+            let sessions = (0..<sessionCount).map { makeSampleTranscriptSession(index: $0 + 1) }
+
+            let rootDirectoryURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("BugNarrator-PrivacyStreamTests-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+            let exportURL = try PrivacyDataExporter().writeBundle(
+                sessions: PrivacyDataSessionStream(
+                    count: sessions.count,
+                    forEach: { body in try sessions.forEach(body) }
+                ),
+                settings: Self.makeFixtureSettings(),
+                diagnostics: Self.makeFixtureDiagnostics(),
+                to: rootDirectoryURL
+            )
+            let streamedData = try Data(contentsOf: exportURL.appendingPathComponent("sessions.json"))
+
+            let referenceEncoder = JSONEncoder()
+            referenceEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            referenceEncoder.dateEncodingStrategy = .iso8601
+            let referenceData = try referenceEncoder.encode(sessions)
+
+            XCTAssertEqual(
+                streamedData,
+                referenceData,
+                "Streamed sessions.json for \(sessionCount) session(s) must be byte-identical to the array encoding."
+            )
+        }
+    }
+
+    func testWriteBundlePullsSessionsLazilyOneAtATime() throws {
+        // The exporter must request sessions through the stream (not a prebuilt
+        // array), and the round-trip must decode back to the same sessions.
+        let sessions = (0..<4).map { makeSampleTranscriptSession(index: $0 + 1) }
+        var maxConcurrentlyHeld = 0
+        var liveCount = 0
+
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BugNarrator-PrivacyLazyTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let stream = PrivacyDataSessionStream(count: sessions.count) { body in
+            for session in sessions {
+                liveCount += 1
+                maxConcurrentlyHeld = max(maxConcurrentlyHeld, liveCount)
+                try body(session)
+                // The exporter encodes + writes the element before pulling the
+                // next, so each yielded session is released before the next is
+                // requested.
+                liveCount -= 1
+            }
+        }
+
+        let exportURL = try PrivacyDataExporter().writeBundle(
+            sessions: stream,
+            settings: Self.makeFixtureSettings(),
+            diagnostics: Self.makeFixtureDiagnostics(),
+            to: rootDirectoryURL
+        )
+
+        XCTAssertEqual(maxConcurrentlyHeld, 1, "The exporter must consume one session at a time, not buffer the library.")
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let written = try decoder.decode(
+            [TranscriptSession].self,
+            from: Data(contentsOf: exportURL.appendingPathComponent("sessions.json"))
+        )
+        XCTAssertEqual(written, sessions)
+    }
+
+    func testManifestSessionCountMatchesSessionsActuallyWrittenWhenStreamSkipsBodies() throws {
+        // A library entry whose body cannot be decoded is skipped by the stream,
+        // so `count` (library entries) overstates what lands in sessions.json. The
+        // manifest must report the number actually written, keeping it consistent
+        // with sessions.json — as it was before streaming.
+        let writable = [makeSampleTranscriptSession(index: 1), makeSampleTranscriptSession(index: 2)]
+        let stream = PrivacyDataSessionStream(count: 3) { body in
+            for session in writable {
+                try body(session)
+            }
+            // The 3rd entry is "corrupt" and never yielded.
+        }
+
+        let rootDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BugNarrator-PrivacyManifestTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDirectoryURL) }
+
+        let exportURL = try PrivacyDataExporter().writeBundle(
+            sessions: stream,
+            settings: Self.makeFixtureSettings(),
+            diagnostics: Self.makeFixtureDiagnostics(),
+            to: rootDirectoryURL
+        )
+
+        let manifest = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: exportURL.appendingPathComponent("manifest.json"))
+        ) as? [String: Any]
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let writtenSessions = try decoder.decode(
+            [TranscriptSession].self,
+            from: Data(contentsOf: exportURL.appendingPathComponent("sessions.json"))
+        )
+
+        XCTAssertEqual(writtenSessions, writable)
+        XCTAssertEqual(manifest?["sessionCount"] as? Int, writable.count)
+    }
+
+    private static func makeFixtureSettings() -> PrivacyDataExportSettingsSnapshot {
+        let settingsStore = SettingsStore(
+            defaults: UserDefaults(suiteName: "BugNarrator-PrivacyFixture-\(UUID().uuidString)") ?? .standard,
+            keychainService: MockKeychainService(),
+            launchAtLoginService: MockLaunchAtLoginService()
+        )
+        return PrivacyDataExportSettingsSnapshot(settingsStore: settingsStore)
+    }
+
+    private static func makeFixtureDiagnostics() -> PrivacyDataExportDiagnosticsSnapshot {
+        PrivacyDataExportDiagnosticsSnapshot(
+            appName: "BugNarrator",
+            versionDescription: "1.0.0 (1)",
+            macOSVersion: "macOS Test",
+            architecture: "arm64",
+            activeTranscriptionModel: "whisper-1",
+            issueExtractionModel: "gpt-4.1-mini",
+            logLevel: "info",
+            debugModeEnabled: false,
+            recentTelemetryEvents: [],
+            recentDiagnosticsLog: "",
+            exportHistory: []
+        )
+    }
+
     func testLocalPrivacyDataManagerClearsDiagnosticsTelemetryAndSupportFiles() async throws {
         let rootDirectoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("BugNarrator-LocalPrivacyDataManagerTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/BugNarratorTests/TestSupport.swift
+++ b/Tests/BugNarratorTests/TestSupport.swift
@@ -594,13 +594,17 @@ final class MockPrivacyDataExporter: PrivacyDataExporting {
     private(set) var exportRequests: [ExportRequest] = []
 
     func export(
-        sessions: [TranscriptSession],
+        sessions: PrivacyDataSessionStream,
         settings: PrivacyDataExportSettingsSnapshot,
         diagnostics: PrivacyDataExportDiagnosticsSnapshot
     ) throws -> URL? {
+        // Materialize the lazy stream so existing assertions on the requested
+        // sessions keep working.
+        var materialized: [TranscriptSession] = []
+        try sessions.forEach { materialized.append($0) }
         exportRequests.append(
             ExportRequest(
-                sessions: sessions,
+                sessions: materialized,
                 settings: settings,
                 diagnostics: diagnostics
             )


### PR DESCRIPTION
## Summary

The privacy/support data export materialized the **entire session library in memory twice**: `TranscriptStore.allStoredSessions()` loaded every session body up front, and `encoder.encode(sessions)` then built one JSON buffer holding all of them. For a large library (hundreds of long sessions — e.g. the 40-minute sessions from #466) that is a large simultaneous allocation that grows with library size.

This streams the export so **peak memory is bounded by a single session**:

- `TranscriptStore.forEachStoredSessionForExport` loads each body lazily and, crucially, does **not** populate the in-memory cache — so the export no longer forces the whole library resident. Order and skip-on-decode-failure match `allStoredSessions()`.
- `PrivacyDataExporter` writes `sessions.json` **incrementally via a `FileHandle`**, encoding one element at a time. The output is **byte-identical** to `encoder.encode([TranscriptSession])` with the same `[.prettyPrinted, .sortedKeys]` formatting (each element re-indented one level; empty arrays and empty nested containers reproduced exactly).
- The export protocol now takes a lazy `PrivacyDataSessionStream` instead of a materialized array; a convenience array overload is kept for existing callers/tests.
- `manifest.sessionCount` is taken from the number of sessions **actually written** (not the library entry count), so it stays consistent with `sessions.json` when a corrupt body is skipped — preserving the prior invariant. *(Caught in codex build review.)*

## Acceptance criteria

- [x] Export does not require all session bodies in memory simultaneously (non-caching lazy source + incremental write).
- [x] Bundle content is unchanged — byte-identical `sessions.json` (test asserts equality vs the array encoding for 0/1/3 sessions).
- [x] Peak memory bounded regardless of library size (test asserts one-at-a-time consumption).

## Testing

`xcodebuild ... test` (BugNarratorTests) green. New coverage: byte-identical streamed output (0/1/3 sessions), lazy one-at-a-time consumption, manifest/sessions.json count consistency when the stream skips a body; plus existing round-trip / no-secrets coverage. The one UI-test blip during a full run (`testSessionLibraryDialogCoversIssueEditingAndExportActions`, a text-field hittability flake unrelated to this path) passed on isolated re-run.

Reviewed by codex (subscription); its one finding (manifest count vs written count) is fixed here.

Closes #508