### PR TITLE
refactor: absorb isUnsaved(_:) into AppState+SessionLibrary (#634)

### DIFF
--- a/Sources/BugNarrator/AppState+SessionLibrary.swift
+++ b/Sources/BugNarrator/AppState+SessionLibrary.swift
@@ -28,6 +28,10 @@ extension AppState {
         )
     }
 
+    func isUnsaved(_ sessionID: UUID) -> Bool {
+        currentTranscript?.id == sessionID && !currentTranscriptIsPersisted
+    }
+
     // MARK: - Computed properties
 
     var currentTranscript: TranscriptSession? {

--- a/Sources/BugNarrator/Views/Transcript/SessionRow.swift
+++ b/Sources/BugNarrator/Views/Transcript/SessionRow.swift
@@ -29,7 +29,7 @@ struct SessionRow: View {
                             .background(.yellow.opacity(0.16), in: Capsule())
                     }
 
-                    if isUnsaved(entry.id) {
+                    if appState.isUnsaved(entry.id) {
                         Text("Unsaved")
                             .font(.caption2.weight(.semibold))
                             .padding(.horizontal, 6)
@@ -87,10 +87,6 @@ struct SessionRow: View {
             .background(.quaternary.opacity(0.45), in: Capsule())
     }
 
-    private func isUnsaved(_ sessionID: UUID) -> Bool {
-        appState.currentTranscript?.id == sessionID && !appState.currentTranscriptIsPersisted
-    }
-
     private func sessionRowAccessibilitySummary(for entry: SessionLibraryEntry) -> String {
         var components = [
             entry.createdAt.formatted(date: .abbreviated, time: .shortened),
@@ -109,7 +105,7 @@ struct SessionRow: View {
             components.append("Retry needed before transcription is complete")
         }
 
-        if isUnsaved(entry.id) {
+        if appState.isUnsaved(entry.id) {
             components.append("Unsaved")
         }
 

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -570,10 +570,6 @@ struct TranscriptView: View {
         showDeletionConfirmation = true
     }
 
-    private func isUnsaved(_ sessionID: UUID) -> Bool {
-        appState.currentTranscript?.id == sessionID && !appState.currentTranscriptIsPersisted
-    }
-
     private func transcriptDetail(for session: TranscriptSession) -> some View {
         GeometryReader { proxy in
             ScrollView {
@@ -637,7 +633,7 @@ struct TranscriptView: View {
                         .controlSize(.small)
                     }
                 }
-            } else if isUnsaved(session.id) {
+            } else if appState.isUnsaved(session.id) {
                 HStack(spacing: 10) {
                     Label("Only stored in memory until you save it.", systemImage: "tray")
                         .font(.footnote)


### PR DESCRIPTION
Closes #634. Promotes the 3-line isUnsaved(_:) helper (was duplicated between TranscriptView and SessionRow after #633) to a single method on AppState+SessionLibrary.

Both call sites updated. Tests: 667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)