### PR TITLE
refactor: extract SessionArtifactsManaging+Defaults.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		31A36AA0F41DF712DD79262B /* TranscriptStoreRecoveryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E813CF73D0B819D24B8C81 /* TranscriptStoreRecoveryEvent.swift */; };
 		31D0FF8CFB99E767103A0561 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2173ED04BA5467313B6261 /* AppErrorPresenterTests.swift */; };
 		31DE75541AFCD7104ED7F09E /* AppStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */; };
+		3314F7A973C21C09B7D7BE90 /* SessionArtifactsManaging+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A6E79ED4A2689DE1ACBC9D /* SessionArtifactsManaging+Defaults.swift */; };
 		334D366819B92F5AE7F00961 /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554387017B49D9CD63967BE3 /* AppStateTests.swift */; };
 		33D0E3F65FCAE14DBC117B40 /* TranscriptionSessionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECDD27F91ED65247C1FA689 /* TranscriptionSessionBuilderTests.swift */; };
 		33DB3B8F22BD0E75CFC65F10 /* TranscriptionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800BFCC6407B534886C65D77 /* TranscriptionClient.swift */; };
@@ -401,6 +402,7 @@
 		40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLoggerTests.swift; sourceTree = "<group>"; };
 		411B7523656188E4CCDE188D /* AppState+ExportHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+ExportHistory.swift"; sourceTree = "<group>"; };
 		417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginService.swift; sourceTree = "<group>"; };
+		43A6E79ED4A2689DE1ACBC9D /* SessionArtifactsManaging+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionArtifactsManaging+Defaults.swift"; sourceTree = "<group>"; };
 		440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinator.swift; sourceTree = "<group>"; };
 		4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
@@ -932,6 +934,7 @@
 				EB9FC5A9F96173F2DA9C5B90 /* ScreenshotSelectionService.swift */,
 				0B3EA5B797B5D53F17A47C8D /* SecretSlot.swift */,
 				6B6F8B0D0A9D777735FD3E44 /* ServiceProtocols.swift */,
+				43A6E79ED4A2689DE1ACBC9D /* SessionArtifactsManaging+Defaults.swift */,
 				9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */,
 				76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */,
 				52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */,
@@ -1414,6 +1417,7 @@
 				255F6B56A8E14ED7C80DB0FA /* ScreenshotsSection.swift in Sources */,
 				609D4B42C4786F625CCD0623 /* SecretSlot.swift in Sources */,
 				3893EB325B3915242FBD4BA6 /* ServiceProtocols.swift in Sources */,
+				3314F7A973C21C09B7D7BE90 /* SessionArtifactsManaging+Defaults.swift in Sources */,
 				6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */,
 				A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */,
 				B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */,

--- a/Sources/BugNarrator/Services/SessionArtifactsManaging+Defaults.swift
+++ b/Sources/BugNarrator/Services/SessionArtifactsManaging+Defaults.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension SessionArtifactsManaging {
+    /// Copies a finished recording from its temp location into a session artifacts
+    /// directory and returns the durable URL, so a successful-but-low-quality
+    /// transcript session keeps its audio available for re-transcription (#466).
+    /// The source is left untouched; the caller decides when to delete the temp.
+    func preserveRecordedAudio(_ recordedAudio: RecordedAudio, in directoryURL: URL) throws -> URL {
+        let fileManager = FileManager.default
+        let destinationURL = makeRecordedAudioURL(in: directoryURL, sourceFileURL: recordedAudio.fileURL)
+
+        if recordedAudio.fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
+            if !fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            }
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.copyItem(at: recordedAudio.fileURL, to: destinationURL)
+        }
+
+        let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        guard fileSize > 0 else {
+            try? fileManager.removeItem(at: destinationURL)
+            throw AppError.recordingFailure("The preserved audio file was empty.")
+        }
+
+        return destinationURL
+    }
+}

--- a/Sources/BugNarrator/Services/SessionArtifactsService.swift
+++ b/Sources/BugNarrator/Services/SessionArtifactsService.swift
@@ -108,33 +108,3 @@ struct SessionArtifactsService: SessionArtifactsManaging {
         return standardizedDirectoryURL.path.hasPrefix(standardizedRootURL.path + "/")
     }
 }
-
-extension SessionArtifactsManaging {
-    /// Copies a finished recording from its temp location into a session artifacts
-    /// directory and returns the durable URL, so a successful-but-low-quality
-    /// transcript session keeps its audio available for re-transcription (#466).
-    /// The source is left untouched; the caller decides when to delete the temp.
-    func preserveRecordedAudio(_ recordedAudio: RecordedAudio, in directoryURL: URL) throws -> URL {
-        let fileManager = FileManager.default
-        let destinationURL = makeRecordedAudioURL(in: directoryURL, sourceFileURL: recordedAudio.fileURL)
-
-        if recordedAudio.fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
-            if !fileManager.fileExists(atPath: directoryURL.path) {
-                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-            }
-            if fileManager.fileExists(atPath: destinationURL.path) {
-                try fileManager.removeItem(at: destinationURL)
-            }
-            try fileManager.copyItem(at: recordedAudio.fileURL, to: destinationURL)
-        }
-
-        let attributes = try fileManager.attributesOfItem(atPath: destinationURL.path)
-        let fileSize = (attributes[.size] as? NSNumber)?.intValue ?? 0
-        guard fileSize > 0 else {
-            try? fileManager.removeItem(at: destinationURL)
-            throw AppError.recordingFailure("The preserved audio file was empty.")
-        }
-
-        return destinationURL
-    }
-}


### PR DESCRIPTION
Splits the default-impl extension (~30 lines) out of SessionArtifactsService.swift into its own file. Byte-identical move. Tests: 667.