### PR TITLE
refactor: extract AppState+PermissionRecovery (4 delegators) (#626, #601 slice K)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		683F3BD6F8192C53766A10DC /* TranscriptExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */; };
 		6893046A1554A3B15625C96A /* AppState+RecordingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F0A81E02972573D2556B85 /* AppState+RecordingTimer.swift */; };
 		68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */; };
+		69F0F76E67B312F356DE7354 /* AppState+PermissionRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */; };
 		6B52833F68E7F99EE7D2FE07 /* AppState+IssueExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */; };
 		6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */; };
 		6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */; };
@@ -412,6 +413,7 @@
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProductInfoView.swift; sourceTree = "<group>"; };
 		90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
+		92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PermissionRecovery.swift"; sourceTree = "<group>"; };
 		92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		94052C02271A22E78259D71B /* ScreenshotCaptureServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureServiceTests.swift; sourceTree = "<group>"; };
 		97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporter.swift; sourceTree = "<group>"; };
@@ -691,6 +693,7 @@
 				0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */,
 				776E95F5977423452961A52B /* AppState+IssueExportQueries.swift */,
 				77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */,
+				92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */,
 				C53226A9282239858514440C /* AppState+PresentationState.swift */,
 				64F0A81E02972573D2556B85 /* AppState+RecordingTimer.swift */,
 				538AED509468E82A6BABF577 /* AppState+ScreenshotCapture.swift */,
@@ -1111,6 +1114,7 @@
 				B697C4571507A5D3C6AA0DD4 /* AppState+FileRevealActions.swift in Sources */,
 				1BCD3E21C690E06B00319440 /* AppState+IssueExportQueries.swift in Sources */,
 				6B52833F68E7F99EE7D2FE07 /* AppState+IssueExtraction.swift in Sources */,
+				69F0F76E67B312F356DE7354 /* AppState+PermissionRecovery.swift in Sources */,
 				4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */,
 				6893046A1554A3B15625C96A /* AppState+RecordingTimer.swift in Sources */,
 				B390350FDD265690EA647D2E /* AppState+ScreenshotCapture.swift in Sources */,

--- a/Sources/BugNarrator/AppState+PermissionRecovery.swift
+++ b/Sources/BugNarrator/AppState+PermissionRecovery.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension AppState {
+    // MARK: - Methods
+
+    func refreshPermissionRecoveryState() {
+        permissionRecoveryStatusPresenter.present(
+            permissionRecoveryController.refreshRecoveryState(
+                currentError: currentError,
+                statusPhase: status.phase
+            )
+        )
+    }
+
+    // MARK: - Computed properties
+
+    var microphoneRecoveryGuidance: String {
+        microphoneRecoveryGuidanceDetails.message
+    }
+
+    var microphoneRecoveryLocalTestingNote: String? {
+        microphoneRecoveryGuidanceDetails.localTestingNote
+    }
+
+    private var microphoneRecoveryGuidanceDetails: MicrophoneRecoveryGuidance {
+        permissionRecoveryController.microphoneRecoveryGuidance(currentError: currentError)
+    }
+}

--- a/Sources/BugNarrator/AppState.swift
+++ b/Sources/BugNarrator/AppState.swift
@@ -561,14 +561,6 @@ final class AppState: ObservableObject {
         "Open the recording controls window or use the global hotkeys while you keep testing."
     }
 
-    var microphoneRecoveryGuidance: String {
-        microphoneRecoveryGuidanceDetails.message
-    }
-
-    var microphoneRecoveryLocalTestingNote: String? {
-        microphoneRecoveryGuidanceDetails.localTestingNote
-    }
-
     var debugInfoSnapshot: DebugInfoSnapshot {
         supportDataController.debugInfoSnapshot(sessionID: currentDebugSessionID)
     }
@@ -580,15 +572,6 @@ final class AppState: ObservableObject {
     var activeRecordingSession: RecordingSessionDraft? {
         recordingSessionController.activeRecordingSession
     }
-    func refreshPermissionRecoveryState() {
-        permissionRecoveryStatusPresenter.present(
-            permissionRecoveryController.refreshRecoveryState(
-                currentError: currentError,
-                statusPhase: status.phase
-            )
-        )
-    }
-
     func startSession() async {
         recordingLogger.info(.sessionStartRequested, "A feedback session start was requested.")
 
@@ -1086,9 +1069,5 @@ final class AppState: ObservableObject {
             status: status,
             currentError: currentError
         )
-    }
-
-    private var microphoneRecoveryGuidanceDetails: MicrophoneRecoveryGuidance {
-        permissionRecoveryController.microphoneRecoveryGuidance(currentError: currentError)
     }
 }


### PR DESCRIPTION
Closes #626. Slice K of #601.

Creates new `AppState+PermissionRecovery.swift` with 4 permissionRecoveryController delegators (1 method + 2 computed properties + 1 supporting private helper).

## Members
- `refreshPermissionRecoveryState()` — method
- `microphoneRecoveryGuidance` — computed property
- `microphoneRecoveryLocalTestingNote` — computed property
- `microphoneRecoveryGuidanceDetails` — private helper (stays private within new file)

## Key insight

The private helper stays private in the new file — Swift's file-scope private semantics ensure it's accessible only to the 2 public delegators in the same file. No visibility widen needed. This is the first #601 slice with a private-helper-supported delegator pattern.

## SHAs
- microphoneRecovery* properties: `49c6602c...`
- refreshPermissionRecoveryState: `e073c11a...`
- private helper: `720bab14...`

## Test
BugNarratorTests: 667 (unchanged). Safety checklist green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)