### PR TITLE
refactor: extract PrivacyDataExportManifest.swift from PrivacyDataExportTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
 		15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */; };
+		188D106C4C60C6F896F5C5D0 /* PrivacyDataExportManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576983E35FEBFE0EB0ECD237 /* PrivacyDataExportManifest.swift */; };
 		18EE2A64D0A551934978247B /* AudioObjectIDExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB94B9DE300200CB6C35E6F1 /* AudioObjectIDExtensions.swift */; };
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
@@ -423,6 +424,7 @@
 		553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrapTests.swift; sourceTree = "<group>"; };
 		554387017B49D9CD63967BE3 /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		56EE955B03EE30CC1EB568A1 /* DiagnosticsLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLogger.swift; sourceTree = "<group>"; };
+		576983E35FEBFE0EB0ECD237 /* PrivacyDataExportManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExportManifest.swift; sourceTree = "<group>"; };
 		57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotPreviewCache.swift; sourceTree = "<group>"; };
 		58645DF704D4244897938E77 /* TranscriptSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSectionTests.swift; sourceTree = "<group>"; };
 		598E006D3F529E46315F3585 /* HotkeyAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyAction.swift; sourceTree = "<group>"; };
@@ -917,6 +919,7 @@
 				E18153669404C9BD089DE846 /* PostTranscriptionPipelineController.swift */,
 				4C809A64CE202980AFC55953 /* PostTranscriptionResultHandlers.swift */,
 				97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */,
+				576983E35FEBFE0EB0ECD237 /* PrivacyDataExportManifest.swift */,
 				154255C955FE33FD6D016BE9 /* PrivacyDataExportTypes.swift */,
 				7EFD71FC016C2F699D022EDB /* RecordingPreferencesStore.swift */,
 				875DD52AC7741ABC898365F4 /* RecordingSessionController.swift */,
@@ -1388,6 +1391,7 @@
 				B1577062BEB420A4348A86F6 /* PostTranscriptionPipelineController.swift in Sources */,
 				A2C76BB4E680144BF1CE9586 /* PostTranscriptionPipelineTypes.swift in Sources */,
 				D9A9D1BB81401E2D14462808 /* PostTranscriptionResultHandlers.swift in Sources */,
+				188D106C4C60C6F896F5C5D0 /* PrivacyDataExportManifest.swift in Sources */,
 				61D4778489BCA1F3B7C16161 /* PrivacyDataExportTypes.swift in Sources */,
 				A29BE3EF9236161E2E8713CD /* PrivacyDataExporter.swift in Sources */,
 				30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */,

--- a/Sources/BugNarrator/Services/PrivacyDataExportManifest.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExportManifest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct PrivacyDataExportManifest: Encodable {
+    let generatedAt: Date
+    let sessionCount: Int
+    let includesSecrets: Bool
+    let exportedFiles: [String]
+    let notes: [String]
+}

--- a/Sources/BugNarrator/Services/PrivacyDataExportTypes.swift
+++ b/Sources/BugNarrator/Services/PrivacyDataExportTypes.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-struct PrivacyDataExportManifest: Encodable {
-    let generatedAt: Date
-    let sessionCount: Int
-    let includesSecrets: Bool
-    let exportedFiles: [String]
-    let notes: [String]
-}
-
 struct PrivacyDataExportSettingsSnapshot: Codable, Equatable {
     let openAIBaseURL: String
     let transcriptionModel: String


### PR DESCRIPTION
Splits Encodable manifest out. Byte-identical move. Tests: 667.