### PR TITLE
refactor: extract SettingsReadinessTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		D1816E560B00B71EB9A625EA /* SystemAudioFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCEC36FA2A05A4FD9CE5F0B /* SystemAudioFileWriter.swift */; };
 		D2AEB3EA7C80F6B47D0193C5 /* SimilarIssueReviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */; };
 		D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */; };
+		D687F22809BF99AF4D202C1E /* SettingsReadinessTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05CD611B03D4E8792F7CD35 /* SettingsReadinessTypes.swift */; };
 		D759CEA88F50769454691AFC /* SettingsIntegrationsPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */; };
 		D7D868701BE0B53E59DD6DFD /* TranscriptQualityFindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */; };
 		D8438A30A02978B808CE9040 /* IssueExtractionCompletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6D695E380D1F9B3D04BD68 /* IssueExtractionCompletionLog.swift */; };
@@ -543,6 +544,7 @@
 		BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionService.swift; sourceTree = "<group>"; };
 		BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingAudioSource.swift; sourceTree = "<group>"; };
 		BE6D695E380D1F9B3D04BD68 /* IssueExtractionCompletionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionCompletionLog.swift; sourceTree = "<group>"; };
+		C05CD611B03D4E8792F7CD35 /* SettingsReadinessTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsReadinessTypes.swift; sourceTree = "<group>"; };
 		C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitorTests.swift; sourceTree = "<group>"; };
 		C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusTests.swift; sourceTree = "<group>"; };
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */,
 				0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */,
 				B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */,
+				C05CD611B03D4E8792F7CD35 /* SettingsReadinessTypes.swift */,
 				8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */,
 			);
 			path = Settings;
@@ -1411,6 +1414,7 @@
 				8E41CD2A7BE6A70F5CD9F46C /* SettingsGeneralPanes.swift in Sources */,
 				D759CEA88F50769454691AFC /* SettingsIntegrationsPanes.swift in Sources */,
 				BA99127A39D827962D535164 /* SettingsReadiness.swift in Sources */,
+				D687F22809BF99AF4D202C1E /* SettingsReadinessTypes.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/SettingsReadiness.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsReadiness.swift
@@ -5,64 +5,6 @@ import SwiftUI
 /// top-level "at a glance" status summary and the Integrations pane can compute
 /// and render the same status rows. Pure relocation: identical logic and layout.
 
-/// The configured-ness of a Settings capability (AI provider, GitHub, Jira).
-enum SettingsReadinessStatus {
-    case ready
-    case needsSetup
-    case pendingSave
-    case locked
-
-    var title: String {
-        switch self {
-        case .ready:
-            return "Ready"
-        case .needsSetup:
-            return "Needs setup"
-        case .pendingSave:
-            return "Pending save"
-        case .locked:
-            return "Locked"
-        }
-    }
-
-    var symbolName: String {
-        switch self {
-        case .ready:
-            return "checkmark.circle.fill"
-        case .needsSetup:
-            return "exclamationmark.circle.fill"
-        case .pendingSave:
-            return "clock.fill"
-        case .locked:
-            return "lock.fill"
-        }
-    }
-
-    var color: Color {
-        switch self {
-        case .ready:
-            return .green
-        case .needsSetup:
-            return .orange
-        case .pendingSave:
-            return .blue
-        case .locked:
-            return .red
-        }
-    }
-}
-
-/// One row in a per-integration prerequisite checklist.
-struct PrerequisiteRow: Identifiable {
-    let title: String
-    let detail: String
-    let status: SettingsReadinessStatus
-
-    var id: String {
-        title
-    }
-}
-
 /// Pure readiness computations derived from `SettingsStore` state.
 enum SettingsReadiness {
     static func credentialStatus(

--- a/Sources/BugNarrator/Views/Settings/SettingsReadinessTypes.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsReadinessTypes.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+enum SettingsReadinessStatus {
+    case ready
+    case needsSetup
+    case pendingSave
+    case locked
+
+    var title: String {
+        switch self {
+        case .ready:
+            return "Ready"
+        case .needsSetup:
+            return "Needs setup"
+        case .pendingSave:
+            return "Pending save"
+        case .locked:
+            return "Locked"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .ready:
+            return "checkmark.circle.fill"
+        case .needsSetup:
+            return "exclamationmark.circle.fill"
+        case .pendingSave:
+            return "clock.fill"
+        case .locked:
+            return "lock.fill"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .ready:
+            return .green
+        case .needsSetup:
+            return .orange
+        case .pendingSave:
+            return .blue
+        case .locked:
+            return .red
+        }
+    }
+}
+
+/// One row in a per-integration prerequisite checklist.
+struct PrerequisiteRow: Identifiable {
+    let title: String
+    let detail: String
+    let status: SettingsReadinessStatus
+
+    var id: String {
+        title
+    }
+}
+


### PR DESCRIPTION
Extracts 2 support types (57 lines) into own file. Imports: SwiftUI (for Color). SettingsReadiness.swift: 218 → 160 lines. Tests: 667.