### PR TITLE
refactor: extract RawTranscriptSection into dedicated view file (#630, #401 slice c)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */; };
 		1F758F881FC9E36B8EB89C18 /* IssueExtractionRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EF5167B9226AE01E478075 /* IssueExtractionRequestBuilder.swift */; };
 		20CFCC7656BA4B234DBE8004 /* IssueExportPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB75074747EE722764CC071 /* IssueExportPresenters.swift */; };
+		2286D25AE254328242252388 /* RawTranscriptSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39D0F0D8152AB34E5CC2EB /* RawTranscriptSection.swift */; };
 		231AC81D88405F6044354D75 /* SystemAudioAggregateDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE7687249AD70EDFF06A569 /* SystemAudioAggregateDevice.swift */; };
 		24EAF9A3DAF9624979F3F358 /* IssueExportTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D566BDB865CF9FF245BB283 /* IssueExportTestSupport.swift */; };
 		255F6B56A8E14ED7C80DB0FA /* ScreenshotsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */; };
@@ -352,6 +353,7 @@
 		1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarIssueReviewService.swift; sourceTree = "<group>"; };
 		1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTests.swift; sourceTree = "<group>"; };
 		1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioExplainerView.swift; sourceTree = "<group>"; };
+		1F39D0F0D8152AB34E5CC2EB /* RawTranscriptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawTranscriptSection.swift; sourceTree = "<group>"; };
 		2064E70346EE9E9D138A9D10 /* PendingTranscriptionRetryFailureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailureHandlerTests.swift; sourceTree = "<group>"; };
 		20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionServiceTests.swift; sourceTree = "<group>"; };
 		22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraft.swift; sourceTree = "<group>"; };
@@ -1010,6 +1012,7 @@
 			isa = PBXGroup;
 			children = (
 				6ED395C71ADE17A2DFA5BD21 /* ExportReviewSheet.swift */,
+				1F39D0F0D8152AB34E5CC2EB /* RawTranscriptSection.swift */,
 				16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */,
 				EE629842187FE002FE2DE05D /* SessionRow.swift */,
 				C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */,
@@ -1363,6 +1366,7 @@
 				D9A9D1BB81401E2D14462808 /* PostTranscriptionResultHandlers.swift in Sources */,
 				61D4778489BCA1F3B7C16161 /* PrivacyDataExportTypes.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
+				2286D25AE254328242252388 /* RawTranscriptSection.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,
 				7017710A0A23DB217399D8FC /* RecordingPreferencesStore.swift in Sources */,

