### PR TITLE
refactor: extract Workflow Defaults + Global Hotkeys settings panes (#527, #355)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		8CF257839BEA4B0681BEA508 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */; };
 		8E0DE1B3EABFCECD46EF5ED0 /* SessionDataProtectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */; };
 		8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */; };
+		8E41CD2A7BE6A70F5CD9F46C /* SettingsGeneralPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */; };
 		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
 		8F4B3823ACB48DDF270E2BAE /* AppStateIssueExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */; };
@@ -234,6 +235,7 @@
 		073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
 		0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingControlPanelView.swift; sourceTree = "<group>"; };
+		0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGeneralPanes.swift; sourceTree = "<group>"; };
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsSection.swift; sourceTree = "<group>"; };
@@ -436,6 +438,7 @@
 			children = (
 				9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */,
 				D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */,
+				0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */,
 				8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */,
 			);
 			path = Settings;
@@ -1051,6 +1054,7 @@
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,
 				1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */,
 				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,
+				8E41CD2A7BE6A70F5CD9F46C /* SettingsGeneralPanes.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/SettingsGeneralPanes.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsGeneralPanes.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// The "Workflow Defaults" section of Settings, extracted verbatim from
+/// `SettingsView` (#355). Pure UI relocation: same toggles, bindings, and
+/// `SettingsStore` keys, rendered identically.
+struct SettingsWorkflowDefaultsPane: View {
+    @ObservedObject var settingsStore: SettingsStore
+
+    var body: some View {
+        GroupBox("Workflow Defaults") {
+            VStack(alignment: .leading, spacing: 10) {
+                settingsSectionIntro("Control what BugNarrator does automatically after recording, transcription, and support workflows.")
+
+                Toggle("Auto-copy transcript to clipboard", isOn: $settingsStore.autoCopyTranscript)
+                Toggle("Open BugNarrator at startup", isOn: $settingsStore.openAtStartup)
+                    .disabled(!settingsStore.openAtStartupControlIsEnabled)
+                Toggle("Debug mode enables verbose local diagnostics", isOn: $settingsStore.debugMode)
+
+                if let openAtStartupStatusMessage = settingsStore.openAtStartupStatusMessage {
+                    Text(openAtStartupStatusMessage)
+                        .font(.footnote)
+                        .foregroundStyle(calloutColor(for: settingsStore.openAtStartupStatusTone))
+                }
+
+                Text("Screenshot capture prompts for Screen Recording permission the first time you use it if macOS requires access.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                Text("When transcription cannot finish after a recording stops, BugNarrator saves the recording locally as a pending session so you can retry transcription.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                Text("When debug mode is on, BugNarrator records extra local diagnostics, keeps successful temp audio files, and adds more validation notes to exported debug bundles.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func calloutColor(for tone: SettingsCalloutTone) -> Color {
+        switch tone {
+        case .secondary:
+            return .secondary
+        case .warning:
+            return .orange
+        case .error:
+            return .red
+        }
+    }
+}
+
+/// The "Global Hotkeys" section of Settings, extracted verbatim from
+/// `SettingsView` (#355). Pure UI relocation.
+struct SettingsGlobalHotkeysPane: View {
+    @ObservedObject var settingsStore: SettingsStore
+    let secureControlsDisabled: Bool
+
+    var body: some View {
+        GroupBox("Global Hotkeys") {
+            VStack(alignment: .leading, spacing: 12) {
+                settingsSectionIntro("Hotkeys are optional. BugNarrator starts with every shortcut unassigned, so choose only the ones you want to use.")
+
+                hotkeyRow(action: .startRecording, shortcut: $settingsStore.startRecordingHotkeyShortcut)
+                hotkeyRow(action: .stopRecording, shortcut: $settingsStore.stopRecordingHotkeyShortcut)
+                hotkeyRow(action: .captureScreenshot, shortcut: $settingsStore.screenshotHotkeyShortcut)
+
+                if let hotkeyConflictMessage = settingsStore.hotkeyConflictMessage {
+                    HStack(spacing: 8) {
+                        Text(hotkeyConflictMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                        if let conflicting = settingsStore.conflictingHotkeyAction {
+                            Button("Clear \(conflicting.title)") {
+                                settingsStore.clearHotkey(for: conflicting)
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                }
+
+                Text("Hotkeys use Carbon and do not require Accessibility access. Screenshot hotkeys only work while a session is recording. If you choose a shortcut that is already assigned to another BugNarrator action, the new assignment is rejected until you clear or change the conflicting shortcut.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func hotkeyRow(action: HotkeyAction, shortcut: Binding<HotkeyShortcut>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(action.title)
+                .font(.subheadline.weight(.medium))
+            HotkeyRecorderView(actionTitle: action.title, shortcut: shortcut)
+
+            if !shortcut.wrappedValue.isEnabled,
+               let suggestion = settingsStore.suggestedShortcutIfAvailable(for: action) {
+                Button("Use suggested: \(suggestion.displayString)") {
+                    shortcut.wrappedValue = suggestion
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(secureControlsDisabled)
+                .help("Apply the recommended shortcut for \(action.title).")
+                .accessibilityLabel("Use suggested shortcut \(suggestion.displayString) for \(action.title)")
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -58,67 +58,17 @@ struct SettingsView: View {
                     secureControlsDisabled: secureControlsDisabled
                 )
 
-                GroupBox("Workflow Defaults") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionIntro("Control what BugNarrator does automatically after recording, transcription, and support workflows.")
-
-                        Toggle("Auto-copy transcript to clipboard", isOn: $settingsStore.autoCopyTranscript)
-                        Toggle("Open BugNarrator at startup", isOn: $settingsStore.openAtStartup)
-                            .disabled(!settingsStore.openAtStartupControlIsEnabled)
-                        Toggle("Debug mode enables verbose local diagnostics", isOn: $settingsStore.debugMode)
-
-                        if let openAtStartupStatusMessage = settingsStore.openAtStartupStatusMessage {
-                            Text(openAtStartupStatusMessage)
-                                .font(.footnote)
-                                .foregroundStyle(calloutColor(for: settingsStore.openAtStartupStatusTone))
-                        }
-
-                        Text("Screenshot capture prompts for Screen Recording permission the first time you use it if macOS requires access.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        Text("When transcription cannot finish after a recording stops, BugNarrator saves the recording locally as a pending session so you can retry transcription.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        Text("When debug mode is on, BugNarrator records extra local diagnostics, keeps successful temp audio files, and adds more validation notes to exported debug bundles.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                SettingsWorkflowDefaultsPane(settingsStore: settingsStore)
 
                 SettingsPermissionsPane(
                     appState: appState,
                     settingsStore: settingsStore
                 )
 
-                GroupBox("Global Hotkeys") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        sectionIntro("Hotkeys are optional. BugNarrator starts with every shortcut unassigned, so choose only the ones you want to use.")
-
-                        hotkeyRow(action: .startRecording, shortcut: $settingsStore.startRecordingHotkeyShortcut)
-                        hotkeyRow(action: .stopRecording, shortcut: $settingsStore.stopRecordingHotkeyShortcut)
-                        hotkeyRow(action: .captureScreenshot, shortcut: $settingsStore.screenshotHotkeyShortcut)
-
-                        if let hotkeyConflictMessage = settingsStore.hotkeyConflictMessage {
-                            HStack(spacing: 8) {
-                                Text(hotkeyConflictMessage)
-                                    .font(.footnote)
-                                    .foregroundStyle(.red)
-                                if let conflicting = settingsStore.conflictingHotkeyAction {
-                                    Button("Clear \(conflicting.title)") {
-                                        settingsStore.clearHotkey(for: conflicting)
-                                    }
-                                    .controlSize(.small)
-                                }
-                            }
-                        }
-
-                        Text("Hotkeys use Carbon and do not require Accessibility access. Screenshot hotkeys only work while a session is recording. If you choose a shortcut that is already assigned to another BugNarrator action, the new assignment is rejected until you clear or change the conflicting shortcut.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                SettingsGlobalHotkeysPane(
+                    settingsStore: settingsStore,
+                    secureControlsDisabled: secureControlsDisabled
+                )
 
                 GroupBox("GitHub Export (Experimental)") {
                     VStack(alignment: .leading, spacing: 12) {
@@ -711,27 +661,6 @@ struct SettingsView: View {
         )
     }
 
-    private func hotkeyRow(action: HotkeyAction, shortcut: Binding<HotkeyShortcut>) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(action.title)
-                .font(.subheadline.weight(.medium))
-            HotkeyRecorderView(actionTitle: action.title, shortcut: shortcut)
-
-            if !shortcut.wrappedValue.isEnabled,
-               let suggestion = settingsStore.suggestedShortcutIfAvailable(for: action) {
-                Button("Use suggested: \(suggestion.displayString)") {
-                    shortcut.wrappedValue = suggestion
-                }
-                .buttonStyle(.borderless)
-                .controlSize(.small)
-                .disabled(secureControlsDisabled)
-                .help("Apply the recommended shortcut for \(action.title).")
-                .accessibilityLabel("Use suggested shortcut \(suggestion.displayString) for \(action.title)")
-            }
-        }
-        .accessibilityElement(children: .contain)
-    }
-
     @ViewBuilder
     private func labeledField<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         settingsLabeledField(title: title, content: content)
@@ -739,17 +668,6 @@ struct SettingsView: View {
 
     private func sectionIntro(_ text: String) -> some View {
         settingsSectionIntro(text)
-    }
-
-    private func calloutColor(for tone: SettingsCalloutTone) -> Color {
-        switch tone {
-        case .secondary:
-            return .secondary
-        case .warning:
-            return .orange
-        case .error:
-            return .red
-        }
     }
 
     private func credentialStatus(valueIsPresent: Bool, persistenceState: APIKeyPersistenceState) -> SettingsReadinessStatus {


### PR DESCRIPTION
## Summary

Slice **A4** of the `SettingsView` pane extraction toward the tabbed layout (#355). Follows A1 (Diagnostics/Privacy, #524) and A2 (Audio/Permissions, #526). Moves the "Workflow Defaults" and "Global Hotkeys" `GroupBox`es into `Views/Settings/SettingsGeneralPanes.swift` as `SettingsWorkflowDefaultsPane` and `SettingsGlobalHotkeysPane`, rendered in their **existing body positions** so the layout is unchanged.

Their exclusive helpers move with them: `calloutColor` (Workflow Defaults) and `hotkeyRow` (Global Hotkeys). With their only callers gone, both are removed from `SettingsView`.

Pure UI relocation: no field added/removed/rewired, every setting keeps its `SettingsStore` key, no controller/validation change.

## Testing
- `xcodebuild ... test -only-testing:BugNarratorTests` — full unit suite green.
- `xcodebuild ... test -only-testing:BugNarratorUITests/BugNarratorSettingsUITests` — all 7 UI tests pass.
- Build clean, no new warnings. `xcodegen generate` run for the new file.

## Remaining (toward #355)
A3 (Integrations pane — most helper-entangled) + the "Before You Start" messaging, then the `TabView` swap + UI-test rework.

Closes #527
Refs #355