### PR TITLE
refactor: extract shared Settings readiness layer (#531, #355)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		B3FF6A0FB442CAC98A7B9E81 /* ScreenshotCaptureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */; };
 		B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A663ED1B160E290FCFAC3AED /* ClipboardService.swift */; };
 		B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */; };
+		BA99127A39D827962D535164 /* SettingsReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */; };
 		BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */; };
 		C1FDA2B024230D874D06D08B /* ApplicationTerminationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */; };
 		C32D262C1E3A497D0B371C06 /* ScreenshotCaptureControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */; };
@@ -368,6 +369,7 @@
 		AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshotTests.swift; sourceTree = "<group>"; };
 		AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProviderTests.swift; sourceTree = "<group>"; };
 		B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraftTests.swift; sourceTree = "<group>"; };
+		B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsReadiness.swift; sourceTree = "<group>"; };
 		B09CA463A8DF59221937A2C7 /* TranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptView.swift; sourceTree = "<group>"; };
 		B0D1F9ADC8F56876FCB33162 /* KeychainServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainServiceTests.swift; sourceTree = "<group>"; };
 		B294CC5102A78C8F1D01EEB6 /* BugNarrator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BugNarrator.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -439,6 +441,7 @@
 				9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */,
 				D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */,
 				0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */,
+				B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */,
 				8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */,
 			);
 			path = Settings;
@@ -1055,6 +1058,7 @@
 				1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */,
 				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,
 				8E41CD2A7BE6A70F5CD9F46C /* SettingsGeneralPanes.swift in Sources */,
