### PR TITLE
refactor: absorb 2 issueExportController properties into AppState+IssueExportQueries (#614, #601 slice F)

### DIFF
--- a/Sources/BugNarrator/AppState+IssueExportQueries.swift
+++ b/Sources/BugNarrator/AppState+IssueExportQueries.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension AppState {
+    // MARK: - Methods
+
     func canExportIssues(from session: TranscriptSession, to destination: ExportDestination) -> Bool {
         issueExportController.canExportIssues(from: session, to: destination, statusPhase: status.phase)
     }
@@ -27,5 +29,15 @@ extension AppState {
 
     func isExporting(to destination: ExportDestination) -> Bool {
         issueExportController.isExporting(to: destination)
+    }
+
+    // MARK: - Computed properties
+
+    var exportDestinationInProgress: ExportDestination? {
+        issueExportController.exportDestinationInProgress
+    }
+
+    var pendingExportReview: IssueExportReview? {
+        issueExportController.pendingExportReview
     }
 }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -78,14 +78,6 @@ final class AppState: ObservableObject {
     private let transcriptionLogger = DiagnosticsLogger(category: .transcription)
     private let settingsLogger = DiagnosticsLogger(category: .settings)
 
-    var exportDestinationInProgress: ExportDestination? {
-        issueExportController.exportDestinationInProgress
-    }
-
-    var pendingExportReview: IssueExportReview? {
-        issueExportController.pendingExportReview
-    }
-
     var retryingSessionID: UUID? {
         transcriptionRecovery.retryingSessionID
     }


### PR DESCRIPTION
Closes #614. Sixth slice of #601.

Absorbs `exportDestinationInProgress` + `pendingExportReview` into existing `AppState+IssueExportQueries.swift`. Same-collaborator absorb into an already-7-method extension.

SHA `92b1f45c...` verified against origin/main lines 93-99. Safety checklist all green. Tests: 667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)