### PR TITLE
refactor: extract Audio + Permissions settings panes to their own views (#525, #355)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */; };
 		1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */; };
+		1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */; };
 		1F758F881FC9E36B8EB89C18 /* IssueExtractionRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EF5167B9226AE01E478075 /* IssueExtractionRequestBuilder.swift */; };
 		255F6B56A8E14ED7C80DB0FA /* ScreenshotsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */; };
 		280973289AE78D9919ECD80C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5346EDB503C6B05C81C368 /* KeychainService.swift */; };
@@ -348,6 +349,7 @@
 		98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		9AFA7A7FD4F1B6ACB5E3D70F /* AsyncTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimeoutTests.swift; sourceTree = "<group>"; };
+		9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAudioPanes.swift; sourceTree = "<group>"; };
 		9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentation.swift; sourceTree = "<group>"; };
 		9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapperTests.swift; sourceTree = "<group>"; };
 		9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsService.swift; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 		05B6FECAF7F08D43DE50EBA0 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */,
 				D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */,
 				8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */,
 			);
@@ -1046,6 +1049,7 @@
 				CEDAB8D8BF65455F21123B22 /* SessionLibraryController.swift in Sources */,
 				6DDE29389B4D58A9BD6CD115 /* SessionMarker.swift in Sources */,
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,
+				1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */,
 				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/SettingsAudioPanes.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsAudioPanes.swift
