### PR TITLE
refactor: extract ReviewSummaryIssueGroup.swift from ReviewWorkspaceTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */; };
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
 		544FA33C107DC4D4AA136D2B /* SystemAudioFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D6357236D21D641327DEE /* SystemAudioFileWriterTests.swift */; };
+		55CD86DE7946EF3A586AB539 /* ReviewSummaryIssueGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31495528D448645364A434F /* ReviewSummaryIssueGroup.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
 		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
 		56B6B994C39B8B439752CCA3 /* MenuProductInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */; };
@@ -573,6 +574,7 @@
 		D2297A64FD7D8AD5B556637F /* SessionDataProtectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataProtectorTests.swift; sourceTree = "<group>"; };
 		D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioTapSession.swift; sourceTree = "<group>"; };
 		D23CC2E19AE4AA8233EE3DBE /* MixedAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorderTests.swift; sourceTree = "<group>"; };
+		D31495528D448645364A434F /* ReviewSummaryIssueGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewSummaryIssueGroup.swift; sourceTree = "<group>"; };
 		D3C3F2C78E5CE5F897E804CC /* AppState+TrackerIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+TrackerIntegration.swift"; sourceTree = "<group>"; };
 		D58A3885853863EE9118FC63 /* SettingsDiagnosticsPrivacyPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDiagnosticsPrivacyPane.swift; sourceTree = "<group>"; };
 		D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorLinks.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				B2F0C360F83AB792370FADAF /* RecordingStatusMessageBuilder.swift */,
 				125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */,
 				002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */,
+				D31495528D448645364A434F /* ReviewSummaryIssueGroup.swift */,
 				60982ABA90B0CE76BF93E46A /* ReviewWorkspace.swift */,
 				D70C2AF1D71698B8CB98490E /* ReviewWorkspaceTypes.swift */,
 				57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */,
@@ -1400,6 +1403,7 @@
 				952BBC1ED94400857FF4E837 /* RecordingStatusMessageBuilder.swift in Sources */,
 				8D34D845BE5587EC9B1E1765 /* RecordingStatusMessageProvider.swift in Sources */,
 				5C18E905F94644D69AA9CB60 /* RecordingTimerViewModel.swift in Sources */,
+				55CD86DE7946EF3A586AB539 /* ReviewSummaryIssueGroup.swift in Sources */,
 				981A2F83EC4A0550815EF1B4 /* ReviewWorkspace.swift in Sources */,
 				BBE16FF238B059EF08346355 /* ReviewWorkspaceTypes.swift in Sources */,
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,

--- a/Sources/BugNarrator/Utilities/ReviewSummaryIssueGroup.swift
+++ b/Sources/BugNarrator/Utilities/ReviewSummaryIssueGroup.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct ReviewSummaryIssueGroup: Equatable {
+    let category: ExtractedIssueCategory
+    let issues: [ExtractedIssue]
+
+    var title: String {
+        switch category {
+        case .bug:
+            return "Bugs"
+        case .uxIssue:
+            return "UX Issues"
+        case .enhancement:
+            return "Enhancements"
+        case .followUp:
+            return "Questions / Follow-ups"
+        }
+    }
+}

--- a/Sources/BugNarrator/Utilities/ReviewWorkspaceTypes.swift
+++ b/Sources/BugNarrator/Utilities/ReviewWorkspaceTypes.swift
@@ -53,21 +53,3 @@ enum ReviewWorkspaceTimelineEntryKind: Equatable {
         }
     }
 }
-
-struct ReviewSummaryIssueGroup: Equatable {
-    let category: ExtractedIssueCategory
-    let issues: [ExtractedIssue]
-
-    var title: String {
-        switch category {
-        case .bug:
-            return "Bugs"
-        case .uxIssue:
-            return "UX Issues"
-        case .enhancement:
-            return "Enhancements"
-        case .followUp:
-            return "Questions / Follow-ups"
-        }
-    }
-}


### PR DESCRIPTION
Splits category-grouping struct out. Byte-identical move. Tests: 667.