### PR TITLE
refactor: rename IssueMutationFailurePresenter + fix .sessionLibrary label bug (#599)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		0C3B061E5ECAD626CDB83B89 /* ScreenshotTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E849C3E02857E9CF3FDCC39A /* ScreenshotTestSupport.swift */; };
 		0D3E82C811F386795DBE5D82 /* ExportReceiptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */; };
 		0E06D8F0874CB1CBB2FEA135 /* AppState+ExportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7881C3E0425DCA7D35C6C10E /* AppState+ExportReview.swift */; };
-		11C503F55518734C65BF9523 /* IssueMutationFailurePresenter+Attempt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F4260DB7346E46D2D6A9FDF /* IssueMutationFailurePresenter+Attempt.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
@@ -29,6 +28,7 @@
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */; };
+		1B6F43DA42AC21571CE4381D /* IssueExtractionFailurePresenter+Attempt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EFDC92FB70AFBB28EA6CF7 /* IssueExtractionFailurePresenter+Attempt.swift */; };
 		1BCD3E21C690E06B00319440 /* AppState+IssueExportQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776E95F5977423452961A52B /* AppState+IssueExportQueries.swift */; };
 		1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */; };
 		1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */; };
@@ -276,7 +276,6 @@
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntegrationsPanes.swift; sourceTree = "<group>"; };
 		0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FileRevealActions.swift"; sourceTree = "<group>"; };
-		0F4260DB7346E46D2D6A9FDF /* IssueMutationFailurePresenter+Attempt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IssueMutationFailurePresenter+Attempt.swift"; sourceTree = "<group>"; };
 		1691FC9128F5B3D543C87721 /* ExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestSupport.swift; sourceTree = "<group>"; };
 		16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsSection.swift; sourceTree = "<group>"; };
 		17E01384A3A5079D5BCBEF1B /* LocalDataDeletionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionControllerTests.swift; sourceTree = "<group>"; };
@@ -490,6 +489,7 @@
 		F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitor.swift; sourceTree = "<group>"; };
 		F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClientTests.swift; sourceTree = "<group>"; };
 		F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBundleExporterTests.swift; sourceTree = "<group>"; };
+		F6EFDC92FB70AFBB28EA6CF7 /* IssueExtractionFailurePresenter+Attempt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IssueExtractionFailurePresenter+Attempt.swift"; sourceTree = "<group>"; };
 		F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportProvider.swift; sourceTree = "<group>"; };
 		FB94B9DE300200CB6C35E6F1 /* AudioObjectIDExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioObjectIDExtensions.swift; sourceTree = "<group>"; };
 		FC68E525601D89A4E993FC89 /* AppErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresenter.swift; sourceTree = "<group>"; };
@@ -738,10 +738,10 @@
 				BA49B2B79731E3A62B083174 /* IssueExportController.swift */,
 				46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */,
 				D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */,
+				F6EFDC92FB70AFBB28EA6CF7 /* IssueExtractionFailurePresenter+Attempt.swift */,
 				E8EF5167B9226AE01E478075 /* IssueExtractionRequestBuilder.swift */,
 				EE77402A6284B705F5F4984A /* IssueExtractionResponseParser.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
-				0F4260DB7346E46D2D6A9FDF /* IssueMutationFailurePresenter+Attempt.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
@@ -1133,10 +1133,10 @@
 				5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */,
 				474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */,
 				EB5DAB7367CC0E4D69D936B6 /* IssueExtractionController.swift in Sources */,
+				1B6F43DA42AC21571CE4381D /* IssueExtractionFailurePresenter+Attempt.swift in Sources */,
 				1F758F881FC9E36B8EB89C18 /* IssueExtractionRequestBuilder.swift in Sources */,
 				9EE81A76B802435C84B8032D /* IssueExtractionResponseParser.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
-				11C503F55518734C65BF9523 /* IssueMutationFailurePresenter+Attempt.swift in Sources */,
 				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,

