### PR TITLE
refactor: extract SessionLibraryDateRange.swift from SessionLibraryQuery.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */; };
 		594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */; };
 		5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D753EF601F00C09C7FF276C /* TransientToast.swift */; };
+		598C780FD149B05DEC2C6AEC /* SessionLibraryDateRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C19661A5F59D1EE3EBFA52 /* SessionLibraryDateRange.swift */; };
 		5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */; };
 		5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */; };
 		5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49B2B79731E3A62B083174 /* IssueExportController.swift */; };
@@ -405,6 +406,7 @@
 		4471ECA2ACC707AB91216E17 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 		46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReviewPolicy.swift; sourceTree = "<group>"; };
 		48289EBDC8D8BBE0ECC802BA /* TrackerIntegrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerIntegrationController.swift; sourceTree = "<group>"; };
+		48C19661A5F59D1EE3EBFA52 /* SessionLibraryDateRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryDateRange.swift; sourceTree = "<group>"; };
 		48DF28E6CC5FB74499C91B74 /* TransientToastController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastController.swift; sourceTree = "<group>"; };
 		4A9D6C752334532E660C00AF /* StorageRecoveryBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRecoveryBanner.swift; sourceTree = "<group>"; };
 		4C61E55C375715AA61C799A2 /* ElapsedTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatter.swift; sourceTree = "<group>"; };
@@ -1003,6 +1005,7 @@
 				D70C2AF1D71698B8CB98490E /* ReviewWorkspaceTypes.swift */,
 				57AE8EA0414CE7C5271CFD16 /* ScreenshotPreviewCache.swift */,
 				CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */,
+				48C19661A5F59D1EE3EBFA52 /* SessionLibraryDateRange.swift */,
 				171956F77EBFEE85F9FF0B22 /* SessionLibraryEmptyState.swift */,
 				B33027EA9F37EA57406F2D1A /* SessionLibraryItem.swift */,
 				1C4AD6F9C5461F932D3B455C /* SessionLibraryQuery.swift */,
@@ -1418,6 +1421,7 @@
 				A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */,
 				B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */,
 				CEDAB8D8BF65455F21123B22 /* SessionLibraryController.swift in Sources */,
+				598C780FD149B05DEC2C6AEC /* SessionLibraryDateRange.swift in Sources */,
 				72F6A01ADB045AC8CD503765 /* SessionLibraryEmptyState.swift in Sources */,
 				9BDE73A1F0BA27B80A72F736 /* SessionLibraryItem.swift in Sources */,
 				C177672680CF960A0A36F3D0 /* SessionLibraryPresenters.swift in Sources */,

--- a/Sources/BugNarrator/Utilities/SessionLibraryDateRange.swift
+++ b/Sources/BugNarrator/Utilities/SessionLibraryDateRange.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct SessionLibraryDateRange: Equatable {
+    var startDate: Date
+    var endDate: Date
+
+    func normalized(in calendar: Calendar) -> ClosedRange<Date> {
+        let lowerBound = min(startDate, endDate)
+        let upperBound = max(startDate, endDate)
+        let startOfLowerBound = calendar.startOfDay(for: lowerBound)
+        let startOfUpperBound = calendar.startOfDay(for: upperBound)
+        let inclusiveUpperBound = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: startOfUpperBound)
+            ?? upperBound
+        return startOfLowerBound ... inclusiveUpperBound
+    }
+}

--- a/Sources/BugNarrator/Utilities/SessionLibraryQuery.swift
+++ b/Sources/BugNarrator/Utilities/SessionLibraryQuery.swift
@@ -38,21 +38,6 @@ enum SessionLibrarySortOrder: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
-struct SessionLibraryDateRange: Equatable {
-    var startDate: Date
-    var endDate: Date
-
-    func normalized(in calendar: Calendar) -> ClosedRange<Date> {
-        let lowerBound = min(startDate, endDate)
-        let upperBound = max(startDate, endDate)
-        let startOfLowerBound = calendar.startOfDay(for: lowerBound)
-        let startOfUpperBound = calendar.startOfDay(for: upperBound)
-        let inclusiveUpperBound = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: startOfUpperBound)
-            ?? upperBound
-        return startOfLowerBound ... inclusiveUpperBound
-    }
-}
-
 struct SessionLibraryQuery: Equatable {
     var filter: SessionLibraryDateFilter
     var customDateRange: SessionLibraryDateRange


### PR DESCRIPTION
Splits DateRange struct out. Byte-identical move. Tests: 667.