@@ -1,0 +1,147 @@
+import AVFoundation
+import CoreGraphics
+import SwiftUI
+
+/// The "Recording Audio" section of Settings, extracted verbatim from
+/// `SettingsView` (#523, an #355 precursor). Pure UI relocation: same controls,
+/// bindings, and `SettingsStore` keys, rendered identically.
+struct SettingsRecordingAudioPane: View {
+    @ObservedObject var settingsStore: SettingsStore
+    let secureControlsDisabled: Bool
+
+    private var availableRecordingAudioSources: [RecordingAudioSource] {
+        settingsStore.systemAudioCaptureEnabled
+            ? RecordingAudioSource.allCases
+            : [.microphone]
+    }
+
+    var body: some View {
+        GroupBox("Recording Audio") {
+            VStack(alignment: .leading, spacing: 12) {
+                settingsSectionIntro("Choose what audio BugNarrator records when a session starts.")
+
+                Toggle("System audio capture modes (experimental)", isOn: $settingsStore.systemAudioCaptureEnabled)
+                    .disabled(secureControlsDisabled)
+
+                settingsLabeledField(title: "Audio Source") {
+                    Picker("Audio Source", selection: $settingsStore.recordingAudioSource) {
+                        ForEach(availableRecordingAudioSources) { source in
+                            Text(source.title)
+                                .tag(source)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .disabled(secureControlsDisabled)
+                    .accessibilityLabel("Recording audio source")
+                }
+
+                if settingsStore.recordingAudioSource.usesSystemAudio {
+                    Toggle(
+                        "I understand system audio can include meeting audio and other people's voices",
+                        isOn: $settingsStore.hasAcceptedSystemAudioRecordingConsent
+                    )
+                    .disabled(secureControlsDisabled)
+
+                    Text("Get consent before recording system audio. BugNarrator stores finished sessions locally and \(settingsStore.aiProvider == .parakeetLocal ? "processes audio on this Mac" : "sends recorded audio to \(settingsStore.aiProvider.displayName)") only when transcription runs.")
+                        .font(.footnote)
+                        .foregroundStyle(
+                            settingsStore.hasAcceptedSystemAudioRecordingConsent
+                                ? Color.secondary
+                                : Color.orange
+                        )
+                } else if settingsStore.systemAudioCaptureEnabled {
+                    Text("System audio modes require a separate macOS permission prompt the first time capture starts.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+/// The "Permissions" section of Settings, extracted verbatim from `SettingsView`
+/// (#523). Surfaces microphone / screen-recording recovery rows when access is
+/// blocked. Pure UI relocation.
+struct SettingsPermissionsPane: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var settingsStore: SettingsStore
+
+    private var microphonePermissionBlocked: Bool {
+        guard settingsStore.recordingAudioSource.usesMicrophone else {
+            return false
+        }
+
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .denied, .restricted:
+            return true
+        case .authorized, .notDetermined:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private var screenRecordingPermissionMissing: Bool {
+        !CGPreflightScreenCaptureAccess()
+    }
+
+    var body: some View {
+        GroupBox("Permissions") {
+            VStack(alignment: .leading, spacing: 10) {
+                settingsSectionIntro("BugNarrator only asks for the permissions it needs for recording and screenshots.")
+
+                Text("BugNarrator asks for microphone access only when you start recording.")
+                    .foregroundStyle(.secondary)
+
+                Text("BugNarrator asks for Screen & System Audio Recording access only when a system audio mode starts.")
+                    .foregroundStyle(.secondary)
+
+                Text("BugNarrator asks for Screen Recording access only when you capture a screenshot. Recording can continue without screenshots if you skip this permission.")
+                    .foregroundStyle(.secondary)
+
+                Text("If you deny a permission, BugNarrator shows recovery buttons in the menu bar window so you can reopen the right System Settings pane.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                if microphonePermissionBlocked {
+                    permissionRecoveryRow(
+                        title: "Microphone access is blocked.",
+                        message: "Open System Settings, enable BugNarrator for Microphone access, then start recording again.",
+                        buttonTitle: "Open Microphone Settings",
+                        action: appState.openMicrophonePrivacySettings
+                    )
+                }
+
+                if screenRecordingPermissionMissing {
+                    permissionRecoveryRow(
+                        title: "Screenshot access is not enabled.",
+                        message: "Recording can continue without screenshots. Enable Screen Recording if you want screenshots during a session.",
+                        buttonTitle: "Open Screen Recording Settings",
+                        action: appState.openScreenRecordingPrivacySettings
+                    )
+                }
+            }
+        }
+    }
+
+    private func permissionRecoveryRow(
+        title: String,
+        message: String,
+        buttonTitle: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.footnote.weight(.semibold))
+
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Button(buttonTitle, action: action)
+                .controlSize(.small)
+        }
+        .padding(.top, 4)
+    }
+}

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -1,6 +1,4 @@
 import AppKit
-import AVFoundation
-import CoreGraphics
 import SwiftUI
 
 struct SettingsView: View {
@@ -55,47 +53,10 @@ struct SettingsView: View {
                     secureControlsDisabled: secureControlsDisabled
                 )
 
-                GroupBox("Recording Audio") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Choose what audio BugNarrator records when a session starts.")
-
-                        Toggle("System audio capture modes (experimental)", isOn: $settingsStore.systemAudioCaptureEnabled)
-                            .disabled(secureControlsDisabled)
-
-                        labeledField(title: "Audio Source") {
-                            Picker("Audio Source", selection: $settingsStore.recordingAudioSource) {
-                                ForEach(availableRecordingAudioSources) { source in
-                                    Text(source.title)
-                                        .tag(source)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-                            .labelsHidden()
-                            .disabled(secureControlsDisabled)
-                            .accessibilityLabel("Recording audio source")
-                        }
-
-                        if settingsStore.recordingAudioSource.usesSystemAudio {
-                            Toggle(
-                                "I understand system audio can include meeting audio and other people's voices",
-                                isOn: $settingsStore.hasAcceptedSystemAudioRecordingConsent
-                            )
-                            .disabled(secureControlsDisabled)
-
-                            Text("Get consent before recording system audio. BugNarrator stores finished sessions locally and \(settingsStore.aiProvider == .parakeetLocal ? "processes audio on this Mac" : "sends recorded audio to \(settingsStore.aiProvider.displayName)") only when transcription runs.")
-                                .font(.footnote)
-                                .foregroundStyle(
-                                    settingsStore.hasAcceptedSystemAudioRecordingConsent
-                                        ? Color.secondary
-                                        : Color.orange
-                                )
-                        } else if settingsStore.systemAudioCaptureEnabled {
-                            Text("System audio modes require a separate macOS permission prompt the first time capture starts.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
+                SettingsRecordingAudioPane(
+                    settingsStore: settingsStore,
+                    secureControlsDisabled: secureControlsDisabled
+                )
 
                 GroupBox("Workflow Defaults") {
                     VStack(alignment: .leading, spacing: 10) {
@@ -126,42 +87,10 @@ struct SettingsView: View {
                     }
                 }
 
-                GroupBox("Permissions") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionIntro("BugNarrator only asks for the permissions it needs for recording and screenshots.")
-
-                        Text("BugNarrator asks for microphone access only when you start recording.")
-                            .foregroundStyle(.secondary)
-
-                        Text("BugNarrator asks for Screen & System Audio Recording access only when a system audio mode starts.")
-                            .foregroundStyle(.secondary)
-
-                        Text("BugNarrator asks for Screen Recording access only when you capture a screenshot. Recording can continue without screenshots if you skip this permission.")
-                            .foregroundStyle(.secondary)
-
-                        Text("If you deny a permission, BugNarrator shows recovery buttons in the menu bar window so you can reopen the right System Settings pane.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        if microphonePermissionBlocked {
-                            permissionRecoveryRow(
-                                title: "Microphone access is blocked.",
-                                message: "Open System Settings, enable BugNarrator for Microphone access, then start recording again.",
-                                buttonTitle: "Open Microphone Settings",
-                                action: appState.openMicrophonePrivacySettings
-                            )
-                        }
-
-                        if screenRecordingPermissionMissing {
-                            permissionRecoveryRow(
-                                title: "Screenshot access is not enabled.",
-                                message: "Recording can continue without screenshots. Enable Screen Recording if you want screenshots during a session.",
-                                buttonTitle: "Open Screen Recording Settings",
-                                action: appState.openScreenRecordingPrivacySettings
-                            )
-                        }
-                    }
-                }
+                SettingsPermissionsPane(
+                    appState: appState,
+                    settingsStore: settingsStore
+                )
 
                 GroupBox("Global Hotkeys") {
                     VStack(alignment: .leading, spacing: 12) {
@@ -587,31 +516,6 @@ struct SettingsView: View {
         "Disabled while recording or transcribing is in progress."
     }
 
-    private var availableRecordingAudioSources: [RecordingAudioSource] {
-        settingsStore.systemAudioCaptureEnabled
-            ? RecordingAudioSource.allCases
-            : [.microphone]
-    }
-
-    private var microphonePermissionBlocked: Bool {
-        guard settingsStore.recordingAudioSource.usesMicrophone else {
-            return false
-        }
-
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .denied, .restricted:
-            return true
-        case .authorized, .notDetermined:
-            return false
-        @unknown default:
-            return false
-        }
-    }
-
-    private var screenRecordingPermissionMissing: Bool {
-        !CGPreflightScreenCaptureAccess()
-    }
-
     private var openAIReadiness: SettingsReadinessStatus {
         if !settingsStore.aiProvider.requiresAPIKey {
             return settingsStore.aiProviderConfigurationIsReady ? .ready : .needsSetup
@@ -835,26 +739,6 @@ struct SettingsView: View {
 
     private func sectionIntro(_ text: String) -> some View {
         settingsSectionIntro(text)
-    }
-
-    private func permissionRecoveryRow(
-        title: String,
-        message: String,
-        buttonTitle: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.footnote.weight(.semibold))
-
-            Text(message)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-            Button(buttonTitle, action: action)
-                .controlSize(.small)
-        }
-        .padding(.top, 4)
     }
 
     private func calloutColor(for tone: SettingsCalloutTone) -> Color {


### PR DESCRIPTION
## Summary

Slice **A2** of the `SettingsView` pane extraction toward the tabbed layout (#355). Follows A1 (Diagnostics/Privacy pane, #524). Moves the "Recording Audio" and "Permissions" `GroupBox`es into `Views/Settings/SettingsAudioPanes.swift` as `SettingsRecordingAudioPane` and `SettingsPermissionsPane`, rendered in their **existing body positions** so the layout is unchanged.

The pane-local helpers move with them: `availableRecordingAudioSources` (recording-audio pane); `microphonePermissionBlocked`, `screenRecordingPermissionMissing`, and `permissionRecoveryRow` (permissions pane). With their only callers gone, those helpers and the now-unused `AVFoundation` / `CoreGraphics` imports are removed from `SettingsView`.

Pure UI relocation: no field added/removed/rewired, every setting keeps its `SettingsStore` key, no controller/validation change.

## Testing

- `xcodebuild ... test -only-testing:BugNarratorTests` — full unit suite green.
- `xcodebuild ... test -only-testing:BugNarratorUITests/BugNarratorSettingsUITests` — all 7 UI tests pass. (One unrelated `testRecordingControlsDialogCoversButtonsAndSafeStateTransitions` timing flake — asserts a button in the separate Recording Controls window — failed once and **passed on isolated re-run**.)
- Build clean, no new warnings. `xcodegen generate` run for the new file.

## Remaining (toward #355)
A3 (Integrations) and A4 (General) panes, then the `TabView` swap + UI-test rework — tracked in #525 / #355.

Closes #525
Refs #355