### PR TITLE
refactor: absorb isExporting into AppState+IssueExportQueries (#595, #430)

### DIFF
--- a/Sources/BugNarrator/AppState+IssueExportQueries.swift
+++ b/Sources/BugNarrator/AppState+IssueExportQueries.swift
@@ -24,4 +24,8 @@ extension AppState {
     func defaultJiraIssueExportTarget() -> JiraIssueExportTarget? {
         issueExportController.defaultJiraIssueExportTarget()
     }
+
+    func isExporting(to destination: ExportDestination) -> Bool {
+        issueExportController.isExporting(to: destination)
+    }
 }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -684,10 +684,6 @@ final class AppState: ObservableObject {
         screenshotCaptureController.isCaptureInProgress
     }
 
-    func isExporting(to destination: ExportDestination) -> Bool {
-        issueExportController.isExporting(to: destination)
-    }
-
     func refreshPermissionRecoveryState() {
         permissionRecoveryStatusPresenter.present(
             permissionRecoveryController.refreshRecoveryState(


### PR DESCRIPTION
Closes #595. Part of #430.

## Summary

Sweep-caught orphan from the #430 final delegator-test pass (#583 review 27). `isExporting(to:)` shares its sole collaborator (`issueExportController`) with the 6 methods already in `AppState+IssueExportQueries.swift`, so absorbs into that extension.

Byte-identical move; SHA-256:
`709f4e8fd0cb89fa7e1f4c0b9a9606c4ca032da42cb803b292ead0db26533450`

## Test plan
- [x] BugNarratorTests: 667 passing
- [x] Byte-diff against `origin/main`: silent for the 3-line block
- [x] Delegator-vs-orchestrator test: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)