### PR TITLE
refactor: extract PendingTranscriptionRetryFailure.swift from TranscriptionRecoverySupport.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		F6A698B3E54CEF73047BC042 /* SessionMarkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */; };
 		F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */; };
 		F715303DE87CE267F3336E39 /* TranscriptionSessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305726D5E9A576C4C9729670 /* TranscriptionSessionBuilder.swift */; };
+		F8488FEFDEB1E4661A43B0A7 /* PendingTranscriptionRetryFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5A6AFF629F499508C2C89C /* PendingTranscriptionRetryFailure.swift */; };
 		F8BF8DC6CA90989293D790EF /* IssueExtractionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C72E7D77CE5A2F8560651F /* IssueExtractionServiceTests.swift */; };
 		FAABB483CA602BDFE9F90FBF /* TranscriptionRecoverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95694D28269EE30BBED24AFE /* TranscriptionRecoverySupport.swift */; };
 		FAF01A932489386F2FEFA1AB /* TransientToastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */; };
@@ -358,6 +359,7 @@
 		1C4AD6F9C5461F932D3B455C /* SessionLibraryQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryQuery.swift; sourceTree = "<group>"; };
 		1C7E7C066184078E8F7462AD /* TrackerExportPayloadBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportPayloadBudget.swift; sourceTree = "<group>"; };
 		1D1805C56FBAED6588A225F0 /* AppRuntimeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironment.swift; sourceTree = "<group>"; };
+		1E5A6AFF629F499508C2C89C /* PendingTranscriptionRetryFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscriptionRetryFailure.swift; sourceTree = "<group>"; };
 		1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarIssueReviewService.swift; sourceTree = "<group>"; };
 		1EF216E69324B1E22CC5FFC4 /* TransientToastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToastTests.swift; sourceTree = "<group>"; };
 		1F165EE5C53B4355CFF91393 /* SystemAudioExplainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioExplainerView.swift; sourceTree = "<group>"; };
@@ -911,6 +913,7 @@
 				518C6045D8668A1179198A6D /* MultipartFormDataBuilder.swift */,
 				60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */,
 				AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */,
+				1E5A6AFF629F499508C2C89C /* PendingTranscriptionRetryFailure.swift */,
 				31EF5F62FF802B7B8D41022D /* PermissionAndPreflightTypes.swift */,
 				6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */,
 				AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */,
@@ -1382,6 +1385,7 @@
 				7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */,
 				C78BD5EF85ED92EADB317E96 /* OperationalTelemetryRecorder.swift in Sources */,
 				9D12A5E2379C328D473E6452 /* PendingTranscription.swift in Sources */,
+				F8488FEFDEB1E4661A43B0A7 /* PendingTranscriptionRetryFailure.swift in Sources */,
 				5E4490C17E49287B620FF2FA /* PermissionAndPreflightTypes.swift in Sources */,
 				68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */,
 				E60F34C1E0FED78A8F28FFDE /* PermissionRecoveryTypes.swift in Sources */,

--- a/Sources/BugNarrator/Services/PendingTranscriptionRetryFailure.swift
+++ b/Sources/BugNarrator/Services/PendingTranscriptionRetryFailure.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct PendingTranscriptionRetryFailure {
+    let session: TranscriptSession
+    let appError: AppError
+    let statusMessage: String
+}

--- a/Sources/BugNarrator/Services/TranscriptionRecoverySupport.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRecoverySupport.swift
@@ -12,12 +12,6 @@ enum PendingTranscriptionRetryResolution {
     case failure(AppError, opensSettings: Bool, statusMessage: String?)
 }
 
-struct PendingTranscriptionRetryFailure {
-    let session: TranscriptSession
-    let appError: AppError
-    let statusMessage: String
-}
-
 enum RetryableSessionPreservationResult {
     case preserved(session: TranscriptSession, appError: AppError)
     case persistenceFailure(session: TranscriptSession, error: Error)


### PR DESCRIPTION
Splits retry-failure data struct out. Byte-identical move. Tests: 667.