### PR TITLE
refactor: absorb 9 trackerIntegration computed properties into AppState+TrackerIntegration (#607, #601 slice A)

### DIFF
--- a/Sources/BugNarrator/AppState+TrackerIntegration.swift
+++ b/Sources/BugNarrator/AppState+TrackerIntegration.swift
@@ -28,4 +28,40 @@ extension AppState {
     func loadJiraIssueTypes(forProjectID projectID: String) async {
         await trackerIntegration.loadJiraIssueTypes(forProjectID: projectID)
     }
+
+    var gitHubValidationState: APIKeyValidationState {
+        trackerIntegration.gitHubValidationState
+    }
+
+    var jiraValidationState: APIKeyValidationState {
+        trackerIntegration.jiraValidationState
+    }
+
+    var gitHubRepositories: [GitHubRepositoryOption] {
+        trackerIntegration.gitHubRepositories
+    }
+
+    var isLoadingGitHubRepositories: Bool {
+        trackerIntegration.isLoadingGitHubRepositories
+    }
+
+    var jiraProjects: [JiraProjectOption] {
+        trackerIntegration.jiraProjects
+    }
+
+    var jiraIssueTypes: [JiraIssueTypeOption] {
+        trackerIntegration.jiraIssueTypes
+    }
+
+    var isLoadingJiraIssueTypes: Bool {
+        trackerIntegration.isLoadingJiraIssueTypes
+    }
+
+    var jiraProjectMetadataIsStale: Bool {
+        trackerIntegration.jiraProjectMetadataIsStale
+    }
+
+    var jiraIssueTypeMetadataIsStale: Bool {
+        trackerIntegration.jiraIssueTypeMetadataIsStale
+    }
 }

--- a/Sources/BugNarrator/AppState+TrackerIntegration.swift
+++ b/Sources/BugNarrator/AppState+TrackerIntegration.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension AppState {
+    // MARK: - Methods
+
     func jiraIssueTypes(for target: JiraIssueExportTarget) -> [JiraIssueTypeOption] {
         trackerIntegration.jiraIssueTypes(for: target)
     }
@@ -28,6 +30,8 @@ extension AppState {
     func loadJiraIssueTypes(forProjectID projectID: String) async {
         await trackerIntegration.loadJiraIssueTypes(forProjectID: projectID)
     }
+
+    // MARK: - Computed properties
 
     var gitHubValidationState: APIKeyValidationState {
         trackerIntegration.gitHubValidationState

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -116,44 +116,8 @@ final class AppState: ObservableObject {
         transcriptionRecovery.retryingSessionID
     }
 
-    var gitHubValidationState: APIKeyValidationState {
-        trackerIntegration.gitHubValidationState
-    }
-
-    var jiraValidationState: APIKeyValidationState {
-        trackerIntegration.jiraValidationState
-    }
-
     var apiKeyValidationState: APIKeyValidationState {
         aiProviderSettings.apiKeyValidationState
-    }
-
-    var gitHubRepositories: [GitHubRepositoryOption] {
-        trackerIntegration.gitHubRepositories
-    }
-
-    var isLoadingGitHubRepositories: Bool {
-        trackerIntegration.isLoadingGitHubRepositories
-    }
-
-    var jiraProjects: [JiraProjectOption] {
-        trackerIntegration.jiraProjects
-    }
-
-    var jiraIssueTypes: [JiraIssueTypeOption] {
-        trackerIntegration.jiraIssueTypes
-    }
-
-    var isLoadingJiraIssueTypes: Bool {
-        trackerIntegration.isLoadingJiraIssueTypes
-    }
-
-    var jiraProjectMetadataIsStale: Bool {
-        trackerIntegration.jiraProjectMetadataIsStale
-    }
-
-    var jiraIssueTypeMetadataIsStale: Bool {
-        trackerIntegration.jiraIssueTypeMetadataIsStale
     }
 
     convenience init(


### PR DESCRIPTION
Closes #607. First slice of #601.

## Summary

Absorbs 9 single-expression computed-property delegators for `trackerIntegration` into `AppState+TrackerIntegration.swift`. Same-collaborator absorption, no new file needed.

Non-adjacent extraction — 2 blocks separated by `apiKeyValidationState` (different collaborator, stays for slice B).

Byte-identical moves; SHAs verified against origin/main:
- Block A (2 validation props, lines 119-125): `f8fcce4f...`
- Block B (7 tracker props, lines 131-157): `eea27faf...`

## Delegator-vs-orchestrator test

All 9 pass: single-expression body, no args, no branching, no @Published mutation. First precedent-setting slice for computed properties in existing extensions — see #601's design comment for rationale.

## Test plan
- [x] BugNarratorTests: 667 passing (unchanged)
- [x] Byte-diff per block against `origin/main`
- [x] SwiftUI observation preserved (grep confirmed direct-read access pattern, not $binding)

## Follow-up slices (per #601 inventory)
- Slice B: `apiKeyValidationState` → +AIProviderCredential (1 property)
- Slice C: sessionLibrary get/set pairs → +SessionLibrary (2 props)
- Slices D-I: presentationState, issueExportController, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)