### PR TITLE
refactor: extract PermissionRecoveryStatusPresenter.swift from PermissionRecoveryTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		72F6A01ADB045AC8CD503765 /* SessionLibraryEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171956F77EBFEE85F9FF0B22 /* SessionLibraryEmptyState.swift */; };
+		7594711B1C3C77F23943B075 /* PermissionRecoveryStatusPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADEAA602C785FD9794321AC /* PermissionRecoveryStatusPresenter.swift */; };
 		75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */; };
@@ -429,6 +430,7 @@
 		59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutBugNarratorView.swift; sourceTree = "<group>"; };
 		5A8CB6ECBCE39874B5B432EF /* ChangelogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangelogView.swift; sourceTree = "<group>"; };
 		5ABEC93C3EF20960325C6FF7 /* DebugBundleTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBundleTypes.swift; sourceTree = "<group>"; };
+		5ADEAA602C785FD9794321AC /* PermissionRecoveryStatusPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryStatusPresenter.swift; sourceTree = "<group>"; };
 		5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshot.swift; sourceTree = "<group>"; };
 		5BCEC36FA2A05A4FD9CE5F0B /* SystemAudioFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioFileWriter.swift; sourceTree = "<group>"; };
 		5C5346EDB503C6B05C81C368 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
 				31EF5F62FF802B7B8D41022D /* PermissionAndPreflightTypes.swift */,
 				6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */,
+				5ADEAA602C785FD9794321AC /* PermissionRecoveryStatusPresenter.swift */,
 				AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */,
 				E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */,
 				4C809A64CE202980AFC55953 /* PostTranscriptionResultHandlers.swift */,
@@ -1384,6 +1387,7 @@
 				9D12A5E2379C328D473E6452 /* PendingTranscription.swift in Sources */,
 				5E4490C17E49287B620FF2FA /* PermissionAndPreflightTypes.swift in Sources */,
 				68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */,
+				7594711B1C3C77F23943B075 /* PermissionRecoveryStatusPresenter.swift in Sources */,
 				E60F34C1E0FED78A8F28FFDE /* PermissionRecoveryTypes.swift in Sources */,
 				B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */,
 				A2C76BB4E680144BF1CE9586 /* PostTranscriptionPipelineTypes.swift in Sources */,

--- a/Sources/BugNarrator/Services/PermissionRecoveryStatusPresenter.swift
+++ b/Sources/BugNarrator/Services/PermissionRecoveryStatusPresenter.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@MainActor
+final class PermissionRecoveryStatusPresenter {
+    private let errorPresenter: AppErrorPresenter
+
+    init(errorPresenter: AppErrorPresenter) {
+        self.errorPresenter = errorPresenter
+    }
+
+    func present(_ outcome: PermissionRecoveryRefreshOutcome) {
+        guard case .recovered(let status) = outcome else {
+            return
+        }
+
+        errorPresenter.setStatus(status)
+    }
+}

--- a/Sources/BugNarrator/Services/PermissionRecoveryTypes.swift
+++ b/Sources/BugNarrator/Services/PermissionRecoveryTypes.swift
@@ -9,20 +9,3 @@ enum PermissionSettingsOpenResult: Equatable {
     case opened(URL)
     case failed(String)
 }
-
-@MainActor
-final class PermissionRecoveryStatusPresenter {
-    private let errorPresenter: AppErrorPresenter
-
-    init(errorPresenter: AppErrorPresenter) {
-        self.errorPresenter = errorPresenter
-    }
-
-    func present(_ outcome: PermissionRecoveryRefreshOutcome) {
-        guard case .recovered(let status) = outcome else {
-            return
-        }
-
-        errorPresenter.setStatus(status)
-    }
-}


### PR DESCRIPTION
Splits presenter class into own file; outcome enums stay. Byte-identical move. Tests: 667.