### PR TITLE
refactor: extract RecordingStartPreflightResult.swift from PermissionAndPreflightTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		946F215474A2DE83AA4413C4 /* DiagnosticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EE955B03EE30CC1EB568A1 /* DiagnosticsLogger.swift */; };
 		952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */; };
 		954112959D643236882234B0 /* TrackerIntegrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */; };
+		95F649EB64F11523561726F4 /* RecordingStartPreflightResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2198DD3C26D9DE0BDC23BE /* RecordingStartPreflightResult.swift */; };
 		9619964E0CEE6D5A039340F7 /* SessionScreenshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */; };
 		977D86FA0E7E2C16A5B41D4D /* DebugSessionContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2543B7AFD4F96F3482FE28FA /* DebugSessionContextProvider.swift */; };
 		981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */; };
@@ -361,6 +362,7 @@
 		1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarIssueReviewService.swift; sourceTree = "<group>"; };
 		1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTests.swift; sourceTree = "<group>"; };
 		1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioExplainerView.swift; sourceTree = "<group>"; };
+		1F2198DD3C26D9DE0BDC23BE /* RecordingStartPreflightResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStartPreflightResult.swift; sourceTree = "<group>"; };
 		2064E70346EE9E9D138A9D10 /* PendingTranscriptionRetryFailureHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailureHandlerTests.swift; sourceTree = "<group>"; };
 		20E1935189673C2EEE16DF20 /* ScreenshotSelectionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionServiceTests.swift; sourceTree = "<group>"; };
 		20E5C0B0364E39D6BE9876A5 /* TransientToastTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTypes.swift; sourceTree = "<group>"; };
@@ -922,6 +924,7 @@
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
 				FB3DE4A4EEA68D61D7E4BD14 /* RecordingSessionOutcomes.swift */,
 				DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */,
+				1F2198DD3C26D9DE0BDC23BE /* RecordingStartPreflightResult.swift */,
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
 				3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */,
@@ -1397,6 +1400,7 @@
 				1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */,
 				B6F837040D5A988287E8E8FF /* RecordingSessionOutcomes.swift in Sources */,
 				93561F8BD8484E68D3E96012 /* RecordingSessionPresenters.swift in Sources */,
+				95F649EB64F11523561726F4 /* RecordingStartPreflightResult.swift in Sources */,
 				952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */,
 				8D34D845BE5587EC9B1E1765 /* RecordingStatusMessageProvider.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,

--- a/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
+++ b/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
@@ -23,22 +23,6 @@ struct MicrophoneRecoveryGuidance: Equatable {
     let localTestingNote: String?
 }
 
-enum RecordingStartPreflightResult: Equatable {
-    case success
-    case blocked(AppError)
-    case needsUserAction(AppError)
-    case failure(AppError)
-
-    var error: AppError? {
-        switch self {
-        case .success:
-            return nil
-        case .blocked(let error), .needsUserAction(let error), .failure(let error):
-            return error
-        }
-    }
-}
-
 enum ScreenCapturePermissionState: Equatable {
     case granted
     case notDetermined

--- a/Sources/BugNarrator/Services/RecordingStartPreflightResult.swift
+++ b/Sources/BugNarrator/Services/RecordingStartPreflightResult.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum RecordingStartPreflightResult: Equatable {
+    case success
+    case blocked(AppError)
+    case needsUserAction(AppError)
+    case failure(AppError)
+
+    var error: AppError? {
+        switch self {
+        case .success:
+            return nil
+        case .blocked(let error), .needsUserAction(let error), .failure(let error):
+            return error
+        }
+    }
+}


### PR DESCRIPTION
Splits preflight-result enum out. Byte-identical move. Tests: 667.