### PR TITLE
refactor: extract TranscriptionModels.swift (#648 slice A)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		38B00E4AA8B374646877FBFB /* TranscriptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */; };
 		3953183BDA19D90C13449F73 /* NetworkTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00EA3260CCEECB3FB097702 /* NetworkTestSupport.swift */; };
 		3B4F5CCC16AB9837DD0BD0F4 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277DC17D4084F918920CB8C5 /* URLHandler.swift */; };
+		3CA626CA4757EC95AAA8C8CF /* TranscriptionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CE91359103D30C04663766 /* TranscriptionModels.swift */; };
 		3CDB0E66F370246528266E51 /* HotkeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */; };
 		3CE176593C0130AB6B4A12BA /* TranscriptionRecoveryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A31B0939DF668FFC71CD64FD /* TranscriptionRecoveryControllerTests.swift */; };
 		3F4178877259A14D87101CE5 /* TranscriptQualityInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */; };
@@ -405,6 +406,7 @@
 		800BFCC6407B534886C65D77 /* TranscriptionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClient.swift; sourceTree = "<group>"; };
 		811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionService.swift; sourceTree = "<group>"; };
 		820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabelView.swift; sourceTree = "<group>"; };
+		83CE91359103D30C04663766 /* TranscriptionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionModels.swift; sourceTree = "<group>"; };
 		84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
 		8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateIssueExportTests.swift; sourceTree = "<group>"; };
 		84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionServiceTests.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
 				BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */,
 				800BFCC6407B534886C65D77 /* TranscriptionClient.swift */,
+				83CE91359103D30C04663766 /* TranscriptionModels.swift */,
 				2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */,
 				04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */,
 				7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */,
@@ -1260,6 +1263,7 @@
 				A6AF1CAA204EF971F9417E63 /* TranscriptStore.swift in Sources */,
 				29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */,
 				33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */,
+				3CA626CA4757EC95AAA8C8CF /* TranscriptionModels.swift in Sources */,
 				A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */,
 				F715303DE87CE267F3336E39 /* TranscriptionSessionBuilder.swift in Sources */,
 				5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */,

--- a/Sources/BugNarrator/Services/TranscriptionClient.swift
+++ b/Sources/BugNarrator/Services/TranscriptionClient.swift
@@ -1,47 +1,6 @@
 @preconcurrency import AVFoundation
 import Foundation
 
-struct TranscriptionRequest: Sendable {
-    let model: String
-    let languageHint: String?
-    let prompt: String?
-    let apiBaseURL: URL
-
-    init(
-        model: String,
-        languageHint: String?,
-        prompt: String?,
-        apiBaseURL: URL = URL(string: "https://api.openai.com")!
-    ) {
-        self.model = model
-        self.languageHint = languageHint
-        self.prompt = prompt
-        self.apiBaseURL = apiBaseURL
-    }
-}
-
-struct TranscriptionResult: Sendable {
-    let text: String
-    let segments: [TranscriptionSegment]
-    let qualityFindings: [TranscriptQualityFinding]
-
-    init(
-        text: String,
-        segments: [TranscriptionSegment],
-        qualityFindings: [TranscriptQualityFinding] = []
-    ) {
-        self.text = text
-        self.segments = segments
-        self.qualityFindings = qualityFindings
-    }
-}
-
-struct TranscriptionSegment: Decodable, Sendable {
-    let start: Double
-    let end: Double
-    let text: String
-}
-
 struct MultipartFormDataBuilder {
     let boundary: String
     private var body = Data()

--- a/Sources/BugNarrator/Services/TranscriptionModels.swift
+++ b/Sources/BugNarrator/Services/TranscriptionModels.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct TranscriptionRequest: Sendable {
+    let model: String
+    let languageHint: String?
+    let prompt: String?
+    let apiBaseURL: URL
+
+    init(
+        model: String,
+        languageHint: String?,
+        prompt: String?,
+        apiBaseURL: URL = URL(string: "https://api.openai.com")!
+    ) {
+        self.model = model
+        self.languageHint = languageHint
+        self.prompt = prompt
+        self.apiBaseURL = apiBaseURL
+    }
+}
+
+struct TranscriptionResult: Sendable {
+    let text: String
+    let segments: [TranscriptionSegment]
+    let qualityFindings: [TranscriptQualityFinding]
+
+    init(
+        text: String,
+        segments: [TranscriptionSegment],
+        qualityFindings: [TranscriptQualityFinding] = []
+    ) {
+        self.text = text
+        self.segments = segments
+        self.qualityFindings = qualityFindings
+    }
+}
+
+struct TranscriptionSegment: Decodable, Sendable {
+    let start: Double
+    let end: Double
+    let text: String
+}


### PR DESCRIPTION
Closes #648 (partial — slice A only). First slice of TranscriptionClient.swift decomposition.

Extracts 3 model structs (TranscriptionRequest, TranscriptionResult, TranscriptionSegment) into new `TranscriptionModels.swift`.

SHA `32c99bb5...` verified against origin/main lines 4-43. Byte-identical.

TranscriptionClient.swift: 753 → 711 lines.

Tests: 667 (unchanged).

## Follow-up
Remaining slices (MultipartFormDataBuilder, TranscriptionRequestFactory, VerboseTranscriptionResponseParser, TranscriptionAudioChunk + DefaultTranscriptionChunker) — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)