### PR TITLE
refactor: extract PlaintextSessionDataProtector.swift from SessionDataProtector.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		821321214EEE301B11A61654 /* MenuBarStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D2B31107CC14CDD9E0898ED /* MenuBarStatusPresentation.swift */; };
 		82C0E2BE74D268CA44EEA500 /* IssueScreenshotAnnotationPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE0730768765056797499E6B /* IssueScreenshotAnnotationPreview.swift */; };
 		8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */; };
+		8479179960EE80BF651ED9C0 /* PlaintextSessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11FAE2CE372D3E48ED5FFC20 /* PlaintextSessionDataProtector.swift */; };
 		8507C1549A3313E2C9CD4C10 /* TranscriptionRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CD9BA732E87ECCC87659E2 /* TranscriptionRequestFactory.swift */; };
 		8598258404428C8692A51907 /* ExportReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */; };
 		8666985E2260463398766FBD /* HotkeyShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE5A3102900FD595AE2A07E /* HotkeyShortcut.swift */; };
@@ -345,6 +346,7 @@
 		0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FileRevealActions.swift"; sourceTree = "<group>"; };
 		102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceipt.swift; sourceTree = "<group>"; };
 		104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportConfig.swift; sourceTree = "<group>"; };
+		11FAE2CE372D3E48ED5FFC20 /* PlaintextSessionDataProtector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaintextSessionDataProtector.swift; sourceTree = "<group>"; };
 		125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageProvider.swift; sourceTree = "<group>"; };
 		154255C955FE33FD6D016BE9 /* PrivacyDataExportTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExportTypes.swift; sourceTree = "<group>"; };
 		1691FC9128F5B3D543C87721 /* ExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestSupport.swift; sourceTree = "<group>"; };
@@ -914,6 +916,7 @@
 				31EF5F62FF802B7B8D41022D /* PermissionAndPreflightTypes.swift */,
 				6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */,
 				AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */,
+				11FAE2CE372D3E48ED5FFC20 /* PlaintextSessionDataProtector.swift */,
 				E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */,
 				4C809A64CE202980AFC55953 /* PostTranscriptionResultHandlers.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
@@ -1385,6 +1388,7 @@
 				5E4490C17E49287B620FF2FA /* PermissionAndPreflightTypes.swift in Sources */,
 				68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */,
 				E60F34C1E0FED78A8F28FFDE /* PermissionRecoveryTypes.swift in Sources */,
+				8479179960EE80BF651ED9C0 /* PlaintextSessionDataProtector.swift in Sources */,
 				B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */,
 				A2C76BB4E680144BF1CE9586 /* PostTranscriptionPipelineTypes.swift in Sources */,
 				D9A9D1BB81401E2D14462808 /* PostTranscriptionResultHandlers.swift in Sources */,

--- a/Sources/BugNarrator/Services/PlaintextSessionDataProtector.swift
+++ b/Sources/BugNarrator/Services/PlaintextSessionDataProtector.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct PlaintextSessionDataProtector: SessionDataProtecting {
+    let writesEncryptedPayloads = false
+
+    func protect(_ data: Data) throws -> Data {
+        data
+    }
+
+    func unprotect(_ data: Data) throws -> Data {
+        data
+    }
+}

--- a/Sources/BugNarrator/Services/SessionDataProtector.swift
+++ b/Sources/BugNarrator/Services/SessionDataProtector.swift
@@ -7,19 +7,6 @@ protocol SessionDataProtecting {
     func protect(_ data: Data) throws -> Data
     func unprotect(_ data: Data) throws -> Data
 }
-
-struct PlaintextSessionDataProtector: SessionDataProtecting {
-    let writesEncryptedPayloads = false
-
-    func protect(_ data: Data) throws -> Data {
-        data
-    }
-
-    func unprotect(_ data: Data) throws -> Data {
-        data
-    }
-}
-
 struct KeychainSessionDataProtector: SessionDataProtecting {
     static let service = "BugNarrator.SessionData"
     static let account = "session-data-encryption-key"


### PR DESCRIPTION
Mirrors #760 KSDP. Splits the trivial passthrough protector into own file. Byte-identical move. Tests: 667.