### PR TITLE
refactor: extract SettingsCalloutTone.swift from SettingsStore.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EFF170BAD57E66A7CB20AB /* AppState.swift */; };
 		A0CCAAA3701FF6274B792685 /* APIKeyValidationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */; };
 		A17B5FCA1F95211DF2321774 /* AppStateHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C367EF1F4D24E1E5819087 /* AppStateHarness.swift */; };
+		A233D37201A3BD9FA2F30F60 /* SettingsCalloutTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A6ECB97385B9451286916C /* SettingsCalloutTone.swift */; };
 		A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */; };
 		A2C76BB4E680144BF1CE9586 /* PostTranscriptionPipelineTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3D789DB36F39ADB7CC2A79 /* PostTranscriptionPipelineTypes.swift */; };
 		A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */; };
@@ -445,6 +446,7 @@
 		60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapper.swift; sourceTree = "<group>"; };
 		6131EA189B853D1B456A8D26 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6161AB93D74FD6A2471534C5 /* AppState+SessionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SessionLibrary.swift"; sourceTree = "<group>"; };
+		61A6ECB97385B9451286916C /* SettingsCalloutTone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCalloutTone.swift; sourceTree = "<group>"; };
 		6346CF407E47D31933561CA1 /* HotkeySupportClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeySupportClasses.swift; sourceTree = "<group>"; };
 		64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironmentTests.swift; sourceTree = "<group>"; };
 		64F0A81E02972573D2556B85 /* AppState+RecordingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+RecordingTimer.swift"; sourceTree = "<group>"; };
@@ -937,6 +939,7 @@
 				52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */,
 				5FC9AEF9C67019E23C116896 /* SessionLibraryPresenters.swift */,
 				313F4C6AD4D6A93E3995386E /* SessionLibraryStatusPresenter+Attempt.swift */,
+				61A6ECB97385B9451286916C /* SettingsCalloutTone.swift */,
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
@@ -1427,6 +1430,7 @@
 				F0C234F3BD7753A09B98A332 /* SessionRow.swift in Sources */,
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,
 				1D7402D8CC37B5E8F4F71CD6 /* SettingsAudioPanes.swift in Sources */,
+				A233D37201A3BD9FA2F30F60 /* SettingsCalloutTone.swift in Sources */,
 				3546CF9BD922CF576E96F1C5 /* SettingsDiagnosticsPrivacyPane.swift in Sources */,
 				8E41CD2A7BE6A70F5CD9F46C /* SettingsGeneralPanes.swift in Sources */,
 				D759CEA88F50769454691AFC /* SettingsIntegrationsPanes.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsCalloutTone.swift
+++ b/Sources/BugNarrator/Services/SettingsCalloutTone.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum SettingsCalloutTone: Equatable {
+    case secondary
+    case warning
+    case error
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -1955,9 +1955,3 @@ enum APIKeyPersistenceState: Equatable {
     case sessionOnly
     case pendingSave
 }
-
-enum SettingsCalloutTone: Equatable {
-    case secondary
-    case warning
-    case error
-}


### PR DESCRIPTION
Mirrors #768. Extracts callout tone enum. Byte-identical move. Tests: 667.