### PR TITLE
refactor: extract LaunchAtLoginStatus.swift from LaunchAtLoginService.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		4226DF118953DA972D420D85 /* AppState+PresentationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53226A9282239858514440C /* AppState+PresentationState.swift */; };
 		456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */; };
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
+		45EAFD92593440839C53A224 /* LaunchAtLoginStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA6C8C5233E84AAF2602C18 /* LaunchAtLoginStatus.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
 		474596AEBE0A97F33B320E59 /* AppErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54521C239C09E5B94712EB /* AppErrorTypes.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
@@ -533,6 +534,7 @@
 		A8E2942C142197B34696946C /* TranscriptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSection.swift; sourceTree = "<group>"; };
 		A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBundleDirectoryWriter.swift; sourceTree = "<group>"; };
 		ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugSessionContextProviderTests.swift; sourceTree = "<group>"; };
+		ACA6C8C5233E84AAF2602C18 /* LaunchAtLoginStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginStatus.swift; sourceTree = "<group>"; };
 		AD6AE9B0A2681924431362E5 /* OperationalTelemetryRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationalTelemetryRecorder.swift; sourceTree = "<group>"; };
 		AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryTypes.swift; sourceTree = "<group>"; };
 		AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshotTests.swift; sourceTree = "<group>"; };
@@ -903,6 +905,7 @@
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
+				ACA6C8C5233E84AAF2602C18 /* LaunchAtLoginStatus.swift */,
 				F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */,
 				38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */,
 				FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */,
@@ -1367,6 +1370,7 @@
 				318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,
 				099F3585D99B3E078A61EFE3 /* LaunchAtLoginService.swift in Sources */,
+				45EAFD92593440839C53A224 /* LaunchAtLoginStatus.swift in Sources */,
 				E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */,
 				525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */,
 				E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */,

--- a/Sources/BugNarrator/Services/LaunchAtLoginService.swift
+++ b/Sources/BugNarrator/Services/LaunchAtLoginService.swift
@@ -1,60 +1,6 @@
 import Foundation
 import ServiceManagement
 
-enum LaunchAtLoginStatus: Equatable {
-    case disabled
-    case enabled
-    case requiresApproval
-    case notFound
-    case unavailable
-
-    var isEnabled: Bool {
-        switch self {
-        case .enabled, .requiresApproval:
-            return true
-        case .disabled, .notFound, .unavailable:
-            return false
-        }
-    }
-
-    var isAvailable: Bool {
-        switch self {
-        case .unavailable:
-            return false
-        case .disabled, .enabled, .requiresApproval, .notFound:
-            return true
-        }
-    }
-
-    var message: String? {
-        switch self {
-        case .disabled, .enabled:
-            return nil
-        case .requiresApproval:
-            return "BugNarrator is enabled to open at login, but macOS still requires approval in System Settings > General > Login Items."
-        case .notFound:
-            return "Open at Startup is not registered with macOS yet. Turn it on to register BugNarrator as a Login Item."
-        case .unavailable:
-            return "Open at Startup is unavailable for this app copy. Install BugNarrator in Applications and use a signed build if you want BugNarrator to launch automatically."
-        }
-    }
-
-    var logValue: String {
-        switch self {
-        case .disabled:
-            return "disabled"
-        case .enabled:
-            return "enabled"
-        case .requiresApproval:
-            return "requires_approval"
-        case .notFound:
-            return "not_found"
-        case .unavailable:
-            return "unavailable"
-        }
-    }
-}
-
 protocol LaunchAtLoginControlling {
     func currentStatus() -> LaunchAtLoginStatus
     func setEnabled(_ enabled: Bool) throws -> LaunchAtLoginStatus

--- a/Sources/BugNarrator/Services/LaunchAtLoginStatus.swift
+++ b/Sources/BugNarrator/Services/LaunchAtLoginStatus.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+enum LaunchAtLoginStatus: Equatable {
+    case disabled
+    case enabled
+    case requiresApproval
+    case notFound
+    case unavailable
+
+    var isEnabled: Bool {
+        switch self {
+        case .enabled, .requiresApproval:
+            return true
+        case .disabled, .notFound, .unavailable:
+            return false
+        }
+    }
+
+    var isAvailable: Bool {
+        switch self {
+        case .unavailable:
+            return false
+        case .disabled, .enabled, .requiresApproval, .notFound:
+            return true
+        }
+    }
+
+    var message: String? {
+        switch self {
+        case .disabled, .enabled:
+            return nil
+        case .requiresApproval:
+            return "BugNarrator is enabled to open at login, but macOS still requires approval in System Settings > General > Login Items."
+        case .notFound:
+            return "Open at Startup is not registered with macOS yet. Turn it on to register BugNarrator as a Login Item."
+        case .unavailable:
+            return "Open at Startup is unavailable for this app copy. Install BugNarrator in Applications and use a signed build if you want BugNarrator to launch automatically."
+        }
+    }
+
+    var logValue: String {
+        switch self {
+        case .disabled:
+            return "disabled"
+        case .enabled:
+            return "enabled"
+        case .requiresApproval:
+            return "requires_approval"
+        case .notFound:
+            return "not_found"
+        case .unavailable:
+            return "unavailable"
+        }
+    }
+}


### PR DESCRIPTION
Splits status enum (~53 lines) out. Byte-identical move. Tests: 667.