### PR TITLE
refactor: extract MixedAudioTrackInsertionOffsets.swift from MixedAudioTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		A903B084AE51759DC0889D3A /* AppStateProviderValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D98BD0399A4FCBF9BFA27773 /* AppStateProviderValidationTests.swift */; };
 		A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */; };
 		AA75C664726B10D24FA0393A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8E0EE1D051EF433249045D /* TestUtilities.swift */; };
+		AB077A8D16AEE93179DDC4D4 /* MixedAudioTrackInsertionOffsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12152B33B2F2B09C71B85533 /* MixedAudioTrackInsertionOffsets.swift */; };
 		AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */; };
 		ABA48997F0B07377178EDEE0 /* SystemAudioTapSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */; };
 		AD2549206170CE4F862AD61B /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */; };
@@ -345,6 +346,7 @@
 		0EB2CB153890C16C2DE4C815 /* AppState+FileRevealActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+FileRevealActions.swift"; sourceTree = "<group>"; };
 		102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceipt.swift; sourceTree = "<group>"; };
 		104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportConfig.swift; sourceTree = "<group>"; };
+		12152B33B2F2B09C71B85533 /* MixedAudioTrackInsertionOffsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioTrackInsertionOffsets.swift; sourceTree = "<group>"; };
 		125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageProvider.swift; sourceTree = "<group>"; };
 		154255C955FE33FD6D016BE9 /* PrivacyDataExportTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExportTypes.swift; sourceTree = "<group>"; };
 		1691FC9128F5B3D543C87721 /* ExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestSupport.swift; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 				38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
 				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
+				12152B33B2F2B09C71B85533 /* MixedAudioTrackInsertionOffsets.swift */,
 				DEBC588ED995D6DA1A06A1D7 /* MixedAudioTypes.swift */,
 				518C6045D8668A1179198A6D /* MultipartFormDataBuilder.swift */,
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
@@ -1377,6 +1380,7 @@
 				2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */,
 				D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */,
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,
+				AB077A8D16AEE93179DDC4D4 /* MixedAudioTrackInsertionOffsets.swift in Sources */,
 				0ACE5A1504C869B2A2A756A6 /* MixedAudioTypes.swift in Sources */,
 				8E676FE06F6D5D7CAD9CDAD4 /* MultipartFormDataBuilder.swift in Sources */,
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,

--- a/Sources/BugNarrator/Services/MixedAudioTrackInsertionOffsets.swift
+++ b/Sources/BugNarrator/Services/MixedAudioTrackInsertionOffsets.swift
@@ -1,0 +1,31 @@
+import CoreMedia
+import Foundation
+
+struct MixedAudioTrackInsertionOffsets: Equatable {
+    static let zero = MixedAudioTrackInsertionOffsets(
+        microphoneOffset: 0,
+        systemAudioOffset: 0
+    )
+
+    let microphoneOffset: TimeInterval
+    let systemAudioOffset: TimeInterval
+
+    init(microphoneStartedAt: TimeInterval, systemAudioStartedAt: TimeInterval) {
+        let earliestStart = min(microphoneStartedAt, systemAudioStartedAt)
+        microphoneOffset = max(0, microphoneStartedAt - earliestStart)
+        systemAudioOffset = max(0, systemAudioStartedAt - earliestStart)
+    }
+
+    private init(microphoneOffset: TimeInterval, systemAudioOffset: TimeInterval) {
+        self.microphoneOffset = microphoneOffset
+        self.systemAudioOffset = systemAudioOffset
+    }
+
+    var microphoneInsertionTime: CMTime {
+        CMTime(seconds: microphoneOffset, preferredTimescale: 1_000_000)
+    }
+
+    var systemAudioInsertionTime: CMTime {
+        CMTime(seconds: systemAudioOffset, preferredTimescale: 1_000_000)
+    }
+}

--- a/Sources/BugNarrator/Services/MixedAudioTypes.swift
+++ b/Sources/BugNarrator/Services/MixedAudioTypes.swift
@@ -12,32 +12,3 @@ struct MixedAudioSourceStartTimes {
         )
     }
 }
-
-struct MixedAudioTrackInsertionOffsets: Equatable {
-    static let zero = MixedAudioTrackInsertionOffsets(
-        microphoneOffset: 0,
-        systemAudioOffset: 0
-    )
-
-    let microphoneOffset: TimeInterval
-    let systemAudioOffset: TimeInterval
-
-    init(microphoneStartedAt: TimeInterval, systemAudioStartedAt: TimeInterval) {
-        let earliestStart = min(microphoneStartedAt, systemAudioStartedAt)
-        microphoneOffset = max(0, microphoneStartedAt - earliestStart)
-        systemAudioOffset = max(0, systemAudioStartedAt - earliestStart)
-    }
-
-    private init(microphoneOffset: TimeInterval, systemAudioOffset: TimeInterval) {
-        self.microphoneOffset = microphoneOffset
-        self.systemAudioOffset = systemAudioOffset
-    }
-
-    var microphoneInsertionTime: CMTime {
-        CMTime(seconds: microphoneOffset, preferredTimescale: 1_000_000)
-    }
-
-    var systemAudioInsertionTime: CMTime {
-        CMTime(seconds: systemAudioOffset, preferredTimescale: 1_000_000)
-    }
-}


### PR DESCRIPTION
Splits insertion-offsets struct into own file. Byte-identical move. Tests: 667.