--- a/Sources/BugNarrator/AppState+IssueExtraction.swift
+++ b/Sources/BugNarrator/AppState+IssueExtraction.swift
@@ -2,19 +2,19 @@ import Foundation
 
 extension AppState {
     func updateExtractedIssue(_ updatedIssue: ExtractedIssue, in sessionID: UUID) {
-        issueMutationFailurePresenter.attempt {
+        issueExtractionFailurePresenter.attempt {
             try issueExtractionController.updateExtractedIssue(updatedIssue, in: sessionID)
         }
     }
 
     func setIssueSelection(_ isSelected: Bool, issueID: UUID, in sessionID: UUID) {
-        issueMutationFailurePresenter.attempt {
+        issueExtractionFailurePresenter.attempt {
             try issueExtractionController.setIssueSelection(isSelected, issueID: issueID, in: sessionID)
         }
     }
 
     func setAllIssuesSelected(_ isSelected: Bool, in sessionID: UUID) {
-        issueMutationFailurePresenter.attempt {
+        issueExtractionFailurePresenter.attempt {
             try issueExtractionController.setAllIssuesSelected(isSelected, in: sessionID)
         }
     }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -32,7 +32,7 @@ final class AppState: ObservableObject {
     let exportHistoryController: ExportHistoryController
     let issueExtractionController: IssueExtractionController
     let manualIssueExtractionStatusPresenter: ManualIssueExtractionStatusPresenter
-    let issueMutationFailurePresenter: IssueMutationFailurePresenter
+    let issueExtractionFailurePresenter: IssueExtractionFailurePresenter
     let issueExportController: IssueExportController
     let issueExportPresentationController: IssueExportPresentationController
     let permissionRecoveryController: PermissionRecoveryController
@@ -335,7 +335,7 @@ final class AppState: ObservableObject {
             showTranscriptWindow: { appUtilityActions.showTranscriptWindow?() },
             showSettingsWindow: { appUtilityActions.showSettingsWindow?() }
         )
-        self.issueMutationFailurePresenter = IssueMutationFailurePresenter(
+        self.issueExtractionFailurePresenter = IssueExtractionFailurePresenter(
             errorPresenter: self.errorPresenter
         )
         self.issueExportPresentationController = IssueExportPresentationController(
@@ -567,7 +567,7 @@ final class AppState: ObservableObject {
         recordingSessionStartStatusPresenter.prepareErrorPresentationSideEffects = { [weak self] in
             self?.prepareErrorPresentationSideEffects()
         }
-        issueMutationFailurePresenter.prepareErrorPresentationSideEffects = { [weak self] in
+        issueExtractionFailurePresenter.prepareErrorPresentationSideEffects = { [weak self] in
             self?.prepareErrorPresentationSideEffects()
         }
         sessionLibraryStatusPresenter.prepareErrorPresentationSideEffects = { [weak self] in

--- a/Sources/BugNarrator/Services/AppErrorPresenter.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresenter.swift
@@ -12,6 +12,7 @@ enum AppErrorOperation: String {
     case privacyExport = "privacy_export"
     case export
     case sessionLibrary = "session_library"
+    case issueExtraction = "issue_extraction"
 }
 
 struct AppErrorNormalization: Equatable {

--- a/Sources/BugNarrator/Services/IssueExtractionController.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionController.swift
@@ -69,7 +69,7 @@ final class ManualIssueExtractionStatusPresenter {
 }
 
 @MainActor
-final class IssueMutationFailurePresenter {
+final class IssueExtractionFailurePresenter {
     private let errorPresenter: AppErrorPresenter
     var prepareErrorPresentationSideEffects: () -> Void
 
@@ -83,7 +83,7 @@ final class IssueMutationFailurePresenter {
 
     func presentFailure(_ error: Error) {
         prepareErrorPresentationSideEffects()
-        _ = errorPresenter.presentError(error, operation: .sessionLibrary, fallback: { .storageFailure($0) })
+        _ = errorPresenter.presentError(error, operation: .issueExtraction, fallback: { .storageFailure($0) })
     }
 }
 

--- a/Sources/BugNarrator/Services/IssueExtractionFailurePresenter+Attempt.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionFailurePresenter+Attempt.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension IssueMutationFailurePresenter {
+extension IssueExtractionFailurePresenter {
     /// Runs a throwing issue-mutation operation, discarding any return value on success
     /// (the mutation controllers return `@discardableResult Bool`). On failure delegates
     /// to `presentFailure(error)`. Bridges the three do/catch delegators in

--- a/Sources/BugNarrator/Services/IssueExtractionFailurePresenter+Attempt.swift
+++ b/Sources/BugNarrator/Services/IssueExtractionFailurePresenter+Attempt.swift
@@ -4,7 +4,7 @@ extension IssueExtractionFailurePresenter {
     /// Runs a throwing issue-mutation operation, discarding any return value on success
     /// (the mutation controllers return `@discardableResult Bool`). On failure delegates
     /// to `presentFailure(error)`. Bridges the three do/catch delegators in
-    /// `AppState+IssueMutation.swift` (#578).
+    /// `AppState+IssueExtraction.swift` (#578, renamed in #597).
     func attempt<T>(_ operation: () throws -> T) {
         do {
             _ = try operation()

--- a/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
+++ b/Tests/BugNarratorTests/IssueExtractionControllerTests.swift
@@ -74,8 +74,8 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "post_transcription")
     }
 
-    func testIssueMutationFailurePresenterNormalizesStorageFailure() {
-        let harness = makeIssueMutationFailurePresenter()
+    func testIssueExtractionFailurePresenterNormalizesStorageFailure() {
+        let harness = makeIssueExtractionFailurePresenter()
         let error = NSError(
             domain: "BugNarratorTests",
             code: 1,
@@ -88,12 +88,12 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(harness.presentationState.status, .error(expectedError.userMessage))
         XCTAssertEqual(harness.presentationState.currentError, expectedError)
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
-        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "session_library")
+        XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.metadata["operation"], "issue_extraction")
     }
 
-    func testIssueMutationFailurePresenterRunsCleanupHookOnFailure() {
+    func testIssueExtractionFailurePresenterRunsCleanupHookOnFailure() {
         var cleanupCallCount = 0
-        let harness = makeIssueMutationFailurePresenter(
+        let harness = makeIssueExtractionFailurePresenter(
             prepareErrorPresentationSideEffects: { cleanupCallCount += 1 }
         )
 
@@ -231,7 +231,7 @@ final class IssueExtractionControllerTests: XCTestCase {
     // MARK: - attempt(_:) helper (#578)
 
     func testAttemptDiscardsSuccessResultAndSkipsPresentFailure() {
-        let harness = makeIssueMutationFailurePresenter()
+        let harness = makeIssueExtractionFailurePresenter()
 
         harness.presenter.attempt { true }
 
@@ -240,7 +240,7 @@ final class IssueExtractionControllerTests: XCTestCase {
     }
 
     func testAttemptWithVoidOperationRunsAndSkipsPresentFailure() {
-        let harness = makeIssueMutationFailurePresenter()
+        let harness = makeIssueExtractionFailurePresenter()
         var ran = false
 
         harness.presenter.attempt { () -> Void in ran = true }
@@ -251,7 +251,7 @@ final class IssueExtractionControllerTests: XCTestCase {
     }
 
     func testAttemptDelegatesThrownErrorToPresentFailure() {
-        let harness = makeIssueMutationFailurePresenter()
+        let harness = makeIssueExtractionFailurePresenter()
         let error = NSError(
             domain: "BugNarratorTests",
             code: 9,
@@ -264,17 +264,17 @@ final class IssueExtractionControllerTests: XCTestCase {
         XCTAssertEqual(harness.telemetryRecorder.recordedEvents.first?.name, "app_error")
     }
 
-    private func makeIssueMutationFailurePresenter(
+    private func makeIssueExtractionFailurePresenter(
         status: AppStatus = .idle(),
         prepareErrorPresentationSideEffects: @escaping () -> Void = {}
     ) -> (
-        presenter: IssueMutationFailurePresenter,
+        presenter: IssueExtractionFailurePresenter,
         presentationState: AppPresentationState,
         telemetryRecorder: MockOperationalTelemetryRecorder
     ) {
         let presentationState = AppPresentationState(status: status)
         let telemetryRecorder = MockOperationalTelemetryRecorder()
-        let presenter = IssueMutationFailurePresenter(
+        let presenter = IssueExtractionFailurePresenter(
             errorPresenter: AppErrorPresenter(
                 presentationState: presentationState,
                 telemetryRecorder: telemetryRecorder


### PR DESCRIPTION
Closes #599.

## Rename (per #597 review 28)

- Type: `IssueMutationFailurePresenter` → `IssueExtractionFailurePresenter`
- Property: `issueMutationFailurePresenter` → `issueExtractionFailurePresenter`
- File: `IssueMutationFailurePresenter+Attempt.swift` → `IssueExtractionFailurePresenter+Attempt.swift` (via `git mv`, blame preserved)

Rationale: matches `AppState+IssueExtraction` extension (renamed in #597) — the presenter serves the issue-extraction domain (mutations + state observation), not just mutations.

## Label bug fix (per #578 review)

`IssueExtractionFailurePresenter.presentFailure` was reporting failures under `operation: .sessionLibrary` — wrong: these aren't session-library operations. Added `.issueExtraction = "issue_extraction"` to `AppErrorOperation` and updated the call site.

## ⚠️ Behavioral change — telemetry value

The emitted `AppError` telemetry event's `metadata["operation"]` value changes for the 3 issue-mutation failure call sites (`updateExtractedIssue`, `setIssueSelection`, `setAllIssuesSelected`) from `"session_library"` → `"issue_extraction"`. bug-narrator is a local Mac app with no external analytics aggregation, so this is a safe change — but future contributors joining historical vs new events on the operation label will need to remap for issue-mutation failures pre-vs-post this PR.

## Test plan
- [x] BugNarratorTests: 667 passing (unchanged)
- [x] Rename completeness: `rg 'IssueMutation'` returned 1 stringly-typed straggler in the +Attempt.swift doc comment — fixed in-PR
- [x] Telemetry emits `"issue_extraction"` instead of `"session_library"` for issue-mutation failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)