### PR TITLE
refactor: extract MicrophoneRecoveryGuidance.swift from PermissionAndPreflightTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		24EAF9A3DAF9624979F3F358 /* IssueExportTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D566BDB865CF9FF245BB283 /* IssueExportTestSupport.swift */; };
 		255F6B56A8E14ED7C80DB0FA /* ScreenshotsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */; };
 		280973289AE78D9919ECD80C /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5346EDB503C6B05C81C368 /* KeychainService.swift */; };
+		2862B1A3774BBA21F6B7FA44 /* MicrophoneRecoveryGuidance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8190CCDD6364A3E3A66394D1 /* MicrophoneRecoveryGuidance.swift */; };
 		289E65529C0ED7D189FCCFFF /* TrackerExportSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70541D070FF81D54D6559524 /* TrackerExportSettingsStore.swift */; };
 		28FFF0FBF53923BC686FF79D /* ScreenshotAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8E3D66AA1E0FB9030E4A78 /* ScreenshotAnnotationTests.swift */; };
 		292C923C8BBAAC790BB12BED /* AppServiceContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */; };
@@ -488,6 +489,7 @@
 		7F271FCF4D5A2759B4D6DCE4 /* TranscriptionRecoveryPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryPresenters.swift; sourceTree = "<group>"; };
 		800BFCC6407B534886C65D77 /* TranscriptionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClient.swift; sourceTree = "<group>"; };
 		811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionService.swift; sourceTree = "<group>"; };
+		8190CCDD6364A3E3A66394D1 /* MicrophoneRecoveryGuidance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophoneRecoveryGuidance.swift; sourceTree = "<group>"; };
 		820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabelView.swift; sourceTree = "<group>"; };
 		83CE91359103D30C04663766 /* TranscriptionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionModels.swift; sourceTree = "<group>"; };
 		84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTranscriptionPipelineControllerTests.swift; sourceTree = "<group>"; };
@@ -906,6 +908,7 @@
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
 				38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
+				8190CCDD6364A3E3A66394D1 /* MicrophoneRecoveryGuidance.swift */,
 				0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */,
 				DEBC588ED995D6DA1A06A1D7 /* MixedAudioTypes.swift */,
 				518C6045D8668A1179198A6D /* MultipartFormDataBuilder.swift */,
@@ -1376,6 +1379,7 @@
 				5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */,
 				2C4B0D2F815BAB20916ABD9C /* MicrophonePermissionResolver.swift in Sources */,
 				D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */,
+				2862B1A3774BBA21F6B7FA44 /* MicrophoneRecoveryGuidance.swift in Sources */,
 				7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */,
 				0ACE5A1504C869B2A2A756A6 /* MixedAudioTypes.swift in Sources */,
 				8E676FE06F6D5D7CAD9CDAD4 /* MultipartFormDataBuilder.swift in Sources */,

--- a/Sources/BugNarrator/Services/MicrophoneRecoveryGuidance.swift
+++ b/Sources/BugNarrator/Services/MicrophoneRecoveryGuidance.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct MicrophoneRecoveryGuidance: Equatable {
+    let headline: String
+    let message: String
+    let localTestingNote: String?
+}

--- a/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
+++ b/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
@@ -17,12 +17,6 @@ enum MicrophonePermissionStatus: String, Equatable {
     case unknownError
 }
 
-struct MicrophoneRecoveryGuidance: Equatable {
-    let headline: String
-    let message: String
-    let localTestingNote: String?
-}
-
 enum RecordingStartPreflightResult: Equatable {
     case success
     case blocked(AppError)


### PR DESCRIPTION
Splits data struct out. Byte-identical move. Tests: 667.