### PR TITLE
refactor: extract AppState+PresentationState with 3 computed properties (#612, #601 slice D)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */; };
 		3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */; };
 		40D75D2D2C83EE58CBB45F6B /* BugNarratorLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */; };
+		4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53226A9282239858514440C /* AppState+PresentationState.swift */; };
 		456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */; };
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
@@ -447,6 +448,7 @@
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
 		C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSharedHelpers.swift; sourceTree = "<group>"; };
 		C38FE78312021B0A9C7DEBD0 /* UtilityTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTestSupport.swift; sourceTree = "<group>"; };
+		C53226A9282239858514440C /* AppState+PresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PresentationState.swift"; sourceTree = "<group>"; };
 		C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
 		C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsServiceTests.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */,
 				776E95F5977423452961A52B /* AppState+IssueExportQueries.swift */,
 				77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */,
+				C53226A9282239858514440C /* AppState+PresentationState.swift */,
 				6161AB93D74FD6A2471534C5 /* AppState+SessionLibrary.swift */,
 				3E7CA92ED5A94500B96290D0 /* AppState+SupportNavigation.swift */,
 				B486B153518EB9E1BBC08F17 /* AppState+SystemActions.swift */,
@@ -1098,6 +1101,7 @@
 				B697C4571507A5D3C6AA0DD4 /* AppState+FileRevealActions.swift in Sources */,
 				1BCD3E21C690E06B00319440 /* AppState+IssueExportQueries.swift in Sources */,
 				6B52833F68E7F99EE7D2FE07 /* AppState+IssueExtraction.swift in Sources */,
+				4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */,
 				04D66F9B419137D1948D12A4 /* AppState+SessionLibrary.swift in Sources */,
 				AD5CE09A6639155D68E44618 /* AppState+SupportNavigation.swift in Sources */,
 				600F14353C222547C1284413 /* AppState+SystemActions.swift in Sources */,

--- a/Sources/BugNarrator/AppState+PresentationState.swift
+++ b/Sources/BugNarrator/AppState+PresentationState.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension AppState {
+    var status: AppStatus {
+        presentationState.status
+    }
+
+    var currentError: AppError? {
+        presentationState.currentError
+    }
+
+    var transientToast: TransientToast? {
+        presentationState.transientToast
+    }
+}

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -78,14 +78,6 @@ final class AppState: ObservableObject {
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
-    var status: AppStatus {
-        presentationState.status
-    }
-
-    var currentError: AppError? {
-        presentationState.currentError
-    }
-
     var exportHistory: [ExportReceipt] {
         exportHistoryController.exportHistory
     }
@@ -96,10 +88,6 @@ final class AppState: ObservableObject {
 
     var pendingExportReview: IssueExportReview? {
         issueExportController.pendingExportReview
-    }
-
-    var transientToast: TransientToast? {
-        presentationState.transientToast
     }
 
     var retryingSessionID: UUID? {


### PR DESCRIPTION
Closes #612. Fourth slice of #601.

Creates new `AppState+PresentationState.swift` with 3 computed properties: `status`, `currentError`, `transientToast`.

Non-adjacent extraction (2 blocks separated by exportHistoryController + issueExportController properties that stay for slices E and F).

SHAs: block A (status+currentError) `507be903...`, block B (transientToast) `11def79d...`.

Safety checklist all green. Tests: 667.

Properties-only file (no methods yet) — future presentationState methods land here per intent-first + same-collaborator rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)