### PR TITLE
refactor: extract SimilarIssueResolution.swift from IssueExportReview.swift

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
 		8F4B3823ACB48DDF270E2BAE /* AppStateIssueExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */; };
+		910649C09F1906AA4C531D40 /* SimilarIssueResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5406AAC3E5D422EEBD2DC9A /* SimilarIssueResolution.swift */; };
 		93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */; };
 		93561F8BD8484E68D3E96012 /* RecordingSessionPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */; };
 		9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */; };
@@ -562,6 +563,7 @@
 		C38FE78312021B0A9C7DEBD0 /* UtilityTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTestSupport.swift; sourceTree = "<group>"; };
 		C514D909BF8C4543E740640F /* IssueExportReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportReview.swift; sourceTree = "<group>"; };
 		C53226A9282239858514440C /* AppState+PresentationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PresentationState.swift"; sourceTree = "<group>"; };
+		C5406AAC3E5D422EEBD2DC9A /* SimilarIssueResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarIssueResolution.swift; sourceTree = "<group>"; };
 		C9A627A3D91ED77FE7657BAD /* AppErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
 		C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		CB4317A37DFABA4E92CBEA33 /* SessionArtifactsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionArtifactsServiceTests.swift; sourceTree = "<group>"; };
@@ -775,6 +777,7 @@
 				22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */,
 				86D135AC919EF9A5E8C21235 /* SessionMarker.swift */,
 				5B60FF3096207405A3ECB6D0 /* SessionScreenshot.swift */,
+				C5406AAC3E5D422EEBD2DC9A /* SimilarIssueResolution.swift */,
 				3104282993DE974208688237 /* TranscriptQualityFinding.swift */,
 				A8E2942C142197B34696946C /* TranscriptSection.swift */,
 				6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */,
@@ -1435,6 +1438,7 @@
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,
+				910649C09F1906AA4C531D40 /* SimilarIssueResolution.swift in Sources */,
 				D2AEB3EA7C80F6B47D0193C5 /* SimilarIssueReviewService.swift in Sources */,
 				6DD15D4989138430B1DB845E /* SingleInstanceController.swift in Sources */,
 				4D81592844E0FDC8BDF43D90 /* StorageRecoveryBanner.swift in Sources */,

--- a/Sources/BugNarrator/Models/IssueExportReview.swift
+++ b/Sources/BugNarrator/Models/IssueExportReview.swift
@@ -1,24 +1,5 @@
 import Foundation
 
-enum SimilarIssueResolution: String, CaseIterable, Identifiable {
-    case exportNew = "Export as New"
-    case linkAsRelated = "Link as Related"
-    case markDuplicate = "Mark as Duplicate"
-
-    var id: String { rawValue }
-
-    var helpText: String {
-        switch self {
-        case .exportNew:
-            return "Create a brand-new tracker issue."
-        case .linkAsRelated:
-            return "Create a new issue and reference an existing tracker issue as related context."
-        case .markDuplicate:
-            return "Skip creating a new issue and use the matched tracker issue instead."
-        }
-    }
-}
-
 struct SimilarIssueMatch: Identifiable, Equatable {
     let id: String
     let remoteIdentifier: String

--- a/Sources/BugNarrator/Models/SimilarIssueResolution.swift
+++ b/Sources/BugNarrator/Models/SimilarIssueResolution.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum SimilarIssueResolution: String, CaseIterable, Identifiable {
+    case exportNew = "Export as New"
+    case linkAsRelated = "Link as Related"
+    case markDuplicate = "Mark as Duplicate"
+
+    var id: String { rawValue }
+
+    var helpText: String {
+        switch self {
+        case .exportNew:
+            return "Create a brand-new tracker issue."
+        case .linkAsRelated:
+            return "Create a new issue and reference an existing tracker issue as related context."
+        case .markDuplicate:
+            return "Skip creating a new issue and use the matched tracker issue instead."
+        }
+    }
+}


### PR DESCRIPTION
Splits resolution enum out. Byte-identical move. Tests: 667.