### PR TITLE
refactor: extract AppErrorPresentationResult.swift from AppErrorTypes.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		3FA2E58DF45C2A9FEBF9FE0B /* AtomicBundleDirectoryWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */; };
 		40D75D2D2C83EE58CBB45F6B /* BugNarratorLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C80DD2FADBED13E068990D /* BugNarratorLinks.swift */; };
 		4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53226A9282239858514440C /* AppState+PresentationState.swift */; };
+		43FC5C533FB1A321D0239BF3 /* AppErrorPresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE10EBB81E0B7F7EF6820AA /* AppErrorPresentationResult.swift */; };
 		456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */; };
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
@@ -582,6 +583,7 @@
 		D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryTranscriptionStatusPresenterTests.swift; sourceTree = "<group>"; };
 		D98BD0399A4FCBF9BFA27773 /* AppStateProviderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateProviderValidationTests.swift; sourceTree = "<group>"; };
 		DAE6A1D707211E467BFD8EF0 /* VerboseTranscriptionResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerboseTranscriptionResponseParser.swift; sourceTree = "<group>"; };
+		DBE10EBB81E0B7F7EF6820AA /* AppErrorPresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorPresentationResult.swift; sourceTree = "<group>"; };
 		DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStore.swift; sourceTree = "<group>"; };
 		DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionPresenters.swift; sourceTree = "<group>"; };
 		DD521B33574057DABAC05903 /* IssueExtractionPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionPresenters.swift; sourceTree = "<group>"; };
@@ -868,6 +870,7 @@
 			children = (
 				CD7E24CD9C6DBE0BF94F5A53 /* AIProvider.swift */,
 				99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */,
+				DBE10EBB81E0B7F7EF6820AA /* AppErrorPresentationResult.swift */,
 				FC68E525601D89A4E993FC89 /* AppErrorPresenter.swift */,
 				778F1E0C90308A1D868A187E /* AppErrorSubPresenters.swift */,
 				EA54521C239C09E5B94712EB /* AppErrorTypes.swift */,
@@ -1282,6 +1285,7 @@
 				7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */,
 				19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */,
 				CB9E1F15D2FB0B7CF38DD5F6 /* AppError.swift in Sources */,
+				43FC5C533FB1A321D0239BF3 /* AppErrorPresentationResult.swift in Sources */,
 				D05B48ECBEFAF80A63A7E3CF /* AppErrorPresenter.swift in Sources */,
 				BC9E4D8AE8F5F1F539C5641A /* AppErrorSubPresenters.swift in Sources */,
 				474596AEBE0A97F33B320E59 /* AppErrorTypes.swift in Sources */,

--- a/Sources/BugNarrator/Services/AppErrorPresentationResult.swift
+++ b/Sources/BugNarrator/Services/AppErrorPresentationResult.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct AppErrorPresentationResult: Equatable {
+    let appError: AppError
+    let shouldOpenSettingsWindow: Bool
+}

--- a/Sources/BugNarrator/Services/AppErrorTypes.swift
+++ b/Sources/BugNarrator/Services/AppErrorTypes.swift
@@ -21,7 +21,3 @@ struct AppErrorNormalization: Equatable {
     let underlyingErrorDescription: String?
 }
 
-struct AppErrorPresentationResult: Equatable {
-    let appError: AppError
-    let shouldOpenSettingsWindow: Bool
-}


### PR DESCRIPTION
Splits presentation result out. Byte-identical move. Tests: 667.