### PR TITLE
refactor: extract TrackerExportRetryTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		DA404465664E7425E991C177 /* SystemAudioAggregateDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F967DF7EA1081CFFF0E55EE /* SystemAudioAggregateDeviceTests.swift */; };
 		DABA5D4856C56172E1DFB2FF /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */; };
 		DB44B00A8FFA358E3239DA48 /* RecordingAudioSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A79F0CD44463306F35C431 /* RecordingAudioSourceTests.swift */; };
+		DBFA5905D305404FAD17EC5E /* TrackerExportRetryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */; };
 		DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */; };
 		DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */; };
 		E1B0000CAD83CD900AA29EAD /* AppSupportLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */; };
@@ -446,6 +447,7 @@
 		70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryController.swift; sourceTree = "<group>"; };
 		7322F6B6A58542DEDFC76CCA /* ExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportService.swift; sourceTree = "<group>"; };
 		73E95A3A144B00D27DA3615A /* IssueExtractionRequestBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBudget.swift; sourceTree = "<group>"; };
+		74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportRetryTypes.swift; sourceTree = "<group>"; };
 		74765CEA41F7FB191B51D03D /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		74F12C05B57E38EDFDCEEEEA /* IssueCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCore.swift; sourceTree = "<group>"; };
 		7539AEF1F536E7EDB2047D7D /* AudioRecorderTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderTypes.swift; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
+				74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */,
 				70541D070FF81D54D6559524 /* TrackerExportSettingsStore.swift */,
 				3B66F6ADC8EDC6AA0A768F30 /* TrackerExportSupport.swift */,
 				48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */,
@@ -1399,6 +1402,7 @@
 				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				ABA48997F0B07377178EDEE0 /* SystemAudioTapSession.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
+				DBFA5905D305404FAD17EC5E /* TrackerExportRetryTypes.swift in Sources */,
 				289E65529C0ED7D189FCCFFF /* TrackerExportSettingsStore.swift in Sources */,
 				E9677D3D9F4E24466B75580F /* TrackerExportSupport.swift in Sources */,
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,

--- a/Sources/BugNarrator/Services/TrackerExportRetryTypes.swift
+++ b/Sources/BugNarrator/Services/TrackerExportRetryTypes.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+
+/// Bounds retry of a single per-issue tracker create. POST issue-creation is not
+/// blindly idempotent, so retries are only safe because the export loop reconciles
+/// by the `bugnarrator-export-id` marker before re-creating (#502).
+struct ExportRetryConfiguration: Sendable {
+    let maxAttempts: Int
+    let baseDelay: Duration
+
+    static let `default` = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .milliseconds(500))
+    /// No real backoff — for tests that simulate transient-then-success.
+    static let immediate = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .zero)
+}
+
+/// Outcome of a single create attempt, classified for the retry loop.
+enum ExportCreateOutcome {
+    case success(remoteIdentifier: String, remoteURL: URL?)
+    case transient(AppError, retryAfterSeconds: Int?)
+    case permanent(AppError)
+}
+
+/// The provider-specific naming the shared retry runner needs. Everything else
+/// in the retry state machine is identical across providers, so only the display
+/// name, destination, and the provider-prefixed log-event keys vary here.
+struct TrackerExportRetryContext: Sendable {
+    /// Human-facing provider name, e.g. "GitHub" / "Jira".
+    let displayName: String
+    let destination: ExportDestination
+    /// Log event emitted on a successful create, e.g. "github_issue_exported".
+    let exportedLogEvent: String
+    /// Log event emitted on a failed create attempt, e.g. "github_export_failed".
+    let failedLogEvent: String
+    /// Log event emitted when reconciliation itself fails, e.g.
+    /// "github_export_reconciliation_failed".
+    let reconciliationFailedLogEvent: String
+}

--- a/Sources/BugNarrator/Services/TrackerExportSupport.swift
+++ b/Sources/BugNarrator/Services/TrackerExportSupport.swift
@@ -91,42 +91,6 @@ enum TrackerExportSupport {
         return base * multiplier
     }
 }
-
-/// Bounds retry of a single per-issue tracker create. POST issue-creation is not
-/// blindly idempotent, so retries are only safe because the export loop reconciles
-/// by the `bugnarrator-export-id` marker before re-creating (#502).
-struct ExportRetryConfiguration: Sendable {
-    let maxAttempts: Int
-    let baseDelay: Duration
-
-    static let `default` = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .milliseconds(500))
-    /// No real backoff — for tests that simulate transient-then-success.
-    static let immediate = ExportRetryConfiguration(maxAttempts: 3, baseDelay: .zero)
-}
-
-/// Outcome of a single create attempt, classified for the retry loop.
-enum ExportCreateOutcome {
-    case success(remoteIdentifier: String, remoteURL: URL?)
-    case transient(AppError, retryAfterSeconds: Int?)
-    case permanent(AppError)
-}
-
-/// The provider-specific naming the shared retry runner needs. Everything else
-/// in the retry state machine is identical across providers, so only the display
-/// name, destination, and the provider-prefixed log-event keys vary here.
-struct TrackerExportRetryContext: Sendable {
-    /// Human-facing provider name, e.g. "GitHub" / "Jira".
-    let displayName: String
-    let destination: ExportDestination
-    /// Log event emitted on a successful create, e.g. "github_issue_exported".
-    let exportedLogEvent: String
-    /// Log event emitted on a failed create attempt, e.g. "github_export_failed".
-    let failedLogEvent: String
-    /// Log event emitted when reconciliation itself fails, e.g.
-    /// "github_export_reconciliation_failed".
-    let reconciliationFailedLogEvent: String
-}
-
 extension TrackerExportSupport {
     /// The shared, dup-safe create-with-retry state machine for tracker exports
     /// (#502). The two providers ran byte-identical copies of this; it now lives


### PR DESCRIPTION
Extracts 3 retry types + doc comment (36 lines) into own file. TrackerExportSupport.swift: 242 → 205 lines. Tests: 667.