### PR TITLE
refactor: extract ExportReceiptStoring.swift from ExportReceipt.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */; };
 		40D75D2D2C83EE58CBB45F6B /* BugNarratorLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */; };
 		4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53226A9282239858514440C /* AppState+PresentationState.swift */; };
+		44D2877047DE535B9D904FD6 /* ExportReceiptStoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF95987710786CE619F032AB /* ExportReceiptStoring.swift */; };
 		456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */; };
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
@@ -627,6 +628,7 @@
 		FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportHistoryControllerTests.swift; sourceTree = "<group>"; };
 		FED17EDC791F33BADA9E14D8 /* BugNarratorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugNarratorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporterTests.swift; sourceTree = "<group>"; };
+		FF95987710786CE619F032AB /* ExportReceiptStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStoring.swift; sourceTree = "<group>"; };
 		FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -883,6 +885,7 @@
 				70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */,
 				102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */,
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
+				FF95987710786CE619F032AB /* ExportReceiptStoring.swift */,
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
@@ -1334,6 +1337,7 @@
 				93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */,
 				8598258404428C8692A51907 /* ExportReceipt.swift in Sources */,
 				A73F5969DB4A2C04BC83BF45 /* ExportReceiptStore.swift in Sources */,
+				44D2877047DE535B9D904FD6 /* ExportReceiptStoring.swift in Sources */,
 				5839C40FC99D94A9C910A218 /* ExportReviewSheet.swift in Sources */,
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
 				BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */,

--- a/Sources/BugNarrator/Services/ExportReceipt.swift
+++ b/Sources/BugNarrator/Services/ExportReceipt.swift
@@ -29,23 +29,3 @@ struct ExportReceipt: Codable, Equatable {
         )
     }
 }
-
-protocol ExportReceiptStoring: Sendable {
-    func receipt(for fingerprint: String) async throws -> ExportReceipt?
-    func allReceipts() async throws -> [ExportReceipt]
-    func markPending(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        destination: ExportDestination,
-        targetIdentity: String
-    ) async throws
-    func markSucceeded(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        destination: ExportDestination,
-        targetIdentity: String,
-        remoteIdentifier: String,
-        remoteURL: URL?
-    ) async throws
-    func clearReceipt(for fingerprint: String) async throws
-}

--- a/Sources/BugNarrator/Services/ExportReceiptStoring.swift
+++ b/Sources/BugNarrator/Services/ExportReceiptStoring.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol ExportReceiptStoring: Sendable {
+    func receipt(for fingerprint: String) async throws -> ExportReceipt?
+    func allReceipts() async throws -> [ExportReceipt]
+    func markPending(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        destination: ExportDestination,
+        targetIdentity: String
+    ) async throws
+    func markSucceeded(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        destination: ExportDestination,
+        targetIdentity: String,
+        remoteIdentifier: String,
+        remoteURL: URL?
+    ) async throws
+    func clearReceipt(for fingerprint: String) async throws
+}


### PR DESCRIPTION
Splits protocol out of value-type file. Byte-identical move. Tests: 667.