+				BA99127A39D827962D535164 /* SettingsReadiness.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/SettingsReadiness.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsReadiness.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+
+/// Shared readiness/status model + view components for the Settings surface,
+/// extracted from `SettingsView` (#530, an #355 A3 precursor) so both the
+/// top-level "at a glance" status summary and the Integrations pane can compute
+/// and render the same status rows. Pure relocation: identical logic and layout.
+
+/// The configured-ness of a Settings capability (AI provider, GitHub, Jira).
+enum SettingsReadinessStatus {
+    case ready
+    case needsSetup
+    case pendingSave
+    case locked
+
+    var title: String {
+        switch self {
+        case .ready:
+            return "Ready"
+        case .needsSetup:
+            return "Needs setup"
+        case .pendingSave:
+            return "Pending save"
+        case .locked:
+            return "Locked"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .ready:
+            return "checkmark.circle.fill"
+        case .needsSetup:
+            return "exclamationmark.circle.fill"
+        case .pendingSave:
+            return "clock.fill"
+        case .locked:
+            return "lock.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .ready:
+            return .green
+        case .needsSetup:
+            return .orange
+        case .pendingSave:
+            return .blue
+        case .locked:
+            return .red
+        }
+    }
+}
+
+/// One row in a per-integration prerequisite checklist.
+struct PrerequisiteRow: Identifiable {
+    let title: String
+    let detail: String
+    let status: SettingsReadinessStatus
+
+    var id: String {
+        title
+    }
+}
+
+/// Pure readiness computations derived from `SettingsStore` state.
+enum SettingsReadiness {
+    static func credentialStatus(
+        valueIsPresent: Bool,
+        persistenceState: APIKeyPersistenceState
+    ) -> SettingsReadinessStatus {
+        switch persistenceState {
+        case .pendingSave:
+            return .pendingSave
+        case .keychainLocked:
+            return .locked
+        case .empty:
+            return .needsSetup
+        case .keychain, .sessionOnly:
+            return valueIsPresent ? .ready : .needsSetup
+        }
+    }
+
+    static func prerequisiteStatus(
+        for persistenceState: APIKeyPersistenceState,
+        isReady: Bool
+    ) -> SettingsReadinessStatus {
+        switch persistenceState {
+        case .pendingSave:
+            return .pendingSave
+        case .keychainLocked:
+            return .locked
+        default:
+            return isReady ? .ready : .needsSetup
+        }
+    }
+
+    static func openAIReadiness(_ settingsStore: SettingsStore) -> SettingsReadinessStatus {
+        if !settingsStore.aiProvider.requiresAPIKey {
+            return settingsStore.aiProviderConfigurationIsReady ? .ready : .needsSetup
+        }
+
+        return credentialStatus(
+            valueIsPresent: settingsStore.aiProviderConfigurationIsReady,
+            persistenceState: settingsStore.apiKeyPersistenceState
+        )
+    }
+
+    static func gitHubReadiness(_ settingsStore: SettingsStore) -> SettingsReadinessStatus {
+        if settingsStore.githubTokenPersistenceState == .pendingSave {
+            return .pendingSave
+        }
+
+        if settingsStore.githubTokenPersistenceState == .keychainLocked {
+            return .locked
+        }
+
+        return settingsStore.githubExportConfiguration == nil ? .needsSetup : .ready
+    }
+
+    static func jiraReadiness(_ settingsStore: SettingsStore) -> SettingsReadinessStatus {
+        if settingsStore.jiraEmailPersistenceState == .pendingSave ||
+            settingsStore.jiraTokenPersistenceState == .pendingSave {
+            return .pendingSave
+        }
+
+        if settingsStore.jiraEmailPersistenceState == .keychainLocked ||
+            settingsStore.jiraTokenPersistenceState == .keychainLocked {
+            return .locked
+        }
+
+        return settingsStore.jiraExportConfiguration == nil ? .needsSetup : .ready
+    }
+}
+
+/// A "Settings at a glance" status row: icon + title/detail + status capsule.
+func settingsStatusRow(
+    title: String,
+    detail: String,
+    status: SettingsReadinessStatus,
+    accessibilityLabel: String
+) -> some View {
+    HStack(spacing: 10) {
+        Image(systemName: status.symbolName)
+            .foregroundStyle(status.color)
+            .frame(width: 18)
+
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+
+            Text(detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+
+        Spacer(minLength: 12)
+
+        Text(status.title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(status.color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(status.color.opacity(0.12), in: Capsule())
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(accessibilityLabel)
+}
+
+/// A titled checklist of per-integration prerequisite rows.
+func settingsPrerequisiteChecklist(title: String, rows: [PrerequisiteRow]) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+        VStack(spacing: 6) {
+            ForEach(rows) { row in
+                settingsPrerequisiteRow(row)
+            }
+        }
+    }
+    .padding(10)
+    .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    .overlay(
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .stroke(.quaternary, lineWidth: 1)
+    )
+}
+
+/// A single prerequisite row within `settingsPrerequisiteChecklist`.
+func settingsPrerequisiteRow(_ row: PrerequisiteRow) -> some View {
+    HStack(spacing: 8) {
+        Image(systemName: row.status.symbolName)
+            .foregroundStyle(row.status.color)
+            .frame(width: 16)
+
+        Text(row.title)
+            .font(.caption.weight(.medium))
+
+        Text(row.detail)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+
+        Spacer()
+
+        Text(row.status.title)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(row.status.color)
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel("\(row.title) prerequisite: \(row.status.title)")
+}

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -467,40 +467,15 @@ struct SettingsView: View {
     }
 
     private var openAIReadiness: SettingsReadinessStatus {
-        if !settingsStore.aiProvider.requiresAPIKey {
-            return settingsStore.aiProviderConfigurationIsReady ? .ready : .needsSetup
-        }
-
-        return credentialStatus(
-            valueIsPresent: settingsStore.aiProviderConfigurationIsReady,
-            persistenceState: settingsStore.apiKeyPersistenceState
-        )
+        SettingsReadiness.openAIReadiness(settingsStore)
     }
 
     private var gitHubReadiness: SettingsReadinessStatus {
-        if settingsStore.githubTokenPersistenceState == .pendingSave {
-            return .pendingSave
-        }
-
-        if settingsStore.githubTokenPersistenceState == .keychainLocked {
-            return .locked
-        }
-
-        return settingsStore.githubExportConfiguration == nil ? .needsSetup : .ready
+        SettingsReadiness.gitHubReadiness(settingsStore)
     }
 
     private var jiraReadiness: SettingsReadinessStatus {
-        if settingsStore.jiraEmailPersistenceState == .pendingSave ||
-            settingsStore.jiraTokenPersistenceState == .pendingSave {
-            return .pendingSave
-        }
-
-        if settingsStore.jiraEmailPersistenceState == .keychainLocked ||
-            settingsStore.jiraTokenPersistenceState == .keychainLocked {
-            return .locked
-        }
-
-        return settingsStore.jiraExportConfiguration == nil ? .needsSetup : .ready
+        SettingsReadiness.jiraReadiness(settingsStore)
     }
 
     private var gitHubTokenPrerequisiteDetail: String {
@@ -671,30 +646,14 @@ struct SettingsView: View {
     }
 
     private func credentialStatus(valueIsPresent: Bool, persistenceState: APIKeyPersistenceState) -> SettingsReadinessStatus {
-        switch persistenceState {
-        case .pendingSave:
-            return .pendingSave
-        case .keychainLocked:
-            return .locked
-        case .empty:
-            return .needsSetup
-        case .keychain, .sessionOnly:
-            return valueIsPresent ? .ready : .needsSetup
-        }
+        SettingsReadiness.credentialStatus(valueIsPresent: valueIsPresent, persistenceState: persistenceState)
     }
 
     private func prerequisiteStatus(
         for persistenceState: APIKeyPersistenceState,
         isReady: Bool
     ) -> SettingsReadinessStatus {
-        switch persistenceState {
-        case .pendingSave:
-            return .pendingSave
-        case .keychainLocked:
-            return .locked
-        default:
-            return isReady ? .ready : .needsSetup
-        }
+        SettingsReadiness.prerequisiteStatus(for: persistenceState, isReady: isReady)
     }
 
     private func settingsStatusRow(
@@ -703,135 +662,20 @@ struct SettingsView: View {
         status: SettingsReadinessStatus,
         accessibilityLabel: String
     ) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: status.symbolName)
-                .foregroundStyle(status.color)
-                .frame(width: 18)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.subheadline.weight(.medium))
-
-                Text(detail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer(minLength: 12)
-
-            Text(status.title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(status.color)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(status.color.opacity(0.12), in: Capsule())
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private func prerequisiteChecklist(title: String, rows: [PrerequisiteRow]) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: 6) {
-                ForEach(rows) { row in
-                    prerequisiteRow(row)
-                }
-            }
-        }
-        .padding(10)
-        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(.quaternary, lineWidth: 1)
+        BugNarrator.settingsStatusRow(
+            title: title,
+            detail: detail,
+            status: status,
+            accessibilityLabel: accessibilityLabel
         )
     }
 
+    private func prerequisiteChecklist(title: String, rows: [PrerequisiteRow]) -> some View {
+        settingsPrerequisiteChecklist(title: title, rows: rows)
+    }
+
     private func prerequisiteRow(_ row: PrerequisiteRow) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: row.status.symbolName)
-                .foregroundStyle(row.status.color)
-                .frame(width: 16)
-
-            Text(row.title)
-                .font(.caption.weight(.medium))
-
-            Text(row.detail)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-
-            Spacer()
-
-            Text(row.status.title)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(row.status.color)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(row.title) prerequisite: \(row.status.title)")
-    }
-}
-
-private struct PrerequisiteRow: Identifiable {
-    let title: String
-    let detail: String
-    let status: SettingsReadinessStatus
-
-    var id: String {
-        title
-    }
-}
-
-private enum SettingsReadinessStatus {
-    case ready
-    case needsSetup
-    case pendingSave
-    case locked
-
-    var title: String {
-        switch self {
-        case .ready:
-            return "Ready"
-        case .needsSetup:
-            return "Needs setup"
-        case .pendingSave:
-            return "Pending save"
-        case .locked:
-            return "Locked"
-        }
-    }
-
-    var symbolName: String {
-        switch self {
-        case .ready:
-            return "checkmark.circle.fill"
-        case .needsSetup:
-            return "exclamationmark.circle.fill"
-        case .pendingSave:
-            return "clock.fill"
-        case .locked:
-            return "lock.fill"
-        }
-    }
-
-    var color: Color {
-        switch self {
-        case .ready:
-            return .green
-        case .needsSetup:
-            return .orange
-        case .pendingSave:
-            return .blue
-        case .locked:
-            return .red
-        }
+        settingsPrerequisiteRow(row)
     }
 }
 


### PR DESCRIPTION
## Summary

Precursor to the Integrations pane extraction (#530 / A3b), implementing **Option A** from that issue's design decision. The GitHub/Jira sections share readiness + status-row helpers with the top-level `statusSummary` (which stays in `SettingsView`), so the shared layer is extracted **first** — UI-identical, no `GroupBox` moves — before the Integrations pane can move out cleanly.

New `Views/Settings/SettingsReadiness.swift` holds:
- `SettingsReadinessStatus` enum + `PrerequisiteRow` model
- pure readiness computations: `SettingsReadiness.credentialStatus` / `prerequisiteStatus` / `openAIReadiness` / `gitHubReadiness` / `jiraReadiness`
- view builders: `settingsStatusRow`, `settingsPrerequisiteChecklist`, `settingsPrerequisiteRow`

`SettingsView`'s readiness vars and status helpers now **delegate** to it, so `statusSummary` and the still-inline Integrations sections render unchanged (call sites untouched).

Pure relocation: identical logic and layout, no field/key/validation change.

## Testing
- `xcodebuild ... test -only-testing:BugNarratorTests` — full unit suite green.
- `xcodebuild ... test -only-testing:BugNarratorUITests/BugNarratorSettingsUITests` — all 7 UI tests pass (incl. `testSettingsAtAGlanceStatusRowsExist`, which exercises the shared status rows).
- Build clean, no new warnings. `xcodegen generate` run for the new file.

## Next
#530 (A3b) moves the GitHub/Jira `GroupBox`es into their own pane using this shared layer; then #355 swaps to a `TabView`.

Closes #531
Refs #355