### PR TITLE
refactor: extract StorageRecoveryBanner.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		474596AEBE0A97F33B320E59 /* AppErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54521C239C09E5B94712EB /* AppErrorTypes.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		4D1C9E0E08BD5550F0A10C10 /* AppState+AIProviderCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6BBD3839BF28AC52214FEB /* AppState+AIProviderCredential.swift */; };
+		4D81592844E0FDC8BDF43D90 /* StorageRecoveryBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9D6C752334532E660C00AF /* StorageRecoveryBanner.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
 		4DB15A558BFFB4097C6DEF50 /* AppState+TrackerIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C3F2C78E5CE5F897E804CC /* AppState+TrackerIntegration.swift */; };
 		4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */; };
@@ -404,6 +405,7 @@
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
 		48DF28E6CC5FB74499C91B74 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
+		4A9D6C752334532E660C00AF /* StorageRecoveryBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRecoveryBanner.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
 		4C809A64CE202980AFC55953 /* PostTranscriptionResultHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionResultHandlers.swift; sourceTree = "<group>"; };
 		4D566BDB865CF9FF245BB283 /* IssueExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportTestSupport.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				865C5FE84904ECA5F4379637 /* MenuBarView.swift */,
 				0B43198BD8701B62D47D02F9 /* RecordingControlPanelView.swift */,
 				6131EA189B853D1B456A8D26 /* SettingsView.swift */,
+				4A9D6C752334532E660C00AF /* StorageRecoveryBanner.swift */,
 				0DF81E6E8D3A702691797E56 /* SupportView.swift */,
 				1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */,
 				A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */,
@@ -1430,6 +1433,7 @@
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,
 				D2AEB3EA7C80F6B47D0193C5 /* SimilarIssueReviewService.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
+				4D81592844E0FDC8BDF43D90 /* StorageRecoveryBanner.swift in Sources */,
 				C937699F6D7B77CED3A96676 /* StringExtensions.swift in Sources */,
 				8839D4116A3265DB08430846 /* SupportDataController.swift in Sources */,
 				8C7B9A73443F9941883AA9D5 /* SupportDataTypes.swift in Sources */,

--- a/Sources/BugNarrator/Views/StorageRecoveryBanner.swift
+++ b/Sources/BugNarrator/Views/StorageRecoveryBanner.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct StorageRecoveryBanner: View {
+    let message: String
+
+    var body: some View {
+        Label(message, systemImage: "externaldrive.badge.checkmark")
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
+++ b/Sources/BugNarrator/Views/TranscriptRecoveryAndHistoryViews.swift
@@ -53,20 +53,6 @@ struct PendingTranscriptionBanner: View {
         return "These sessions were recorded successfully and kept in the library because transcription could not finish. Open the latest one to retry after fixing the \(provider.displayName) setup."
     }
 }
-
-struct StorageRecoveryBanner: View {
-    let message: String
-
-    var body: some View {
-        Label(message, systemImage: "externaldrive.badge.checkmark")
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .padding(12)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
-}
-
 struct TranscriptQualityFindingsView: View {
     let findings: [TranscriptQualityFinding]
 


### PR DESCRIPTION
Extracts View (12 lines) into own file. Tests: 667.