### PR TITLE
refactor: extract SessionRow into dedicated view file (#628, #401 slice a)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		EB5DAB7367CC0E4D69D936B6 /* IssueExtractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FD7C5D1FD4184BCC0CC331 /* IssueExtractionController.swift */; };
 		ED980E311190B73E6EB40DE5 /* RecordingTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1E780B30B585D475E33C82 /* RecordingTestSupport.swift */; };
 		EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60B609057DB2068E0F4FD292 /* AppSupportLocation.swift */; };
+		F0C234F3BD7753A09B98A332 /* SessionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE629842187FE002FE2DE05D /* SessionRow.swift */; };
 		F1871DA7FB3E89FB5AE6C63F /* SessionArtifactsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */; };
 		F6A698B3E54CEF73047BC042 /* SessionMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */; };
 		F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */; };
@@ -490,6 +491,7 @@
 		EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionService.swift; sourceTree = "<group>"; };
 		EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFindingTests.swift; sourceTree = "<group>"; };
 		EE21C0A922E1CA3CF2F1B714 /* MenuBarStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarStatusPresentationTests.swift; sourceTree = "<group>"; };
+		EE629842187FE002FE2DE05D /* SessionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRow.swift; sourceTree = "<group>"; };
 		EE77402A6284B705F5F4984A /* IssueExtractionResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionResponseParser.swift; sourceTree = "<group>"; };
 		EE77CF3D9076FC05278390A6 /* AppPresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPresentationState.swift; sourceTree = "<group>"; };
 		EECE1E25C090853C38690595 /* SupportDataController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataController.swift; sourceTree = "<group>"; };
@@ -859,6 +861,7 @@
 			children = (
 				6ED395C71ADE17A2DFA5BD21 /* ExportReviewSheet.swift */,
 				16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */,
+				EE629842187FE002FE2DE05D /* SessionRow.swift */,
 				C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */,
 			);
 			path = Transcript;
@@ -1205,6 +1208,7 @@
 				CEDAB8D8BF65455F21123B22 /* SessionLibraryController.swift in Sources */,
 				CD22DEA9761A7BAD23814D52 /* SessionLibraryStatusPresenter+Attempt.swift in Sources */,
 				6DDE29389B4D58A9BD6CD115 /* SessionMarker.swift in Sources */,
+				F0C234F3BD7753A09B98A332 /* SessionRow.swift in Sources */,
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,
 				1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */,
 				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,

