### PR TITLE
refactor: extract DiagnosticsLogEntry.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0C3B061E5ECAD626CDB83B89 /* ScreenshotTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E849C3E02857E9CF3FDCC39A /* ScreenshotTestSupport.swift */; };
 		0D3E82C811F386795DBE5D82 /* ExportReceiptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */; };
 		0E06D8F0874CB1CBB2FEA135 /* AppState+ExportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7881C3E0425DCA7D35C6C10E /* AppState+ExportReview.swift */; };
+		11935BB2070F2A08AB015BD9 /* DiagnosticsLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
@@ -313,6 +314,7 @@
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntegrationsPanes.swift; sourceTree = "<group>"; };
+		0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLogEntry.swift; sourceTree = "<group>"; };
 		0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FileRevealActions.swift"; sourceTree = "<group>"; };
 		104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportConfig.swift; sourceTree = "<group>"; };
 		1691FC9128F5B3D543C87721 /* ExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestSupport.swift; sourceTree = "<group>"; };
@@ -909,6 +911,7 @@
 				C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */,
 				33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */,
 				2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */,
+				0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */,
 				E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */,
 				4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */,
 				6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */,
@@ -1238,6 +1241,7 @@
 				B53060D07F7F2428BD78E807 /* ClipboardService.swift in Sources */,
 				040E1F8A34C1C16904AB8370 /* DebugBundleExporter.swift in Sources */,
 				977D86FA0E7E2C16A5B41D4D /* DebugSessionContextProvider.swift in Sources */,
+				11935BB2070F2A08AB015BD9 /* DiagnosticsLogEntry.swift in Sources */,
 				15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */,
 				4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */,
 				93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */,

--- a/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
+++ b/Sources/BugNarrator/Utilities/BugNarratorDiagnostics.swift
@@ -1,47 +1,5 @@
 import Foundation
 import OSLog
-struct DiagnosticsLogEntry: Codable, Equatable {
-    let timestamp: Date
-    let level: DiagnosticsLogLevel
-    let category: DiagnosticsLogCategory
-    let event: String
-    let message: String
-    let metadata: [String: String]
-
-    init(
-        timestamp: Date = Date(),
-        level: DiagnosticsLogLevel,
-        category: DiagnosticsLogCategory,
-        event: String,
-        message: String,
-        metadata: [String: String] = [:]
-    ) {
-        self.timestamp = timestamp
-        self.level = level
-        self.category = category
-        self.event = event
-        self.message = message
-        self.metadata = metadata
-    }
-
-    func formattedLine(using formatter: ISO8601DateFormatter = BugNarratorDiagnostics.makeTimestampFormatter()) -> String {
-        let metadataText = metadata
-            .sorted { lhs, rhs in
-                lhs.key < rhs.key
-            }
-            .map { key, value in
-                "\(key)=\(value)"
-            }
-            .joined(separator: " ")
-
-        if metadataText.isEmpty {
-            return "\(formatter.string(from: timestamp)) [\(level.label)] [\(category.rawValue)] \(event) - \(message)"
-        }
-
-        return "\(formatter.string(from: timestamp)) [\(level.label)] [\(category.rawValue)] \(event) - \(message) \(metadataText)"
-    }
-}
-
 actor DiagnosticsLogStore {
     private enum StoragePolicy {
         static let maximumStoredEntries = 500

--- a/Sources/BugNarrator/Utilities/DiagnosticsLogEntry.swift
+++ b/Sources/BugNarrator/Utilities/DiagnosticsLogEntry.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct DiagnosticsLogEntry: Codable, Equatable {
+    let timestamp: Date
+    let level: DiagnosticsLogLevel
+    let category: DiagnosticsLogCategory
+    let event: String
+    let message: String
+    let metadata: [String: String]
+
+    init(
+        timestamp: Date = Date(),
+        level: DiagnosticsLogLevel,
+        category: DiagnosticsLogCategory,
+        event: String,
+        message: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.timestamp = timestamp
+        self.level = level
+        self.category = category
+        self.event = event
+        self.message = message
+        self.metadata = metadata
+    }
+
+    func formattedLine(using formatter: ISO8601DateFormatter = BugNarratorDiagnostics.makeTimestampFormatter()) -> String {
+        let metadataText = metadata
+            .sorted { lhs, rhs in
+                lhs.key < rhs.key
+            }
+            .map { key, value in
+                "\(key)=\(value)"
+            }
+            .joined(separator: " ")
+
+        if metadataText.isEmpty {
+            return "\(formatter.string(from: timestamp)) [\(level.label)] [\(category.rawValue)] \(event) - \(message)"
+        }
+
+        return "\(formatter.string(from: timestamp)) [\(level.label)] [\(category.rawValue)] \(event) - \(message) \(metadataText)"
+    }
+}


### PR DESCRIPTION
Extracts DiagnosticsLogEntry struct (41 lines) into own file. Tests: 667.