### PR TITLE
test: extract MockLaunchAtLoginService.swift from KeychainTestSupport.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		977D86FA0E7E2C16A5B41D4D /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */; };
 		981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */; };
 		98BEEBB0A54A385DAC55987E /* AppLaunchDiagnosticsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CC17094DFD9502DBA94345 /* AppLaunchDiagnosticsReporter.swift */; };
+		98DFC7E900276157931AEF93 /* MockLaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3916F6A4B6D04E2AEFA94557 /* MockLaunchAtLoginService.swift */; };
 		99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */; };
 		994C5601BD2578CC3A980002 /* AIProviderSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */; };
 		99A01D146ED4D77DA20484A5 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 792A02D8EE4EBB2A02D4043D /* CHANGELOG.md */; };
@@ -393,6 +394,7 @@
 		3703FAAF52D9FFFCA5E7D577 /* RecordingSessionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionControllerTests.swift; sourceTree = "<group>"; };
 		3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
+		3916F6A4B6D04E2AEFA94557 /* MockLaunchAtLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchAtLoginService.swift; sourceTree = "<group>"; };
 		3B66F6ADC8EDC6AA0A768F30 /* TrackerExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportSupport.swift; sourceTree = "<group>"; };
 		3E7CA92ED5A94500B96290D0 /* AppState+SupportNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SupportNavigation.swift"; sourceTree = "<group>"; };
 		3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceControllerTests.swift; sourceTree = "<group>"; };
@@ -702,6 +704,7 @@
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */,
+				3916F6A4B6D04E2AEFA94557 /* MockLaunchAtLoginService.swift */,
 				F00EA3260CCEECB3FB097702 /* NetworkTestSupport.swift */,
 				9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
@@ -1210,6 +1213,7 @@
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				C36540B4BE0CB254215654AB /* MixedAudioRecorderTests.swift in Sources */,
+				98DFC7E900276157931AEF93 /* MockLaunchAtLoginService.swift in Sources */,
 				3953183BDA19D90C13449F73 /* NetworkTestSupport.swift in Sources */,
 				A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,

--- a/Tests/BugNarratorTests/KeychainTestSupport.swift
+++ b/Tests/BugNarratorTests/KeychainTestSupport.swift
@@ -38,26 +38,3 @@ final class MockKeychainService: KeychainServicing {
         "\(service)::\(account)"
     }
 }
-
-final class MockLaunchAtLoginService: LaunchAtLoginControlling {
-    var status: LaunchAtLoginStatus
-    var setEnabledError: Error?
-
-    init(status: LaunchAtLoginStatus = .disabled) {
-        self.status = status
-    }
-
-    func currentStatus() -> LaunchAtLoginStatus {
-        status
-    }
-
-    func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus {
-        if let setEnabledError {
-            throw setEnabledError
-        }
-
-        status = enabled ? .enabled : .disabled
-        return status
-    }
-}
-

--- a/Tests/BugNarratorTests/MockLaunchAtLoginService.swift
+++ b/Tests/BugNarratorTests/MockLaunchAtLoginService.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import BugNarrator
+
+final class MockLaunchAtLoginService: LaunchAtLoginControlling {
+    var status: LaunchAtLoginStatus
+    var setEnabledError: Error?
+
+    init(status: LaunchAtLoginStatus = .disabled) {
+        self.status = status
+    }
+
+    func currentStatus() -> LaunchAtLoginStatus {
+        status
+    }
+
+    func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus {
+        if let setEnabledError {
+            throw setEnabledError
+        }
+
+        status = enabled ? .enabled : .disabled
+        return status
+    }
+}
+


### PR DESCRIPTION
MockLaunchAtLoginService isn't keychain-related; extracting fixes an incidental grouping. Byte-identical move. Tests: 667.