### PR TITLE
refactor: extract AppUtilityActionResultPresenter.swift from AppUtilityActionController.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		994C5601BD2578CC3A980002 /* AIProviderSettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */; };
 		99A01D146ED4D77DA20484A5 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 792A02D8EE4EBB2A02D4043D /* CHANGELOG.md */; };
 		9BDE73A1F0BA27B80A72F736 /* SessionLibraryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33027EA9F37EA57406F2D1A /* SessionLibraryItem.swift */; };
+		9C3B90D25F3A66C7338481D4 /* AppUtilityActionResultPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1BD9C4FD4605E7160818FD /* AppUtilityActionResultPresenter.swift */; };
 		9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */; };
 		9D12A5E2379C328D473E6452 /* PendingTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */; };
 		9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */; };
@@ -504,6 +505,7 @@
 		8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscription.swift; sourceTree = "<group>"; };
 		8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewComponents.swift; sourceTree = "<group>"; };
 		8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilderTests.swift; sourceTree = "<group>"; };
+		8E1BD9C4FD4605E7160818FD /* AppUtilityActionResultPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUtilityActionResultPresenter.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		8FB75074747EE722764CC071 /* IssueExportPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportPresenters.swift; sourceTree = "<group>"; };
 		90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProductInfoView.swift; sourceTree = "<group>"; };
@@ -873,6 +875,7 @@
 				EA54521C239C09E5B94712EB /* AppErrorTypes.swift */,
 				90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */,
 				EFCA1A4773C2BB41581B37CB /* AppUtilityActionController.swift */,
+				8E1BD9C4FD4605E7160818FD /* AppUtilityActionResultPresenter.swift */,
 				FB94B9DE300200CB6C35E6F1 /* AudioObjectIDExtensions.swift */,
 				C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */,
 				7539AEF1F536E7EDB2047D7D /* AudioRecorderTypes.swift */,
@@ -1309,6 +1312,7 @@
 				C4388FB859242F0C2B148293 /* AppStatus.swift in Sources */,
 				EEFC9EAEC399AC7CA55A3128 /* AppSupportLocation.swift in Sources */,
 				6FFA4F6D7629DDCB2EBAA070 /* AppUtilityActionController.swift in Sources */,
+				9C3B90D25F3A66C7338481D4 /* AppUtilityActionResultPresenter.swift in Sources */,
 				C1FDA2B024230D874D06D08B /* ApplicationTerminationController.swift in Sources */,
 				C892C9D265037E2DA579B336 /* AsyncTimeout.swift in Sources */,
 				3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */,

--- a/Sources/BugNarrator/Services/AppUtilityActionController.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionController.swift
@@ -7,55 +7,6 @@ enum AppUtilityActionResult: Equatable {
 }
 
 @MainActor
-final class AppUtilityActionResultPresenter {
-    private let statusPhase: () -> AppStatus.Phase
-    private let setStatus: (AppStatus) -> Void
-    private let logger: DiagnosticsLogger
-
-    init(
-        statusPhase: @escaping () -> AppStatus.Phase,
-        setStatus: @escaping (AppStatus) -> Void,
-        logger: DiagnosticsLogger = DiagnosticsLogger(category: .settings)
-    ) {
-        self.statusPhase = statusPhase
-        self.setStatus = setStatus
-        self.logger = logger
-    }
-
-    func present(_ result: AppUtilityActionResult) {
-        guard case .failed(let message) = result else {
-            return
-        }
-
-        presentFailure(message)
-    }
-
-    func present(_ result: PermissionSettingsOpenResult) {
-        guard case .failed(let message) = result else {
-            return
-        }
-
-        presentFailure(message)
-    }
-
-    func presentFailure(_ message: String) {
-        logger.warning("utility_action_failed", message)
-        setStatus(Self.failureStatus(message: message, statusPhase: statusPhase()))
-    }
-
-    static func failureStatus(message: String, statusPhase: AppStatus.Phase) -> AppStatus {
-        switch statusPhase {
-        case .recording:
-            return .recording("\(message) Recording is still active.")
-        case .transcribing:
-            return .transcribing("\(message) Background work is still in progress.")
-        case .idle, .success, .error:
-            return .error(message)
-        }
-    }
-}
-
-@MainActor
 final class AppUtilityActionController {
     var showTranscriptWindow: (() -> Void)?
     var showSettingsWindow: (() -> Void)?

--- a/Sources/BugNarrator/Services/AppUtilityActionResultPresenter.swift
+++ b/Sources/BugNarrator/Services/AppUtilityActionResultPresenter.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class AppUtilityActionResultPresenter {
+    private let statusPhase: () -> AppStatus.Phase
+    private let setStatus: (AppStatus) -> Void
+    private let logger: DiagnosticsLogger
+
+    init(
+        statusPhase: @escaping () -> AppStatus.Phase,
+        setStatus: @escaping (AppStatus) -> Void,
+        logger: DiagnosticsLogger = DiagnosticsLogger(category: .settings)
+    ) {
+        self.statusPhase = statusPhase
+        self.setStatus = setStatus
+        self.logger = logger
+    }
+
+    func present(_ result: AppUtilityActionResult) {
+        guard case .failed(let message) = result else {
+            return
+        }
+
+        presentFailure(message)
+    }
+
+    func present(_ result: PermissionSettingsOpenResult) {
+        guard case .failed(let message) = result else {
+            return
+        }
+
+        presentFailure(message)
+    }
+
+    func presentFailure(_ message: String) {
+        logger.warning("utility_action_failed", message)
+        setStatus(Self.failureStatus(message: message, statusPhase: statusPhase()))
+    }
+
+    static func failureStatus(message: String, statusPhase: AppStatus.Phase) -> AppStatus {
+        switch statusPhase {
+        case .recording:
+            return .recording("\(message) Recording is still active.")
+        case .transcribing:
+            return .transcribing("\(message) Background work is still in progress.")
+        case .idle, .success, .error:
+            return .error(message)
+        }
+    }


### PR DESCRIPTION
Splits presenter class (~48 lines) into own file. Byte-identical move. Tests: 667.