### PR TITLE
refactor: extract KeychainSessionDataProtector.swift from SessionDataProtector.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
 		474596AEBE0A97F33B320E59 /* AppErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54521C239C09E5B94712EB /* AppErrorTypes.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
+		49456F4EF912E8E0775E366E /* KeychainSessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1750DB333E56F6915C9953B /* KeychainSessionDataProtector.swift */; };
 		4D1C9E0E08BD5550F0A10C10 /* AppState+AIProviderCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6BBD3839BF28AC52214FEB /* AppState+AIProviderCredential.swift */; };
 		4D81592844E0FDC8BDF43D90 /* StorageRecoveryBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9D6C752334532E660C00AF /* StorageRecoveryBanner.swift */; };
 		4D9A19996F3BCEC530DEA5F8 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865C5FE84904ECA5F4379637 /* MenuBarView.swift */; };
@@ -612,6 +613,7 @@
 		F0300D3CA1B339D4D1CCAC84 /* IssueExportTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportTargets.swift; sourceTree = "<group>"; };
 		F03E1852A3D56F888E98739E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionControllerTests.swift; sourceTree = "<group>"; };
+		F1750DB333E56F6915C9953B /* KeychainSessionDataProtector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainSessionDataProtector.swift; sourceTree = "<group>"; };
 		F1FC7CCF9369F37FE80020A9 /* AsyncTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimeout.swift; sourceTree = "<group>"; };
 		F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchContinuityMonitor.swift; sourceTree = "<group>"; };
 		F5A765BE28AA15D4FFE7DAE4 /* TranscriptionClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClientTests.swift; sourceTree = "<group>"; };
@@ -902,6 +904,7 @@
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
+				F1750DB333E56F6915C9953B /* KeychainSessionDataProtector.swift */,
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
 				38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */,
@@ -1366,6 +1369,7 @@
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
+				49456F4EF912E8E0775E366E /* KeychainSessionDataProtector.swift in Sources */,
 				099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */,
 				E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */,
 				525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */,

--- a/Sources/BugNarrator/Services/KeychainSessionDataProtector.swift
+++ b/Sources/BugNarrator/Services/KeychainSessionDataProtector.swift
@@ -1,0 +1,64 @@
+import CryptoKit
+import Foundation
+import Security
+
+struct KeychainSessionDataProtector: SessionDataProtecting {
+    static let service = "BugNarrator.SessionData"
+    static let account = "session-data-encryption-key"
+
+    private static let payloadPrefix = Data("BNENC1\n".utf8)
+
+    let writesEncryptedPayloads = true
+
+    private let keychainService: any KeychainServicing
+
+    init(keychainService: any KeychainServicing = KeychainService()) {
+        self.keychainService = keychainService
+    }
+
+    func protect(_ data: Data) throws -> Data {
+        let sealedBox = try AES.GCM.seal(data, using: symmetricKey())
+        guard let combined = sealedBox.combined else {
+            throw AppError.storageFailure("Encrypted session data could not be prepared.")
+        }
+
+        return Self.payloadPrefix + combined
+    }
+
+    func unprotect(_ data: Data) throws -> Data {
+        guard data.starts(with: Self.payloadPrefix) else {
+            return data
+        }
+
+        let encryptedData = data.dropFirst(Self.payloadPrefix.count)
+        let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
+        return try AES.GCM.open(sealedBox, using: symmetricKey())
+    }
+
+    private func symmetricKey() throws -> SymmetricKey {
+        if let storedValue = try keychainService.string(
+            forService: Self.service,
+            account: Self.account,
+            allowInteraction: true
+        ),
+           let keyData = Data(base64Encoded: storedValue),
+           keyData.count == 32 {
+            return SymmetricKey(data: keyData)
+        }
+
+        var keyData = Data(count: 32)
+        let status = keyData.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, 32, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else {
+            throw AppError.storageFailure("A local session encryption key could not be generated.")
+        }
+
+        try keychainService.setString(
+            keyData.base64EncodedString(),
+            service: Self.service,
+            account: Self.account
+        )
+        return SymmetricKey(data: keyData)
+    }
+}

--- a/Sources/BugNarrator/Services/SessionDataProtector.swift
+++ b/Sources/BugNarrator/Services/SessionDataProtector.swift
@@ -19,68 +19,6 @@ struct PlaintextSessionDataProtector: SessionDataProtecting {
         data
     }
 }
-
-struct KeychainSessionDataProtector: SessionDataProtecting {
-    static let service = "BugNarrator.SessionData"
-    static let account = "session-data-encryption-key"
-
-    private static let payloadPrefix = Data("BNENC1\n".utf8)
-
-    let writesEncryptedPayloads = true
-
-    private let keychainService: any KeychainServicing
-
-    init(keychainService: any KeychainServicing = KeychainService()) {
-        self.keychainService = keychainService
-    }
-
-    func protect(_ data: Data) throws -> Data {
-        let sealedBox = try AES.GCM.seal(data, using: symmetricKey())
-        guard let combined = sealedBox.combined else {
-            throw AppError.storageFailure("Encrypted session data could not be prepared.")
-        }
-
-        return Self.payloadPrefix + combined
-    }
-
-    func unprotect(_ data: Data) throws -> Data {
-        guard data.starts(with: Self.payloadPrefix) else {
-            return data
-        }
-
-        let encryptedData = data.dropFirst(Self.payloadPrefix.count)
-        let sealedBox = try AES.GCM.SealedBox(combined: encryptedData)
-        return try AES.GCM.open(sealedBox, using: symmetricKey())
-    }
-
-    private func symmetricKey() throws -> SymmetricKey {
-        if let storedValue = try keychainService.string(
-            forService: Self.service,
-            account: Self.account,
-            allowInteraction: true
-        ),
-           let keyData = Data(base64Encoded: storedValue),
-           keyData.count == 32 {
-            return SymmetricKey(data: keyData)
-        }
-
-        var keyData = Data(count: 32)
-        let status = keyData.withUnsafeMutableBytes { buffer in
-            SecRandomCopyBytes(kSecRandomDefault, 32, buffer.baseAddress!)
-        }
-        guard status == errSecSuccess else {
-            throw AppError.storageFailure("A local session encryption key could not be generated.")
-        }
-
-        try keychainService.setString(
-            keyData.base64EncodedString(),
-            service: Self.service,
-            account: Self.account
-        )
-        return SymmetricKey(data: keyData)
-    }
-}
-
 enum SessionDataProtectorFactory {
     static func automatic(
         keychainService: any KeychainServicing = KeychainService(),


### PR DESCRIPTION
Splits `KeychainSessionDataProtector` (~60 lines) into own file. Byte-identical move. Tests: 667.