--- a/Sources/BugNarrator/Views/Transcript/SessionRow.swift
+++ b/Sources/BugNarrator/Views/Transcript/SessionRow.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct SessionRow: View {
+    let entry: SessionLibraryEntry
+    @ObservedObject var appState: AppState
+    @ObservedObject var transcriptStore: TranscriptStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.title)
+                        .font(.headline)
+                        .lineLimit(2)
+
+                    Text(entry.createdAt.formatted(date: .abbreviated, time: .shortened))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 6) {
+                    if entry.isPendingTranscription {
+                        Text("Retry Needed")
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 4)
+                            .background(.yellow.opacity(0.16), in: Capsule())
+                    }
+
+                    if isUnsaved(entry.id) {
+                        Text("Unsaved")
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 4)
+                            .background(.orange.opacity(0.14), in: Capsule())
+                    }
+                }
+            }
+
+            HStack(spacing: 8) {
+                metricChip(systemImage: "clock", title: ElapsedTimeFormatter.string(from: entry.duration))
+
+                if entry.screenshotCount > 0 {
+                    metricChip(systemImage: "photo", title: "\(entry.screenshotCount)")
+                }
+
+                if entry.issueCount > 0 {
+                    metricChip(systemImage: "checklist", title: "\(entry.issueCount)")
+                }
+
+                Spacer()
+            }
+
+            Text(sessionPreview(for: entry))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .lineLimit(3)
+
+            if !entry.summaryText.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Review Summary")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+
+                    Text(entry.summaryText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.18), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(entry.title)
+        .accessibilityValue(sessionRowAccessibilitySummary(for: entry))
+        .accessibilityHint("Selects this session and updates the detail pane.")
+    }
+
+    private func metricChip(systemImage: String, title: String) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(0.45), in: Capsule())
+    }
+
+    private func isUnsaved(_ sessionID: UUID) -> Bool {
+        appState.currentTranscript?.id == sessionID && !appState.currentTranscriptIsPersisted
+    }
+
+    private func sessionRowAccessibilitySummary(for entry: SessionLibraryEntry) -> String {
+        var components = [
+            entry.createdAt.formatted(date: .abbreviated, time: .shortened),
+            "Duration \(ElapsedTimeFormatter.string(from: entry.duration))"
+        ]
+
+        if entry.screenshotCount > 0 {
+            components.append("\(entry.screenshotCount) screenshot\(entry.screenshotCount == 1 ? "" : "s")")
+        }
+
+        if entry.issueCount > 0 {
+            components.append("\(entry.issueCount) extracted issue\(entry.issueCount == 1 ? "" : "s")")
+        }
+
+        if entry.isPendingTranscription {
+            components.append("Retry needed before transcription is complete")
+        }
+
+        if isUnsaved(entry.id) {
+            components.append("Unsaved")
+        }
+
+        let preview = sessionPreview(for: entry).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !preview.isEmpty {
+            components.append(preview)
+        }
+
+        return components.joined(separator: ". ")
+    }
+
+    private func sessionPreview(for entry: SessionLibraryEntry) -> String {
+        guard entry.isPendingTranscription,
+              let session = transcriptStore.session(with: entry.id) else {
+            return entry.preview
+        }
+
+        return session.preview(for: appState.settingsStore.aiProvider)
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -150,7 +150,7 @@ struct TranscriptView: View {
             } else {
                 List(selection: selectionBinding) {
                     ForEach(filteredEntries) { entry in
-                        sessionRow(entry: entry)
+                        SessionRow(entry: entry, appState: appState, transcriptStore: transcriptStore)
                             .tag(Optional(entry.id))
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
@@ -568,88 +568,6 @@ struct TranscriptView: View {
 
         pendingDeletionIDs = ids
         showDeletionConfirmation = true
-    }
-
-    private func sessionRow(entry: SessionLibraryEntry) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(entry.title)
-                        .font(.headline)
-                        .lineLimit(2)
-
-                    Text(entry.createdAt.formatted(date: .abbreviated, time: .shortened))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                HStack(spacing: 6) {
-                    if entry.isPendingTranscription {
-                        Text("Retry Needed")
-                            .font(.caption2.weight(.semibold))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 4)
-                            .background(.yellow.opacity(0.16), in: Capsule())
-                    }
-
-                    if isUnsaved(entry.id) {
-                        Text("Unsaved")
-                            .font(.caption2.weight(.semibold))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 4)
-                            .background(.orange.opacity(0.14), in: Capsule())
-                    }
-                }
-            }
-
-            HStack(spacing: 8) {
-                metricChip(systemImage: "clock", title: ElapsedTimeFormatter.string(from: entry.duration))
-
-                if entry.screenshotCount > 0 {
-                    metricChip(systemImage: "photo", title: "\(entry.screenshotCount)")
-                }
-
-                if entry.issueCount > 0 {
-                    metricChip(systemImage: "checklist", title: "\(entry.issueCount)")
-                }
-
-                Spacer()
-            }
-
-            Text(sessionPreview(for: entry))
-                .font(.subheadline)
-                .foregroundStyle(.primary)
-                .lineLimit(3)
-
-            if !entry.summaryText.isEmpty {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Review Summary")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-
-                    Text(entry.summaryText)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-            }
-        }
-        .padding(12)
-        .background(.quaternary.opacity(0.18), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(entry.title)
-        .accessibilityValue(sessionRowAccessibilitySummary(for: entry))
-        .accessibilityHint("Selects this session and updates the detail pane.")
-    }
-
-    private func metricChip(systemImage: String, title: String) -> some View {
-        Label(title, systemImage: systemImage)
-            .font(.caption)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(.quaternary.opacity(0.45), in: Capsule())
     }
 
     private func isUnsaved(_ sessionID: UUID) -> Bool {
@@ -2027,44 +1945,6 @@ struct TranscriptView: View {
         appState.updateExtractedIssue(updatedIssue, in: sessionID)
     }
 
-    private func sessionRowAccessibilitySummary(for entry: SessionLibraryEntry) -> String {
-        var components = [
-            entry.createdAt.formatted(date: .abbreviated, time: .shortened),
-            "Duration \(ElapsedTimeFormatter.string(from: entry.duration))"
-        ]
-
-        if entry.screenshotCount > 0 {
-            components.append("\(entry.screenshotCount) screenshot\(entry.screenshotCount == 1 ? "" : "s")")
-        }
-
-        if entry.issueCount > 0 {
-            components.append("\(entry.issueCount) extracted issue\(entry.issueCount == 1 ? "" : "s")")
-        }
-
-        if entry.isPendingTranscription {
-            components.append("Retry needed before transcription is complete")
-        }
-
-        if isUnsaved(entry.id) {
-            components.append("Unsaved")
-        }
-
-        let preview = sessionPreview(for: entry).trimmingCharacters(in: .whitespacesAndNewlines)
-        if !preview.isEmpty {
-            components.append(preview)
-        }
-
-        return components.joined(separator: ". ")
-    }
-
-    private func sessionPreview(for entry: SessionLibraryEntry) -> String {
-        guard entry.isPendingTranscription,
-              let session = transcriptStore.session(with: entry.id) else {
-            return entry.preview
-        }
-
-        return session.preview(for: appState.settingsStore.aiProvider)
-    }
 
     private var defaultRetryRecoveryMessage: String {
         let provider = appState.settingsStore.aiProvider


### PR DESCRIPTION
Closes #628. First slice of #401 (TranscriptView decomposition).

## Summary

Extracts session list row rendering into a new `SessionRow` view:
- `sessionRow` body (73 lines)
- `metricChip` (7 lines)
- `sessionPreview` (7 lines)
- `sessionRowAccessibilitySummary` (29 lines)
- `isUnsaved` (duplicated — TranscriptView.workspaceActions still calls it)

New file: `Sources/BugNarrator/Views/Transcript/SessionRow.swift`
Signature: `SessionRow(entry, appState, transcriptStore)`

## Test plan
- [x] BugNarratorTests: 667 passing
- [x] Byte-identical view body (moved verbatim)
- [x] Caller updated at TranscriptView.swift:153
- [x] Claude reviewer approved (review 38): observation surface preserved, accessibility chain intact, no @State/@Binding hazards
- [ ] **⚠️ MANUAL SMOKE CHECK REQUIRED before merge**: SwiftUI observation regressions don't surface in unit tests. Render TranscriptView with populated sessions and verify:
  - [ ] Session rows appear with same layout, spacing, chip colors, typography
  - [ ] 'Unsaved' and 'Retry Needed' chips appear on the same entries as pre-move
  - [ ] VoiceOver reads each row's label/value/hint as before
  - [ ] Selecting a row still updates the detail pane

## Follow-up filed
- #634 — absorb `isUnsaved(_:)` into `AppState+SessionLibrary` (removes the 3-line duplication)

Also added a SwiftUI view extraction safety checklist to #401 for slices B-E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)