### PR TITLE
refactor: extract SystemDiagnosticsInfo.swift from DebugBundleExporter.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		B6F837040D5A988287E8E8FF /* RecordingSessionOutcomes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB3DE4A4EEA68D61D7E4BD14 /* RecordingSessionOutcomes.swift */; };
 		B771844AAE785C764AEBD7C6 /* SecretSlotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BD14AE99398DAE80181305 /* SecretSlotTests.swift */; };
 		B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */; };
+		B89741CBB96457235FBCA731 /* SystemDiagnosticsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EEAC07715B517F95847C69C /* SystemDiagnosticsInfo.swift */; };
 		BA99127A39D827962D535164 /* SettingsReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */; };
 		BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B578DB59431378DDC84929 /* GitHubExportConfig.swift */; };
 		BBE16FF238B059EF08346355 /* ReviewWorkspaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70C2AF1D71698B8CB98490E /* ReviewWorkspaceTypes.swift */; };
@@ -343,6 +344,7 @@
 		0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntegrationsPanes.swift; sourceTree = "<group>"; };
 		0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLogEntry.swift; sourceTree = "<group>"; };
 		0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FileRevealActions.swift"; sourceTree = "<group>"; };
+		0EEAC07715B517F95847C69C /* SystemDiagnosticsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemDiagnosticsInfo.swift; sourceTree = "<group>"; };
 		102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceipt.swift; sourceTree = "<group>"; };
 		104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportConfig.swift; sourceTree = "<group>"; };
 		125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageProvider.swift; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 				5BCEC36FA2A05A4FD9CE5F0B /* SystemAudioFileWriter.swift */,
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */,
+				0EEAC07715B517F95847C69C /* SystemDiagnosticsInfo.swift */,
 				5D05D14432F331F83DB44AD9 /* TelemetryTypes.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */,
@@ -1447,6 +1450,7 @@
 				D1816E560B00B71EB9A625EA /* SystemAudioFileWriter.swift in Sources */,
 				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				ABA48997F0B07377178EDEE0 /* SystemAudioTapSession.swift in Sources */,
+				B89741CBB96457235FBCA731 /* SystemDiagnosticsInfo.swift in Sources */,
 				2455C6B282EF275B5B55F591 /* TelemetryTypes.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				DBFA5905D305404FAD17EC5E /* TrackerExportRetryTypes.swift in Sources */,

--- a/Sources/BugNarrator/Services/DebugBundleExporter.swift
+++ b/Sources/BugNarrator/Services/DebugBundleExporter.swift
@@ -94,22 +94,3 @@ struct DebugBundleExporter {
 }
 
 extension DebugBundleExporter: DebugBundleExporting {}
-
-enum SystemDiagnosticsInfo {
-    static func currentArchitecture() -> String {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let machineField = systemInfo.machine
-
-        let machine = withUnsafePointer(to: machineField) { pointer -> String in
-            pointer.withMemoryRebound(
-                to: CChar.self,
-                capacity: MemoryLayout.size(ofValue: machineField)
-            ) { reboundPointer in
-                String(cString: reboundPointer)
-            }
-        }
-
-        return machine.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}

--- a/Sources/BugNarrator/Services/SystemDiagnosticsInfo.swift
+++ b/Sources/BugNarrator/Services/SystemDiagnosticsInfo.swift
@@ -1,0 +1,21 @@
+import Darwin
+import Foundation
+
+enum SystemDiagnosticsInfo {
+    static func currentArchitecture() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineField = systemInfo.machine
+
+        let machine = withUnsafePointer(to: machineField) { pointer -> String in
+            pointer.withMemoryRebound(
+                to: CChar.self,
+                capacity: MemoryLayout.size(ofValue: machineField)
+            ) { reboundPointer in
+                String(cString: reboundPointer)
+            }
+        }
+
+        return machine.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
Extracts `SystemDiagnosticsInfo` enum (uname wrapper) into own file. Byte-identical move. DebugBundleExporter.swift: 115 → 96 lines. Tests: 667.