### PR TITLE
refactor: extract TranscriptionRequest.swift from TranscriptionModels.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3104282993DE974208688237 /* TranscriptQualityFinding.swift */; };
 		7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */; };
 		7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */; };
+		7CA3F19E9403C6B6974AB839 /* TranscriptionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D026D56FC1106D53D7F2798 /* TranscriptionRequest.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
 		806F6B3953A77B84672AD2DA /* AppRuntimeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */; };
 		8124F6AEFE87F470DE1D3B56 /* IssueExtractionRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */; };
@@ -394,6 +395,7 @@
 		3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishedRecordingPostTranscriptionResultHandlerTests.swift; sourceTree = "<group>"; };
 		38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionController.swift; sourceTree = "<group>"; };
 		3B66F6ADC8EDC6AA0A768F30 /* TrackerExportSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerExportSupport.swift; sourceTree = "<group>"; };
+		3D026D56FC1106D53D7F2798 /* TranscriptionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRequest.swift; sourceTree = "<group>"; };
 		3E7CA92ED5A94500B96290D0 /* AppState+SupportNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SupportNavigation.swift"; sourceTree = "<group>"; };
 		3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInstanceControllerTests.swift; sourceTree = "<group>"; };
 		3F350327BA0619E235858F82 /* ScreenshotCaptureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureController.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 				2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */,
 				7F271FCF4D5A2759B4D6DCE4 /* TranscriptionRecoveryPresenters.swift */,
 				95694D28269EE30BBED24AFE /* TranscriptionRecoverySupport.swift */,
+				3D026D56FC1106D53D7F2798 /* TranscriptionRequest.swift */,
 				26CD9BA732E87ECCC87659E2 /* TranscriptionRequestFactory.swift */,
 				04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */,
 				7A7A34EF1391E51E6B1DB8BF /* TranscriptSectionBuilder.swift */,
@@ -1470,6 +1473,7 @@
 				A2E710E8AA18115FD2B9C352 /* TranscriptionRecoveryController.swift in Sources */,
 				D089C488B66D1CCBF625BDA9 /* TranscriptionRecoveryPresenters.swift in Sources */,
 				FAABB483CA602BDFE9F90FBF /* TranscriptionRecoverySupport.swift in Sources */,
+				7CA3F19E9403C6B6974AB839 /* TranscriptionRequest.swift in Sources */,
 				8507C1549A3313E2C9CD4C10 /* TranscriptionRequestFactory.swift in Sources */,
 				F715303DE87CE267F3336E39 /* TranscriptionSessionBuilder.swift in Sources */,
 				5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */,

--- a/Sources/BugNarrator/Services/TranscriptionModels.swift
+++ b/Sources/BugNarrator/Services/TranscriptionModels.swift
@@ -1,24 +1,5 @@
 import Foundation
 
-struct TranscriptionRequest: Sendable {
-    let model: String
-    let languageHint: String?
-    let prompt: String?
-    let apiBaseURL: URL
-
-    init(
-        model: String,
-        languageHint: String?,
-        prompt: String?,
-        apiBaseURL: URL = URL(string: "https://api.openai.com")!
-    ) {
-        self.model = model
-        self.languageHint = languageHint
-        self.prompt = prompt
-        self.apiBaseURL = apiBaseURL
-    }
-}
-
 struct TranscriptionResult: Sendable {
     let text: String
     let segments: [TranscriptionSegment]

--- a/Sources/BugNarrator/Services/TranscriptionRequest.swift
+++ b/Sources/BugNarrator/Services/TranscriptionRequest.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct TranscriptionRequest: Sendable {
+    let model: String
+    let languageHint: String?
+    let prompt: String?
+    let apiBaseURL: URL
+
+    init(
+        model: String,
+        languageHint: String?,
+        prompt: String?,
+        apiBaseURL: URL = URL(string: "https://api.openai.com")!
+    ) {
+        self.model = model
+        self.languageHint = languageHint
+        self.prompt = prompt
+        self.apiBaseURL = apiBaseURL
+    }
+}


### PR DESCRIPTION
Splits Sendable request struct out. Byte-identical move. Tests: 667.