### PR TITLE
test: extract MockPrivacyDataExporter.swift from ExportTestSupport.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		72F6A01ADB045AC8CD503765 /* SessionLibraryEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171956F77EBFEE85F9FF0B22 /* SessionLibraryEmptyState.swift */; };
+		7500170375B97588A081A1BD /* MockPrivacyDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB872F7A7A2A1ED6802B9414 /* MockPrivacyDataExporter.swift */; };
 		75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */; };
@@ -566,6 +567,7 @@
 		C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsServiceTests.swift; sourceTree = "<group>"; };
 		CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainSecretStore.swift; sourceTree = "<group>"; };
+		CB872F7A7A2A1ED6802B9414 /* MockPrivacyDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyDataExporter.swift; sourceTree = "<group>"; };
 		CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibrary.swift; sourceTree = "<group>"; };
 		CCCB5C9DAEB3066CA8E30234 /* SingleInstanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceController.swift; sourceTree = "<group>"; };
 		CD7E24CD9C6DBE0BF94F5A53 /* AIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProvider.swift; sourceTree = "<group>"; };
@@ -702,6 +704,7 @@
 				5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */,
 				9FCEB9CBD524A3CA4F525A7D /* MicrophonePermissionServiceTests.swift */,
 				D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */,
+				CB872F7A7A2A1ED6802B9414 /* MockPrivacyDataExporter.swift */,
 				F00EA3260CCEECB3FB097702 /* NetworkTestSupport.swift */,
 				9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */,
 				D70E5A77E6D0B898A8B3FD81 /* OperationalTelemetryRecorderTests.swift */,
@@ -1210,6 +1213,7 @@
 				14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */,
 				C94BCF47DC9E95A63364E063 /* MicrophonePermissionServiceTests.swift in Sources */,
 				C36540B4BE0CB254215654AB /* MixedAudioRecorderTests.swift in Sources */,
+				7500170375B97588A081A1BD /* MockPrivacyDataExporter.swift in Sources */,
 				3953183BDA19D90C13449F73 /* NetworkTestSupport.swift in Sources */,
 				A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */,
 				00D88D70666311588A8ED4F3 /* OperationalTelemetryRecorderTests.swift in Sources */,

--- a/Tests/BugNarratorTests/ExportTestSupport.swift
+++ b/Tests/BugNarratorTests/ExportTestSupport.swift
@@ -64,35 +64,3 @@ final class MockDebugBundleExporter: DebugBundleExporting {
         return try exportResult.get()
     }
 }
-
-@MainActor
-final class MockPrivacyDataExporter: PrivacyDataExporting {
-    struct ExportRequest {
-        let sessions: [TranscriptSession]
-        let settings: PrivacyDataExportSettingsSnapshot
-        let diagnostics: PrivacyDataExportDiagnosticsSnapshot
-    }
-
-    var exportResult: Result<URL?, Error> = .success(nil)
-    private(set) var exportRequests: [ExportRequest] = []
-
-    func export(
-        sessions: PrivacyDataSessionStream,
-        settings: PrivacyDataExportSettingsSnapshot,
-        diagnostics: PrivacyDataExportDiagnosticsSnapshot
-    ) throws -> URL? {
-        // Materialize the lazy stream so existing assertions on the requested
-        // sessions keep working.
-        var materialized: [TranscriptSession] = []
-        try sessions.forEach { materialized.append($0) }
-        exportRequests.append(
-            ExportRequest(
-                sessions: materialized,
-                settings: settings,
-                diagnostics: diagnostics
-            )
-        )
-        return try exportResult.get()
-    }
-}
-

--- a/Tests/BugNarratorTests/MockPrivacyDataExporter.swift
+++ b/Tests/BugNarratorTests/MockPrivacyDataExporter.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import BugNarrator
+
+@MainActor
+final class MockPrivacyDataExporter: PrivacyDataExporting {
+    struct ExportRequest {
+        let sessions: [TranscriptSession]
+        let settings: PrivacyDataExportSettingsSnapshot
+        let diagnostics: PrivacyDataExportDiagnosticsSnapshot
+    }
+
+    var exportResult: Result<URL?, Error> = .success(nil)
+    private(set) var exportRequests: [ExportRequest] = []
+
+    func export(
+        sessions: PrivacyDataSessionStream,
+        settings: PrivacyDataExportSettingsSnapshot,
+        diagnostics: PrivacyDataExportDiagnosticsSnapshot
+    ) throws -> URL? {
+        // Materialize the lazy stream so existing assertions on the requested
+        // sessions keep working.
+        var materialized: [TranscriptSession] = []
+        try sessions.forEach { materialized.append($0) }
+        exportRequests.append(
+            ExportRequest(
+                sessions: materialized,
+                settings: settings,
+                diagnostics: diagnostics
+            )
+        )
+        return try exportResult.get()
+    }
+}
+


### PR DESCRIPTION
Splits `MockPrivacyDataExporter` (~30 lines) into own file. Byte-identical move. Tests: 667.