### PR TITLE
refactor: extract SystemLaunchAtLoginService.swift from LaunchAtLoginService.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		11935BB2070F2A08AB015BD9 /* DiagnosticsLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */; };
 		11D0925211E3A8D0AC8FF219 /* AppLifecycleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FA8C32EF0CB342E6EF41E9 /* AppLifecycleDelegate.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
+		1486E511D3B8E3503AD08FA6 /* SystemLaunchAtLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3CED6C5316BD316231171E /* SystemLaunchAtLoginService.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
 		15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */; };
@@ -582,6 +583,7 @@
 		D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
 		D98BD0399A4FCBF9BFA27773 /* AppStateProviderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateProviderValidationTests.swift; sourceTree = "<group>"; };
 		DAE6A1D707211E467BFD8EF0 /* VerboseTranscriptionResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerboseTranscriptionResponseParser.swift; sourceTree = "<group>"; };
+		DB3CED6C5316BD316231171E /* SystemLaunchAtLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLaunchAtLoginService.swift; sourceTree = "<group>"; };
 		DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStore.swift; sourceTree = "<group>"; };
 		DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionPresenters.swift; sourceTree = "<group>"; };
 		DD521B33574057DABAC05903 /* IssueExtractionPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionPresenters.swift; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 				5BCEC36FA2A05A4FD9CE5F0B /* SystemAudioFileWriter.swift */,
 				6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */,
 				D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */,
+				DB3CED6C5316BD316231171E /* SystemLaunchAtLoginService.swift */,
 				5D05D14432F331F83DB44AD9 /* TelemetryTypes.swift */,
 				1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */,
 				74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */,
@@ -1447,6 +1450,7 @@
 				D1816E560B00B71EB9A625EA /* SystemAudioFileWriter.swift in Sources */,
 				BE0F157736897DB21F47F8C6 /* SystemAudioRecorder.swift in Sources */,
 				ABA48997F0B07377178EDEE0 /* SystemAudioTapSession.swift in Sources */,
+				1486E511D3B8E3503AD08FA6 /* SystemLaunchAtLoginService.swift in Sources */,
 				2455C6B282EF275B5B55F591 /* TelemetryTypes.swift in Sources */,
 				9C875F3839EE3EE9D7AC083B /* TrackerExportPayloadBudget.swift in Sources */,
 				DBFA5905D305404FAD17EC5E /* TrackerExportRetryTypes.swift in Sources */,

--- a/Sources/BugNarrator/Services/LaunchAtLoginService.swift
+++ b/Sources/BugNarrator/Services/LaunchAtLoginService.swift
@@ -59,42 +59,6 @@ protocol LaunchAtLoginControlling {
     func currentStatus() -> LaunchAtLoginStatus
     func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus
 }
-
-struct SystemLaunchAtLoginService: LaunchAtLoginControlling {
-    func currentStatus() -> LaunchAtLoginStatus {
-        guard #available(macOS 13.0, *) else {
-            return .unavailable
-        }
-
-        switch SMAppService.mainApp.status {
-        case .notRegistered:
-            return .disabled
-        case .enabled:
-            return .enabled
-        case .requiresApproval:
-            return .requiresApproval
-        case .notFound:
-            return .notFound
-        @unknown default:
-            return .unavailable
-        }
-    }
-
-    func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus {
-        guard #available(macOS 13.0, *) else {
-            return .unavailable
-        }
-
-        if enabled {
-            try SMAppService.mainApp.register()
-        } else {
-            try SMAppService.mainApp.unregister()
-        }
-
-        return currentStatus()
-    }
-}
-
 struct TestingLaunchAtLoginService: LaunchAtLoginControlling {
     let status: LaunchAtLoginStatus
 

--- a/Sources/BugNarrator/Services/SystemLaunchAtLoginService.swift
+++ b/Sources/BugNarrator/Services/SystemLaunchAtLoginService.swift
@@ -1,0 +1,37 @@
+import Foundation
+import ServiceManagement
+
+struct SystemLaunchAtLoginService: LaunchAtLoginControlling {
+    func currentStatus() -> LaunchAtLoginStatus {
+        guard #available(macOS 13.0, *) else {
+            return .unavailable
+        }
+
+        switch SMAppService.mainApp.status {
+        case .notRegistered:
+            return .disabled
+        case .enabled:
+            return .enabled
+        case .requiresApproval:
+            return .requiresApproval
+        case .notFound:
+            return .notFound
+        @unknown default:
+            return .unavailable
+        }
+    }
+
+    func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus {
+        guard #available(macOS 13.0, *) else {
+            return .unavailable
+        }
+
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+
+        return currentStatus()
+    }
+}


### PR DESCRIPTION
Mirrors #737. Splits the SMAppService-backed impl out into own file. Byte-identical move. Tests: 667.