### PR TITLE
refactor: extract DisplayedTranscriptCopyResult.swift from SessionLibraryPresenters.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		FB372E7045DCC67CC5321D4B /* DiagnosticsLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F071591002E18986EB6709 /* DiagnosticsLoggerTests.swift */; };
 		FD330322EFE5B739F3657451 /* DebugBundleTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ABEC93C3EF20960325C6FF7 /* DebugBundleTypes.swift */; };
 		FEFF63FB3DA83F5C8BC659C1 /* AppPresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE77CF3D9076FC05278390A6 /* AppPresentationState.swift */; };
+		FF543143D0A1C59B2E97D735 /* DisplayedTranscriptCopyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28BDD07596304B270A77E271 /* DisplayedTranscriptCopyResult.swift */; };
 		FFF767231D9C465D49D307F8 /* AudioUploadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A59E3782D54041B521412C9 /* AudioUploadPolicy.swift */; };
 /* End PBXBuildFile section */
 
@@ -375,6 +376,7 @@
 		277DC17D4084F918920CB8C5 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		27BD14AE99398DAE80181305 /* SecretSlotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretSlotTests.swift; sourceTree = "<group>"; };
 		28B463E2764267ED731EDB99 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
+		28BDD07596304B270A77E271 /* DisplayedTranscriptCopyResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayedTranscriptCopyResult.swift; sourceTree = "<group>"; };
 		2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
 		2D753EF601F00C09C7FF276C /* TransientToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToast.swift; sourceTree = "<group>"; };
 		2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
@@ -880,6 +882,7 @@
 				A663ED1B160E290FCFAC3AED /* ClipboardService.swift */,
 				2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */,
 				5ABEC93C3EF20960325C6FF7 /* DebugBundleTypes.swift */,
+				28BDD07596304B270A77E271 /* DisplayedTranscriptCopyResult.swift */,
 				70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */,
 				102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */,
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
@@ -1330,6 +1333,7 @@
 				946F215474A2DE83AA4413C4 /* DiagnosticsLogger.swift in Sources */,
 				6AC08ACF1118EF6BDAD2E6BA /* DiagnosticsRedactor.swift in Sources */,
 				15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */,
+				FF543143D0A1C59B2E97D735 /* DisplayedTranscriptCopyResult.swift in Sources */,
 				4F04273FAEFE2C33F78701B4 /* ElapsedTimeFormatter.swift in Sources */,
 				93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */,
 				8598258404428C8692A51907 /* ExportReceipt.swift in Sources */,

--- a/Sources/BugNarrator/Services/DisplayedTranscriptCopyResult.swift
+++ b/Sources/BugNarrator/Services/DisplayedTranscriptCopyResult.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum DisplayedTranscriptCopyResult: Equatable {
+    case noDisplayedTranscript
+    case transcriptUnavailable
+    case copied
+}

--- a/Sources/BugNarrator/Services/SessionLibraryPresenters.swift
+++ b/Sources/BugNarrator/Services/SessionLibraryPresenters.swift
@@ -1,12 +1,6 @@
 import Combine
 import Foundation
 
-enum DisplayedTranscriptCopyResult: Equatable {
-    case noDisplayedTranscript
-    case transcriptUnavailable
-    case copied
-}
-
 enum DisplayedTranscriptCopyStatusPresenter {
     static func status(for result: DisplayedTranscriptCopyResult) -> AppStatus? {
         switch result {


### PR DESCRIPTION
Extracts the DisplayedTranscriptCopyResult data enum out of SessionLibraryPresenters.swift so that file holds only presenter enums. Byte-identical move. Tests: 667.