### PR TITLE
refactor: absorb apiKeyValidationState into AppState+AIProviderCredential (#609, #601 slice B)

### DIFF
--- a/Sources/BugNarrator/AppState+AIProviderCredential.swift
+++ b/Sources/BugNarrator/AppState+AIProviderCredential.swift
@@ -1,11 +1,19 @@
 import Foundation
 
 extension AppState {
+    // MARK: - Methods
+
     func validateAPIKey() async {
         await aiProviderSettings.validateConnection()
     }
 
     func removeAPIKey() {
         aiProviderSettings.removeCredential()
+    }
+
+    // MARK: - Computed properties
+
+    var apiKeyValidationState: APIKeyValidationState {
+        aiProviderSettings.apiKeyValidationState
     }
 }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -116,10 +116,6 @@ final class AppState: ObservableObject {
         transcriptionRecovery.retryingSessionID
     }
 
-    var apiKeyValidationState: APIKeyValidationState {
-        aiProviderSettings.apiKeyValidationState
-    }
-
     convenience init(
         settingsStore: SettingsStore,
         transcriptStore: TranscriptStore,


### PR DESCRIPTION
Closes #609. Second slice of #601.

## Summary

Absorbs `apiKeyValidationState` computed-property delegator into `AppState+AIProviderCredential.swift`. Completes the 3-member `aiProviderSettings` domain (2 methods + 1 property).

Uses the `// MARK: - Methods` / `// MARK: - Computed properties` separator convention established in PR #608 review 34.

Byte-identical move; SHA `85e22e64...` verified against `origin/main` lines 119-121.

## Safety checklist (from PR #608 review 34)
- [x] Delegator test passes (single-expression getter, no side effects, no branching)
- [x] `$binding` sanity check: `rg '$appState\.apiKeyValidationState' Sources/` returned zero
- [x] Observation forwarding preserved (AppState.objectWillChange fed by objectChangeForwarder in class-body init — file location doesn't matter)
- [x] Green build + green tests: 667 passing

## Follow-up
- Slice C: sessionLibrary get/set pairs (currentTranscript, selectedTranscriptID)
- Slices D-I per #601 inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)