### PR TITLE
refactor: absorb 2 more sessionLibrary properties into +SessionLibrary (#623, #601 slice J)

### DIFF
--- a/Sources/BugNarrator/AppState+SessionLibrary.swift
+++ b/Sources/BugNarrator/AppState+SessionLibrary.swift
@@ -39,4 +39,12 @@ extension AppState {
         get { sessionLibrary.selectedTranscriptID }
         set { sessionLibrary.selectedTranscriptID = newValue }
     }
+
+    var displayedTranscript: TranscriptSession? {
+        sessionLibrary.displayedTranscript
+    }
+
+    var currentTranscriptIsPersisted: Bool {
+        sessionLibrary.currentTranscriptIsPersisted
+    }
 }

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -560,14 +560,6 @@ final class AppState: ObservableObject {
         status.phase == .recording && activeRecordingSession?.sessionID == sessionID
     }
 
-    var displayedTranscript: TranscriptSession? {
-        sessionLibrary.displayedTranscript
-    }
-
-    var currentTranscriptIsPersisted: Bool {
-        sessionLibrary.currentTranscriptIsPersisted
-    }
-
     var needsAPIKeySetup: Bool {
         settingsStore.aiProviderCompatibilityIssue != nil ||
             (settingsStore.aiProvider.requiresAPIKey && !settingsStore.hasUsableAIProviderCredential)


### PR DESCRIPTION
Closes #623. Slice J of #601.

Absorbs `displayedTranscript` + `currentTranscriptIsPersisted` into existing `AppState+SessionLibrary.swift`. Completes sessionLibrary domain coverage (4 methods + 4 computed properties).

SHA `cb1dc277...` verified. Tests: 667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)