### PR TITLE
refactor: extract ScreenCapturePermissionStatus.swift from PermissionAndPreflightTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		71EF8448D05ED4023C8D7CF0 /* ScreenshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440C303A792898D3E20DA2C0 /* ScreenshotCoordinator.swift */; };
 		7251FD6A3C965C5D9A87805F /* OpenAIErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */; };
 		72F6A01ADB045AC8CD503765 /* SessionLibraryEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171956F77EBFEE85F9FF0B22 /* SessionLibraryEmptyState.swift */; };
+		73E1AA8FB24AFD4286AE42B8 /* ScreenCapturePermissionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C64BEBF75D36AB99D93A1D /* ScreenCapturePermissionStatus.swift */; };
 		75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */; };
 		77CFDF30D3F7AEFA54C4E367 /* ChangelogDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F136949087AFDDDEB2B830 /* ChangelogDocument.swift */; };
 		79EE80974F21923B656A5F87 /* RoutingAudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */; };
@@ -329,6 +330,7 @@
 		002A3FB6CC8E66C5C82E0B56 /* RecordingTimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingTimerViewModel.swift; sourceTree = "<group>"; };
 		00F7DD790A65A410DAF9831C /* PermissionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		01B7F0C1392B31892BE5A796 /* AppState+WindowManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+WindowManagement.swift"; sourceTree = "<group>"; };
+		02C64BEBF75D36AB99D93A1D /* ScreenCapturePermissionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionStatus.swift; sourceTree = "<group>"; };
 		04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspector.swift; sourceTree = "<group>"; };
 		0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatterTests.swift; sourceTree = "<group>"; };
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
@@ -924,6 +926,7 @@
 				DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */,
 				A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */,
 				811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */,
+				02C64BEBF75D36AB99D93A1D /* ScreenCapturePermissionStatus.swift */,
 				3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */,
 				54A8F3C1B2AFF52FBD3D8703 /* ScreenshotCaptureService.swift */,
 				998C4703160B45E816CF929F /* ScreenshotCaptureSupport.swift */,
@@ -1404,6 +1407,7 @@
 				BBE16FF238B059EF08346355 /* ReviewWorkspaceTypes.swift in Sources */,
 				F6BA3B27EE5A89BF800E6DC6 /* RoutingAudioRecorder.swift in Sources */,
 				DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */,
+				73E1AA8FB24AFD4286AE42B8 /* ScreenCapturePermissionStatus.swift in Sources */,
 				B3FF6A0FB442CAC98A7B9E81 /* ScreenshotCaptureController.swift in Sources */,
 				6DC57655A6904ADCF5D41040 /* ScreenshotCaptureService.swift in Sources */,
 				CB86D0DD53DE4F044EC12470 /* ScreenshotCaptureSupport.swift in Sources */,

--- a/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
+++ b/Sources/BugNarrator/Services/PermissionAndPreflightTypes.swift
@@ -46,15 +46,6 @@ enum ScreenCapturePermissionState: Equatable {
     case unavailable
 }
 
-enum ScreenCapturePermissionStatus: String, Equatable {
-    case notDetermined
-    case granted
-    case denied
-    case unavailable
-    case captureSetupFailed
-    case unknownError
-}
-
 struct ScreenCaptureRecoveryGuidance: Equatable {
     let headline: String
     let message: String

--- a/Sources/BugNarrator/Services/ScreenCapturePermissionStatus.swift
+++ b/Sources/BugNarrator/Services/ScreenCapturePermissionStatus.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum ScreenCapturePermissionStatus: String, Equatable {
+    case notDetermined
+    case granted
+    case denied
+    case unavailable
+    case captureSetupFailed
+    case unknownError
+}


### PR DESCRIPTION
Splits raw-string status enum out. Byte-identical move. Tests: 667.