--- a/Sources/BugNarrator/Views/Transcript/RawTranscriptSection.swift
+++ b/Sources/BugNarrator/Views/Transcript/RawTranscriptSection.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+struct RawTranscriptSection: View {
+    let session: TranscriptSession
+    let availableWidth: CGFloat
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        let entries = ReviewWorkspace.timelineEntries(
+            for: session,
+            provider: appState.settingsStore.aiProvider
+        )
+
+        return LazyVStack(alignment: .leading, spacing: 12) {
+            ForEach(entries) { entry in
+                transcriptTimelineRow(entry, session: session, availableWidth: availableWidth)
+            }
+        }
+    }
+
+    private func transcriptTimelineRow(_ entry: ReviewWorkspaceTimelineEntry, session: TranscriptSession, availableWidth: CGFloat) -> some View {
+        Group {
+            if availableWidth < 360 {
+                VStack(alignment: .leading, spacing: 10) {
+                    timelineTimestampLabel(entry.timeLabel)
+                    timelineEntryContent(entry, session: session)
+                }
+            } else {
+                HStack(alignment: .top, spacing: 14) {
+                    timelineTimestampLabel(entry.timeLabel)
+                        .frame(width: 56, alignment: .leading)
+
+                    timelineEntryContent(entry, session: session)
+                }
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func timelineTimestampLabel(_ label: String) -> some View {
+        Text(label)
+            .font(.system(.body, design: .monospaced))
+            .fontWeight(.semibold)
+            .foregroundStyle(.pink)
+    }
+
+    @ViewBuilder
+    private func timelineEntryContent(_ entry: ReviewWorkspaceTimelineEntry, session: TranscriptSession) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            switch entry.kind {
+            case .transcript:
+                if let title = entry.title, !title.isEmpty, title != "Full Session" {
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(entry.text)
+                    .font(.body)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+            case .marker:
+                Text("Timeline marker")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(entry.text)
+                    .font(.body.weight(.semibold))
+
+            case .screenshot:
+                Text("Screenshot marker")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(entry.text)
+                    .font(.body.weight(.semibold))
+
+                if let screenshotID = entry.screenshotID,
+                   let screenshot = session.screenshot(with: screenshotID) {
+                    Button("Open Screenshot") {
+                        appState.openScreenshot(screenshot)
+                    }
+                    .buttonStyle(.link)
+                    .accessibilityLabel(screenshotActionLabel(for: screenshot, index: nil, action: "Open"))
+                }
+            }
+
+            if let secondaryText = entry.secondaryText, !secondaryText.isEmpty {
+                Text(secondaryText)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func screenshotActionLabel(for screenshot: SessionScreenshot, index: Int?, action: String) -> String {
+        let ordinal = index.map { "Screenshot \($0 + 1)" } ?? "Screenshot"
+        return "\(action) \(ordinal) at \(screenshot.timeLabel)"
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -727,7 +727,7 @@ struct TranscriptView: View {
             }
 
             reviewSectionCard("Transcript Timeline") {
-                rawTranscriptSection(session, availableWidth: availableWidth)
+                RawTranscriptSection(session: session, availableWidth: availableWidth, appState: appState)
             }
         }
     }
@@ -774,97 +774,6 @@ struct TranscriptView: View {
         }
     }
 
-    private func rawTranscriptSection(_ session: TranscriptSession, availableWidth: CGFloat) -> some View {
-        let entries = ReviewWorkspace.timelineEntries(
-            for: session,
-            provider: appState.settingsStore.aiProvider
-        )
-
-        return LazyVStack(alignment: .leading, spacing: 12) {
-            ForEach(entries) { entry in
-                transcriptTimelineRow(entry, session: session, availableWidth: availableWidth)
-            }
-        }
-    }
-
-    private func transcriptTimelineRow(_ entry: ReviewWorkspaceTimelineEntry, session: TranscriptSession, availableWidth: CGFloat) -> some View {
-        Group {
-            if availableWidth < 360 {
-                VStack(alignment: .leading, spacing: 10) {
-                    timelineTimestampLabel(entry.timeLabel)
-                    timelineEntryContent(entry, session: session)
-                }
-            } else {
-                HStack(alignment: .top, spacing: 14) {
-                    timelineTimestampLabel(entry.timeLabel)
-                        .frame(width: 56, alignment: .leading)
-
-                    timelineEntryContent(entry, session: session)
-                }
-            }
-        }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
-
-    private func timelineTimestampLabel(_ label: String) -> some View {
-        Text(label)
-            .font(.system(.body, design: .monospaced))
-            .fontWeight(.semibold)
-            .foregroundStyle(.pink)
-    }
-
-    @ViewBuilder
-    private func timelineEntryContent(_ entry: ReviewWorkspaceTimelineEntry, session: TranscriptSession) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            switch entry.kind {
-            case .transcript:
-                if let title = entry.title, !title.isEmpty, title != "Full Session" {
-                    Text(title)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-
-                Text(entry.text)
-                    .font(.body)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-            case .marker:
-                Text("Timeline marker")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                Text(entry.text)
-                    .font(.body.weight(.semibold))
-
-            case .screenshot:
-                Text("Screenshot marker")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                Text(entry.text)
-                    .font(.body.weight(.semibold))
-
-                if let screenshotID = entry.screenshotID,
-                   let screenshot = session.screenshot(with: screenshotID) {
-                    Button("Open Screenshot") {
-                        appState.openScreenshot(screenshot)
-                    }
-                    .buttonStyle(.link)
-                    .accessibilityLabel(screenshotActionLabel(for: screenshot, index: nil, action: "Open"))
-                }
-            }
-
-            if let secondaryText = entry.secondaryText, !secondaryText.isEmpty {
-                Text(secondaryText)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-            }
-        }
-    }
 
     private func extractedIssuesSection(_ session: TranscriptSession, availableWidth: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 14) {


### PR DESCRIPTION
Closes #630. Extracts 91 lines of timeline rendering into new RawTranscriptSection view. Tests: 667.

⚠️ Manual smoke check recommended before merge: render raw transcript pane with all 3 entry kinds (transcript/marker/screenshot).