### PR TITLE
refactor: extract RecordingStatusMessageSnapshot.swift from RecordingStatusMessageProvider.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		A859F2836880F7D2596CD482 /* AudioRecorderTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7539AEF1F536E7EDB2047D7D /* AudioRecorderTypes.swift */; };
 		A88C8D43152C2EE414CC78D2 /* OpenAIErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3A2F0B7AFCAA4E2E0020CF /* OpenAIErrorMapperTests.swift */; };
 		A903B084AE51759DC0889D3A /* AppStateProviderValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D98BD0399A4FCBF9BFA27773 /* AppStateProviderValidationTests.swift */; };
+		A9383A6A196819882B60320A /* RecordingStatusMessageSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89504D6A018EEF2BDE19F9F /* RecordingStatusMessageSnapshot.swift */; };
 		A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */; };
 		AA75C664726B10D24FA0393A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8E0EE1D051EF433249045D /* TestUtilities.swift */; };
 		AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */; };
@@ -597,6 +598,7 @@
 		E59F6509D79E57A86ED795CA /* SessionLibraryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryControllerTests.swift; sourceTree = "<group>"; };
 		E75E9A5FCC6C1D45D20E8F80 /* IssueExportControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportControllerTests.swift; sourceTree = "<group>"; };
 		E849C3E02857E9CF3FDCC39A /* ScreenshotTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotTestSupport.swift; sourceTree = "<group>"; };
+		E89504D6A018EEF2BDE19F9F /* RecordingStatusMessageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageSnapshot.swift; sourceTree = "<group>"; };
 		E8EF5167B9226AE01E478075 /* IssueExtractionRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilder.swift; sourceTree = "<group>"; };
 		E90F9F3F9007D9D9CD1FAABC /* WindowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCoordinator.swift; sourceTree = "<group>"; };
 		EA54521C239C09E5B94712EB /* AppErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTypes.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				9D3D789DB36F39ADB7CC2A79 /* PostTranscriptionPipelineTypes.swift */,
 				B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */,
 				125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */,
+				E89504D6A018EEF2BDE19F9F /* RecordingStatusMessageSnapshot.swift */,
 				002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */,
 				60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */,
 				D70C2AF1D71698B8CB98490E /* ReviewWorkspaceTypes.swift */,
@@ -1399,6 +1402,7 @@
 				93561F8BD8484E68D3E96012 /* RecordingSessionPresenters.swift in Sources */,
 				952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */,
 				8D34D845BE5587EC9B1E1765 /* RecordingStatusMessageProvider.swift in Sources */,
+				A9383A6A196819882B60320A /* RecordingStatusMessageSnapshot.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
 				BBE16FF238B059EF08346355 /* ReviewWorkspaceTypes.swift in Sources */,

--- a/Sources/BugNarrator/Utilities/RecordingStatusMessageProvider.swift
+++ b/Sources/BugNarrator/Utilities/RecordingStatusMessageProvider.swift
@@ -1,14 +1,6 @@
 import Combine
 import Foundation
 
-struct RecordingStatusMessageSnapshot: Equatable {
-    var audioSource: RecordingAudioSource
-    var hasUsableAIProviderCredential: Bool
-    var aiProviderCompatibilityIssue: String?
-    var autoExtractIssues: Bool
-    var autoCopyTranscript: Bool
-}
-
 final class RecordingStatusMessageProvider {
     private let snapshot: () -> RecordingStatusMessageSnapshot
 

--- a/Sources/BugNarrator/Utilities/RecordingStatusMessageSnapshot.swift
+++ b/Sources/BugNarrator/Utilities/RecordingStatusMessageSnapshot.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct RecordingStatusMessageSnapshot: Equatable {
+    var audioSource: RecordingAudioSource
+    var hasUsableAIProviderCredential: Bool
+    var aiProviderCompatibilityIssue: String?
+    var autoExtractIssues: Bool
+    var autoCopyTranscript: Bool
+}


### PR DESCRIPTION
Splits the value struct out. Byte-identical move. Tests: 667.