### PR TITLE
test: extract MockScreenshotSelectionService.swift from ScreenshotTestSupport.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */; };
 		52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */; };
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
+		544A432385783716D2192028 /* MockScreenshotSelectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72F1D45793B61A6997338F3 /* MockScreenshotSelectionService.swift */; };
 		544FA33C107DC4D4AA136D2B /* SystemAudioFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D6357236D21D641327DEE /* SystemAudioFileWriterTests.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
 		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
@@ -547,6 +548,7 @@
 		B3AE33EE76F55AE456924849 /* TransientToastControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastControllerTests.swift; sourceTree = "<group>"; };
 		B486B153518EB9E1BBC08F17 /* AppState+SystemActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SystemActions.swift"; sourceTree = "<group>"; };
 		B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
+		B72F1D45793B61A6997338F3 /* MockScreenshotSelectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScreenshotSelectionService.swift; sourceTree = "<group>"; };
 		BA49B2B79731E3A62B083174 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
 		BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStoreTests.swift; sourceTree = "<group>"; };
 		BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporter.swift; sourceTree = "<group>"; };
@@ -702,6 +704,7 @@
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */,
+				B72F1D45793B61A6997338F3 /* MockScreenshotSelectionService.swift */,
 				F00EA3260CCEECB3FB097702 /* NetworkTestSupport.swift */,
 				9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
@@ -1210,6 +1213,7 @@
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				C36540B4BE0CB254215654AB /* MixedAudioRecorderTests.swift in Sources */,
+				544A432385783716D2192028 /* MockScreenshotSelectionService.swift in Sources */,
 				3953183BDA19D90C13449F73 /* NetworkTestSupport.swift in Sources */,
 				A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,

--- a/Tests/BugNarratorTests/MockScreenshotSelectionService.swift
+++ b/Tests/BugNarratorTests/MockScreenshotSelectionService.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class MockScreenshotSelectionService: ScreenshotSelecting {
+    var nextResult: ScreenshotSelectionResult = .selected(CGRect(x: 20, y: 20, width: 120, height: 80))
+    var error: Error?
+    var suspendUntilCancelled = false
+    var onSelectRegionStart: (() -> Void)?
+    private(set) var selectRegionCallCount = 0
+    private(set) var cancelActiveSelectionCallCount = 0
+    private var selectionContinuation: CheckedContinuation<ScreenshotSelectionResult, Error>?
+
+    func selectRegion() async throws -> ScreenshotSelectionResult {
+        selectRegionCallCount += 1
+        onSelectRegionStart?()
+
+        if let error {
+            throw error
+        }
+
+        if suspendUntilCancelled {
+            return try await withCheckedThrowingContinuation { continuation in
+                selectionContinuation = continuation
+            }
+        }
+
+        return nextResult
+    }
+
+    func cancelActiveSelection() {
+        cancelActiveSelectionCallCount += 1
+        selectionContinuation?.resume(returning: .cancelled)
+        selectionContinuation = nil
+    }
+}
+

--- a/Tests/BugNarratorTests/ScreenshotTestSupport.swift
+++ b/Tests/BugNarratorTests/ScreenshotTestSupport.swift
@@ -36,38 +36,3 @@ final class MockScreenshotCaptureService: ScreenshotCapturing {
         try Data("screenshot".utf8).write(to: url)
     }
 }
-
-@MainActor
-final class MockScreenshotSelectionService: ScreenshotSelecting {
-    var nextResult: ScreenshotSelectionResult = .selected(CGRect(x: 20, y: 20, width: 120, height: 80))
-    var error: Error?
-    var suspendUntilCancelled = false
-    var onSelectRegionStart: (() -> Void)?
-    private(set) var selectRegionCallCount = 0
-    private(set) var cancelActiveSelectionCallCount = 0
-    private var selectionContinuation: CheckedContinuation<ScreenshotSelectionResult, Error>?
-
-    func selectRegion() async throws -> ScreenshotSelectionResult {
-        selectRegionCallCount += 1
-        onSelectRegionStart?()
-
-        if let error {
-            throw error
-        }
-
-        if suspendUntilCancelled {
-            return try await withCheckedThrowingContinuation { continuation in
-                selectionContinuation = continuation
-            }
-        }
-
-        return nextResult
-    }
-
-    func cancelActiveSelection() {
-        cancelActiveSelectionCallCount += 1
-        selectionContinuation?.resume(returning: .cancelled)
-        selectionContinuation = nil
-    }
-}
-


### PR DESCRIPTION
Splits `MockScreenshotSelectionService` (~35 lines) into own file. Byte-identical move. Tests: 667.