### PR TITLE
refactor: absorb sessionLibrary get/set pairs into AppState+SessionLibrary (#611, #601 slice C)

### DIFF
--- a/Sources/BugNarrator/AppState+SessionLibrary.swift
+++ b/Sources/BugNarrator/AppState+SessionLibrary.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension AppState {
+    // MARK: - Methods
+
     func copyDisplayedTranscript() {
         sessionLibraryStatusPresenter.presentDisplayedTranscriptCopyResult(sessionLibrary.copyDisplayedTranscript())
     }
@@ -24,5 +26,17 @@ extension AppState {
             { try sessionLibrary.deleteSessions(withIDs: ids) },
             success: { sessionLibraryStatusPresenter.presentDeletedCount($0) }
         )
+    }
+
+    // MARK: - Computed properties
+
+    var currentTranscript: TranscriptSession? {
+        get { sessionLibrary.currentTranscript }
+        set { sessionLibrary.currentTranscript = newValue }
+    }
+
+    var selectedTranscriptID: UUID? {
+        get { sessionLibrary.selectedTranscriptID }
+        set { sessionLibrary.selectedTranscriptID = newValue }
     }
 }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -102,16 +102,6 @@ final class AppState: ObservableObject {
         presentationState.transientToast
     }
 
-    var currentTranscript: TranscriptSession? {
-        get { sessionLibrary.currentTranscript }
-        set { sessionLibrary.currentTranscript = newValue }
-    }
-
-    var selectedTranscriptID: UUID? {
-        get { sessionLibrary.selectedTranscriptID }
-        set { sessionLibrary.selectedTranscriptID = newValue }
-    }
-
     var retryingSessionID: UUID? {
         transcriptionRecovery.retryingSessionID
     }


### PR DESCRIPTION
Closes #611. Third slice of #601. First slice with get/set pairs.

## Summary

Absorbs 2 sessionLibrary get/set property pairs (`currentTranscript`, `selectedTranscriptID`) into `AppState+SessionLibrary.swift`. Byte-identical move.

SHA `9e3c6327...` verified against `origin/main` lines 105-113.

## Safety checklist (per #601 epic, PR #608 review 34)
- [x] Delegator test (get/set variant): both getter AND setter pass for each pair — single-expression, no side effects
- [x] `$binding` sanity check: `rg '$appState\.(currentTranscript|selectedTranscriptID)' Sources/` returned zero
- [x] Observation forwarding preserved
- [x] Green tests: 667

Uses `// MARK: - Methods` / `// MARK: - Computed properties` separators.

## Precedent-setting

First slice with get/set pairs. Establishes that the delegator test applies to both getter and setter independently — both must pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)