### PR TITLE
refactor: extract PrerequisiteRow.swift from SettingsReadinessTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3104282993DE974208688237 /* TranscriptQualityFinding.swift */; };
 		7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */; };
 		7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */; };
+		7F28C11F0D4E01691C9CA783 /* PrerequisiteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9498897FCC859A9DCFCB53 /* PrerequisiteRow.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
 		806F6B3953A77B84672AD2DA /* AppRuntimeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */; };
 		8124F6AEFE87F470DE1D3B56 /* IssueExtractionRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */; };
@@ -503,6 +504,7 @@
 		8B9EE251C9CCE29EDED45889 /* IssueExtractionResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionResponseParserTests.swift; sourceTree = "<group>"; };
 		8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscription.swift; sourceTree = "<group>"; };
 		8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewComponents.swift; sourceTree = "<group>"; };
+		8D9498897FCC859A9DCFCB53 /* PrerequisiteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrerequisiteRow.swift; sourceTree = "<group>"; };
 		8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilderTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		8FB75074747EE722764CC071 /* IssueExportPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportPresenters.swift; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 		05B6FECAF7F08D43DE50EBA0 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				8D9498897FCC859A9DCFCB53 /* PrerequisiteRow.swift */,
 				9C626F1B07544DE20B370D35 /* SettingsAudioPanes.swift */,
 				D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */,
 				0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */,
@@ -1388,6 +1391,7 @@
 				B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */,
 				A2C76BB4E680144BF1CE9586 /* PostTranscriptionPipelineTypes.swift in Sources */,
 				D9A9D1BB81401E2D14462808 /* PostTranscriptionResultHandlers.swift in Sources */,
+				7F28C11F0D4E01691C9CA783 /* PrerequisiteRow.swift in Sources */,
 				61D4778489BCA1F3B7C16161 /* PrivacyDataExportTypes.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,

--- a/Sources/BugNarrator/Views/Settings/PrerequisiteRow.swift
+++ b/Sources/BugNarrator/Views/Settings/PrerequisiteRow.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// One row in a per-integration prerequisite checklist.
+struct PrerequisiteRow: Identifiable {
+    let title: String
+    let detail: String
+    let status: SettingsReadinessStatus
+
+    var id: String {
+        title
+    }
+}
+

--- a/Sources/BugNarrator/Views/Settings/SettingsReadinessTypes.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsReadinessTypes.swift
@@ -45,15 +45,3 @@ enum SettingsReadinessStatus {
         }
     }
 }
-
-/// One row in a per-integration prerequisite checklist.
-struct PrerequisiteRow: Identifiable {
-    let title: String
-    let detail: String
-    let status: SettingsReadinessStatus
-
-    var id: String {
-        title
-    }
-}
-


### PR DESCRIPTION
Splits data struct out; readiness enum stays. Byte-identical move. Tests: 667.