### PR TITLE
refactor: extract PrivacyDataSessionStream.swift from PrivacyDataExportTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
 		8F4B3823ACB48DDF270E2BAE /* AppStateIssueExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */; };
+		8F7D3EBCECC5A6FE5933D2E6 /* PrivacyDataSessionStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEF89EAFF213B5D5EEC0E86 /* PrivacyDataSessionStream.swift */; };
 		93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */; };
 		93561F8BD8484E68D3E96012 /* RecordingSessionPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */; };
 		9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */; };
@@ -394,6 +395,7 @@
 		3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
 		3B66F6ADC8EDC6AA0A768F30 /* TrackerExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportSupport.swift; sourceTree = "<group>"; };
+		3BEF89EAFF213B5D5EEC0E86 /* PrivacyDataSessionStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataSessionStream.swift; sourceTree = "<group>"; };
 		3E7CA92ED5A94500B96290D0 /* AppState+SupportNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SupportNavigation.swift"; sourceTree = "<group>"; };
 		3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceControllerTests.swift; sourceTree = "<group>"; };
 		3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
@@ -918,6 +920,7 @@
 				4C809A64CE202980AFC55953 /* PostTranscriptionResultHandlers.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
 				154255C955FE33FD6D016BE9 /* PrivacyDataExportTypes.swift */,
+				3BEF89EAFF213B5D5EEC0E86 /* PrivacyDataSessionStream.swift */,
 				7EFD71FC016C2F699D022EDB /* RecordingPreferencesStore.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
 				FB3DE4A4EEA68D61D7E4BD14 /* RecordingSessionOutcomes.swift */,
@@ -1390,6 +1393,7 @@
 				D9A9D1BB81401E2D14462808 /* PostTranscriptionResultHandlers.swift in Sources */,
 				61D4778489BCA1F3B7C16161 /* PrivacyDataExportTypes.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
+				8F7D3EBCECC5A6FE5933D2E6 /* PrivacyDataSessionStream.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,
 				5D4B8A830EA58AFC03AE9982 /* RecordingControlPanelView.swift in Sources */,
 				7017710A0A23DB217399D8FC /* RecordingPreferencesStore.swift in Sources */,

--- a/Sources/BugNarrator/Services/PrivacyDataExportTypes.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExportTypes.swift
@@ -55,27 +55,3 @@ struct PrivacyDataExportDiagnosticsSnapshot: Codable, Equatable {
     let recentDiagnosticsLog: String
     let exportHistory: [ExportReceipt]
 }
-
-/// A lazy source of stored sessions for export. The exporter pulls sessions one
-/// at a time via `forEach`, so the whole library never has to be materialized in
-/// memory simultaneously (#508). `count` is the number of sessions `forEach` will
-/// yield, known up front from the lightweight library index.
-struct PrivacyDataSessionStream {
-    let count: Int
-    let forEach: (_ body: (TranscriptSession) throws -> Void) throws -> Void
-
-    /// Convenience for callers (and tests) that already hold a materialized array.
-    init(sessions: [TranscriptSession]) {
-        count = sessions.count
-        forEach = { body in
-            for session in sessions {
-                try body(session)
-            }
-        }
-    }
-
-    init(count: Int, forEach: @escaping (_ body: (TranscriptSession) throws -> Void) throws -> Void) {
-        self.count = count
-        self.forEach = forEach
-    }
-}

--- a/Sources/BugNarrator/Services/PrivacyDataSessionStream.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataSessionStream.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A lazy source of stored sessions for export. The exporter pulls sessions one
+/// at a time via `forEach`, so the whole library never has to be materialized in
+/// memory simultaneously (#508). `count` is the number of sessions `forEach` will
+/// yield, known up front from the lightweight library index.
+struct PrivacyDataSessionStream {
+    let count: Int
+    let forEach: (_ body: (TranscriptSession) throws -> Void) throws -> Void
+
+    /// Convenience for callers (and tests) that already hold a materialized array.
+    init(sessions: [TranscriptSession]) {
+        count = sessions.count
+        forEach = { body in
+            for session in sessions {
+                try body(session)
+            }
+        }
+    }
+
+    init(count: Int, forEach: @escaping (_ body: (TranscriptSession) throws -> Void) throws -> Void) {
+        self.count = count
+        self.forEach = forEach
+    }
+}


### PR DESCRIPTION
Extracts the lazy session-stream type (~24 lines) out of PrivacyDataExportTypes.swift so that file holds only Codable/Encodable snapshot types. Byte-identical move. Tests: 667.