### PR TITLE
refactor: extract IssueExtractionResult.swift from IssueExportTargets.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		29C25E147DD0810A11C03502 /* TranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09CA463A8DF59221937A2C7 /* TranscriptView.swift */; };
 		2B788786CA9B2E94ECA04033 /* RecordingSessionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */; };
 		2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EFDFC12818F99D04C93CC5 /* MicrophonePermissionResolver.swift */; };
+		2C9EDF1AC6573E37CBE4FF7D /* IssueExtractionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = C154B401D9E25A60FBA1A004 /* IssueExtractionResult.swift */; };
 		2CB3C3FC440FE4C08AC9AF41 /* SystemAudioExplainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */; };
 		2CDA374600484F9DF4079AB5 /* VerboseTranscriptionResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6A1D707211E467BFD8EF0 /* VerboseTranscriptionResponseParser.swift */; };
 		2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */; };
@@ -556,6 +557,7 @@
 		BE6D695E380D1F9B3D04BD68 /* IssueExtractionCompletionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionCompletionLog.swift; sourceTree = "<group>"; };
 		C05CD611B03D4E8792F7CD35 /* SettingsReadinessTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsReadinessTypes.swift; sourceTree = "<group>"; };
 		C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitorTests.swift; sourceTree = "<group>"; };
+		C154B401D9E25A60FBA1A004 /* IssueExtractionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionResult.swift; sourceTree = "<group>"; };
 		C18BAC24C83F070C8DE32996 /* AppStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatusTests.swift; sourceTree = "<group>"; };
 		C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorMetadata.swift; sourceTree = "<group>"; };
 		C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSharedHelpers.swift; sourceTree = "<group>"; };
@@ -769,6 +771,7 @@
 				3394CF24F8CA7410A441170E /* IssueCoreSubtypes.swift */,
 				C514D909BF8C4543E740640F /* IssueExportReview.swift */,
 				F0300D3CA1B339D4D1CCAC84 /* IssueExportTargets.swift */,
+				C154B401D9E25A60FBA1A004 /* IssueExtractionResult.swift */,
 				104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */,
 				8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */,
 				BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */,
@@ -1358,6 +1361,7 @@
 				04C96DDD35BD806168921571 /* IssueExtractionRequestBudget.swift in Sources */,
 				1F758F881FC9E36B8EB89C18 /* IssueExtractionRequestBuilder.swift in Sources */,
 				9EE81A76B802435C84B8032D /* IssueExtractionResponseParser.swift in Sources */,
+				2C9EDF1AC6573E37CBE4FF7D /* IssueExtractionResult.swift in Sources */,
 				E3A4A5182E639F1AE4F7A773 /* IssueExtractionService.swift in Sources */,
 				82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */,
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,

--- a/Sources/BugNarrator/Models/IssueExportTargets.swift
+++ b/Sources/BugNarrator/Models/IssueExportTargets.swift
@@ -62,30 +62,6 @@ struct JiraIssueExportTarget: Codable, Equatable {
         return "\(projectKey) - \(projectName)"
     }
 }
-
-struct IssueExtractionResult: Codable, Equatable {
-    let generatedAt: Date
-    var summary: String
-    var guidanceNote: String
-    var issues: [ExtractedIssue]
-
-    init(
-        generatedAt: Date = Date(),
-        summary: String,
-        guidanceNote: String = "Extracted issues are draft suggestions and should be reviewed before export.",
-        issues: [ExtractedIssue]
-    ) {
-        self.generatedAt = generatedAt
-        self.summary = summary
-        self.guidanceNote = guidanceNote
-        self.issues = issues
-    }
-
-    var selectedIssues: [ExtractedIssue] {
-        issues.filter(\.isSelectedForExport)
-    }
-}
-
 enum ExportDestination: String, Codable, CaseIterable, Identifiable {
     case github = "GitHub"
     case jira = "Jira"

--- a/Sources/BugNarrator/Models/IssueExtractionResult.swift
+++ b/Sources/BugNarrator/Models/IssueExtractionResult.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct IssueExtractionResult: Codable, Equatable {
+    let generatedAt: Date
+    var summary: String
+    var guidanceNote: String
+    var issues: [ExtractedIssue]
+
+    init(
+        generatedAt: Date = Date(),
+        summary: String,
+        guidanceNote: String = "Extracted issues are draft suggestions and should be reviewed before export.",
+        issues: [ExtractedIssue]
+    ) {
+        self.generatedAt = generatedAt
+        self.summary = summary
+        self.guidanceNote = guidanceNote
+        self.issues = issues
+    }
+
+    var selectedIssues: [ExtractedIssue] {
+        issues.filter(\.isSelectedForExport)
+    }
+}
+


### PR DESCRIPTION
Splits the `IssueExtractionResult` value (extraction-pipeline output) out of IssueExportTargets.swift. Byte-identical move. Tests: 667.