### PR TITLE
refactor: extract TranscriptQualityFindingsView.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
 		15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */; };
 		18EE2A64D0A551934978247B /* AudioObjectIDExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB94B9DE300200CB6C35E6F1 /* AudioObjectIDExtensions.swift */; };
+		19CEA27517A315FD58192A45 /* TranscriptQualityFindingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E494EEEB2C018328615FD4AF /* TranscriptQualityFindingsView.swift */; };
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */; };
@@ -587,6 +588,7 @@
 		DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorApp.swift; sourceTree = "<group>"; };
 		E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineController.swift; sourceTree = "<group>"; };
 		E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTypes.swift; sourceTree = "<group>"; };
+		E494EEEB2C018328615FD4AF /* TranscriptQualityFindingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFindingsView.swift; sourceTree = "<group>"; };
 		E500A980171E57FE562FBB7C /* TranscriptSessionSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSessionSchemaTests.swift; sourceTree = "<group>"; };
 		E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
 		E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				6131EA189B853D1B456A8D26 /* SettingsView.swift */,
 				0DF81E6E8D3A702691797E56 /* SupportView.swift */,
 				1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */,
+				E494EEEB2C018328615FD4AF /* TranscriptQualityFindingsView.swift */,
 				A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */,
 				B09CA463A8DF59221937A2C7 /* TranscriptView.swift */,
 				6B5718CA7DF93E9C2A51A16C /* Menu */,
@@ -1443,6 +1446,7 @@
 				954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */,
 				D0754552F75E1CE6B4128800 /* TranscriptExporter.swift in Sources */,
 				7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */,
+				19CEA27517A315FD58192A45 /* TranscriptQualityFindingsView.swift in Sources */,
 				AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */,
 				6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */,
 				6E7D93B7718A9340695B3B76 /* TranscriptSection.swift in Sources */,

--- a/Sources/BugNarrator/Views/TranscriptQualityFindingsView.swift
+++ b/Sources/BugNarrator/Views/TranscriptQualityFindingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct TranscriptQualityFindingsView: View {
+    let findings: [TranscriptQualityFinding]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(findings) { finding in
+                Label(finding.message, systemImage: icon(for: finding))
+                    .font(.subheadline)
+                    .foregroundStyle(finding.severity == .error ? .red : .orange)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func icon(for finding: TranscriptQualityFinding) -> String {
+        switch finding.kind {
+        case .repeatedText:
+            return "repeat"
+        case .boilerplateText:
+            return "text.quote"
+        case .unexpectedLanguageScript:
+            return "globe.asia.australia"
+        case .abruptEnding:
+            return "text.badge.exclamationmark"
+        case .shortTranscript:
+            return "text.magnifyingglass"
+        }
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
+++ b/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
@@ -66,37 +66,6 @@ struct StorageRecoveryBanner: View {
             .background(.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
-
-struct TranscriptQualityFindingsView: View {
-    let findings: [TranscriptQualityFinding]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            ForEach(findings) { finding in
-                Label(finding.message, systemImage: icon(for: finding))
-                    .font(.subheadline)
-                    .foregroundStyle(finding.severity == .error ? .red : .orange)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func icon(for finding: TranscriptQualityFinding) -> String {
-        switch finding.kind {
-        case .repeatedText:
-            return "repeat"
-        case .boilerplateText:
-            return "text.quote"
-        case .unexpectedLanguageScript:
-            return "globe.asia.australia"
-        case .abruptEnding:
-            return "text.badge.exclamationmark"
-        case .shortTranscript:
-            return "text.magnifyingglass"
-        }
-    }
-}
-
 struct ExportHistorySummaryView: View {
     let receipts: [ExportReceipt]
 


### PR DESCRIPTION
Extracts SwiftUI view (29 lines) into own file. TranscriptRecoveryAndHistoryViews.swift: 144 → 112 lines. Tests: 667.

⚠️ Manual smoke check recommended: render session with quality warnings.