### PR TITLE
refactor: extract Diagnostics & Privacy settings pane to its own view (#523, #355)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		33D0E3F65FCAE14DBC117B40 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */; };
 		33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800BFCC6407B534886C65D77 /* TranscriptionClient.swift */; };
 		3426E7C93FFCC254F7016A99 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F03E1852A3D56F888E98739E /* Assets.xcassets */; };
+		3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */; };
 		3893EB325B3915242FBD4BA6 /* ServiceProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */; };
 		38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */; };
 		3B4F5CCC16AB9837DD0BD0F4 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277DC17D4084F918920CB8C5 /* URLHandler.swift */; };
@@ -118,6 +119,7 @@
 		8896B923DAB4B25053694061 /* SessionLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67770387C5BA986EEB40382E /* SessionLibraryTests.swift */; };
 		8CF257839BEA4B0681BEA508 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */; };
 		8E0DE1B3EABFCECD46EF5ED0 /* SessionDataProtectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */; };
+		8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */; };
 		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
 		8F4B3823ACB48DDF270E2BAE /* AppStateIssueExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */; };
@@ -335,6 +337,7 @@
 		8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioUploadPolicy.swift; sourceTree = "<group>"; };
 		8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotAnnotationTests.swift; sourceTree = "<group>"; };
 		8B9EE251C9CCE29EDED45889 /* IssueExtractionResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionResponseParserTests.swift; sourceTree = "<group>"; };
+		8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewComponents.swift; sourceTree = "<group>"; };
 		8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilderTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProductInfoView.swift; sourceTree = "<group>"; };
@@ -385,6 +388,7 @@
 		D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionController.swift; sourceTree = "<group>"; };
 		D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataProtectorTests.swift; sourceTree = "<group>"; };
 		D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorderTests.swift; sourceTree = "<group>"; };
+		D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDiagnosticsPrivacyPane.swift; sourceTree = "<group>"; };
 		D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorLinks.swift; sourceTree = "<group>"; };
 		D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalTelemetryRecorderTests.swift; sourceTree = "<group>"; };
 		D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
@@ -425,6 +429,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		05B6FECAF7F08D43DE50EBA0 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */,
+				8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		1EFE1C893B3A928C8554689D = {
 			isa = PBXGroup;
 			children = (
@@ -600,6 +613,7 @@
 				A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */,
 				B09CA463A8DF59221937A2C7 /* TranscriptView.swift */,
 				6B5718CA7DF93E9C2A51A16C /* Menu */,
+				05B6FECAF7F08D43DE50EBA0 /* Settings */,
 				DAC46A7438CFA4B1A35966FB /* Transcript */,
 			);
 			path = Views;
@@ -1032,8 +1046,10 @@
 				CEDAB8D8BF65455F21123B22 /* SessionLibraryController.swift in Sources */,
 				6DDE29389B4D58A9BD6CD115 /* SessionMarker.swift in Sources */,
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,
+				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
+				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
 				8839D4116A3265DB08430846 /* SupportDataController.swift in Sources */,
 				6470CFDC78DB57C49819E4A9 /* SupportView.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/SettingsDiagnosticsPrivacyPane.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsDiagnosticsPrivacyPane.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// The "Diagnostics & Support" and "Privacy" sections of Settings, extracted
+/// verbatim from `SettingsView` (#355). Pure UI relocation: the same controls,
+/// bindings, and `SettingsStore` keys, rendered identically. The destructive
+/// "Delete All Local Data" confirmation alert stays owned by `SettingsView`
+/// (which holds the presentation state); this pane only requests it via the
+/// `showDeleteAllLocalDataConfirmation` binding.
+struct SettingsDiagnosticsPrivacyPane: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var settingsStore: SettingsStore
+    let secureControlsDisabled: Bool
+    @Binding var showDeleteAllLocalDataConfirmation: Bool
+
+    private var debugInfoSnapshot: DebugInfoSnapshot {
+        appState.debugInfoSnapshot
+    }
+
+    var body: some View {
+        Group {
+            GroupBox("Diagnostics & Support") {
+                VStack(alignment: .leading, spacing: 12) {
+                    settingsSectionIntro("Use these details when filing GitHub issues or sharing a debug bundle with support.")
+
+                    settingsLabeledField(title: "App Version") {
+                        Text(debugInfoSnapshot.versionDescription)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "macOS") {
+                        Text(debugInfoSnapshot.macOSVersion)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "Architecture") {
+                        Text(debugInfoSnapshot.architecture)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "Transcription") {
+                        Text(debugInfoSnapshot.activeTranscriptionModel)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "Issue Extraction") {
+                        Text(debugInfoSnapshot.issueExtractionModel)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "Log Level") {
+                        Text(debugInfoSnapshot.logLevel)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    settingsLabeledField(title: "Session ID") {
+                        Text(debugInfoSnapshot.sessionID?.uuidString ?? "No active or selected session")
+                            .font(.footnote.monospaced())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Text("Attach the debug bundle and, if relevant, an exported session bundle when reporting an issue. BugNarrator never includes OpenAI, GitHub, or Jira credentials in the debug bundle.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            GroupBox("Privacy") {
+                VStack(alignment: .leading, spacing: 12) {
+                    settingsSectionIntro("Export or remove local session data without exposing stored credentials.")
+
+                    HStack(spacing: 12) {
+                        Button("Export Data") {
+                            Task {
+                                await appState.exportPrivacyData()
+                            }
+                        }
+                        .disabled(secureControlsDisabled)
+
+                        Text("Creates a local JSON export of BugNarrator sessions, settings metadata, and diagnostics context. API keys, GitHub tokens, Jira credentials, and Keychain-only secrets are excluded.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 12) {
+                        Button("Delete All Local Data", role: .destructive) {
+                            showDeleteAllLocalDataConfirmation = true
+                        }
+                        .disabled(secureControlsDisabled)
+
+                        Text("Removes locally stored sessions, temporary recording files, export history, and diagnostics files. Saved credentials in the macOS Keychain are not deleted.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Divider()
+
+                    Toggle("Record local usage analytics", isOn: $settingsStore.operationalTelemetryEnabled)
+                        .help("Records named app events (recordings started, transcriptions completed, errors) to a local file. Nothing is uploaded.")
+
+                    Text("BugNarrator records anonymous usage events to a local file (operational-telemetry.jsonl) to help diagnose issues. The data never leaves this Mac and is included in Export Data. Turn this off to stop recording new events.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}

--- a/Sources/BugNarrator/Views/Settings/SettingsViewComponents.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsViewComponents.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Shared field-layout components used across the Settings panes. Extracted from
+/// `SettingsView` (#355) so per-pane views can render byte-identical field rows
+/// as the panes are split out of the monolithic settings body.
+
+/// A label/value row: a fixed-width title on the left and arbitrary content on
+/// the right.
+@ViewBuilder
+func settingsLabeledField<Content: View>(
+    title: String,
+    @ViewBuilder content: () -> Content
+) -> some View {
+    HStack(alignment: .top) {
+        Text(title)
+            .frame(width: 170, alignment: .leading)
+        content()
+    }
+}
+
+/// A secondary-styled introductory line for a settings section.
+func settingsSectionIntro(_ text: String) -> some View {
+    Text(text)
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+}

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -444,97 +444,12 @@ struct SettingsView: View {
                     }
                 }
 
-                GroupBox("Diagnostics & Support") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Use these details when filing GitHub issues or sharing a debug bundle with support.")
-
-                        labeledField(title: "App Version") {
-                            Text(debugInfoSnapshot.versionDescription)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "macOS") {
-                            Text(debugInfoSnapshot.macOSVersion)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "Architecture") {
-                            Text(debugInfoSnapshot.architecture)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "Transcription") {
-                            Text(debugInfoSnapshot.activeTranscriptionModel)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "Issue Extraction") {
-                            Text(debugInfoSnapshot.issueExtractionModel)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "Log Level") {
-                            Text(debugInfoSnapshot.logLevel)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        labeledField(title: "Session ID") {
-                            Text(debugInfoSnapshot.sessionID?.uuidString ?? "No active or selected session")
-                                .font(.footnote.monospaced())
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-
-                        Text("Attach the debug bundle and, if relevant, an exported session bundle when reporting an issue. BugNarrator never includes OpenAI, GitHub, or Jira credentials in the debug bundle.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                GroupBox("Privacy") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Export or remove local session data without exposing stored credentials.")
-
-                        HStack(spacing: 12) {
-                            Button("Export Data") {
-                                Task {
-                                    await appState.exportPrivacyData()
-                                }
-                            }
-                            .disabled(secureControlsDisabled)
-
-                            Text("Creates a local JSON export of BugNarrator sessions, settings metadata, and diagnostics context. API keys, GitHub tokens, Jira credentials, and Keychain-only secrets are excluded.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        HStack(spacing: 12) {
-                            Button("Delete All Local Data", role: .destructive) {
-                                showDeleteAllLocalDataConfirmation = true
-                            }
-                            .disabled(secureControlsDisabled)
-
-                            Text("Removes locally stored sessions, temporary recording files, export history, and diagnostics files. Saved credentials in the macOS Keychain are not deleted.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        Divider()
-
-                        Toggle("Record local usage analytics", isOn: $settingsStore.operationalTelemetryEnabled)
-                            .help("Records named app events (recordings started, transcriptions completed, errors) to a local file. Nothing is uploaded.")
-
-                        Text("BugNarrator records anonymous usage events to a local file (operational-telemetry.jsonl) to help diagnose issues. The data never leaves this Mac and is included in Export Data. Turn this off to stop recording new events.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                SettingsDiagnosticsPrivacyPane(
+                    appState: appState,
+                    settingsStore: settingsStore,
+                    secureControlsDisabled: secureControlsDisabled,
+                    showDeleteAllLocalDataConfirmation: $showDeleteAllLocalDataConfirmation
+                )
 
                 if secureControlsDisabled {
                     Text("Credential changes are disabled while recording, transcription, extraction, or export is in progress.")
@@ -863,10 +778,6 @@ struct SettingsView: View {
         )
     }
 
-    private var debugInfoSnapshot: DebugInfoSnapshot {
-        appState.debugInfoSnapshot
-    }
-
     private var gitHubRepositorySelection: Binding<String> {
         Binding(
             get: {
@@ -919,17 +830,11 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func labeledField<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
-        HStack(alignment: .top) {
-            Text(title)
-                .frame(width: 170, alignment: .leading)
-            content()
-        }
+        settingsLabeledField(title: title, content: content)
     }
 
     private func sectionIntro(_ text: String) -> some View {
-        Text(text)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
+        settingsSectionIntro(text)
     }
 
     private func permissionRecoveryRow(


### PR DESCRIPTION
## Summary

First step toward the tabbed `SettingsView` (#355), tracked as precursor #523.

**Why a precursor:** introducing a `TabView` is **atomic** w.r.t. the settings UI tests — every settings field moves behind a tab at once, forcing a full rework of all 4–5 slow/flaky `BugNarratorSettingsUITests` in one change. So the panes are extracted into their own View files **first, with no layout change** (UI-identical → UI tests untouched); the `TabView` swap becomes a contained final step once all panes are files.

### Changes
- **`Views/Settings/SettingsViewComponents.swift`** — shared field-layout helpers (`settingsLabeledField`, `settingsSectionIntro`). `SettingsView`'s existing `labeledField`/`sectionIntro` now **delegate** to these (call sites unchanged, no duplication).
- **`Views/Settings/SettingsDiagnosticsPrivacyPane.swift`** — the "Diagnostics & Support" and "Privacy" `GroupBox`es, relocated **verbatim**. The destructive delete-all confirmation alert stays owned by `SettingsView` (which holds the `@State`); the pane requests it via a binding.
- `SettingsView.body` hosts the pane in place; the now-dead `debugInfoSnapshot` helper is removed.

Pure UI relocation: no field added/removed/rewired, every setting keeps its `SettingsStore` key, no controller/validation change.

## Testing

- `xcodebuild ... test -only-testing:BugNarratorTests` — full unit suite green.
- `xcodebuild ... test -only-testing:BugNarratorUITests/BugNarratorSettingsUITests` — **all 7 UI tests pass unchanged** (incl. the slow `testSessionLibraryDialogCoversIssueEditingAndExportActions`), confirming the layout is byte-identical to the user.
- `xcodegen generate` run for the new files.

## Staging

Remaining pane extractions (Audio, Integrations, General) tracked in #523; the `TabView` swap + UI-test rework remains #355.

Closes #523
Refs #355