### PR TITLE
fix: clarify system-audio recording failure paths (#856)

### DIFF
--- a/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
+++ b/Sources/BugNarrator/Services/RoutingAudioRecorder.swift
@@ -6,6 +6,7 @@ final class RoutingAudioRecorder: AudioRecording {
     private let microphoneRecorder: any AudioRecording
     private let systemAudioRecorder: any AudioRecording
     private let microphoneAndSystemAudioRecorder: any AudioRecording
+    private let recordingLogger: DiagnosticsLogger
 
     private var activeRecorder: (any AudioRecording)?
 
@@ -13,7 +14,8 @@ final class RoutingAudioRecorder: AudioRecording {
         settingsStore: SettingsStore,
         microphoneRecorder: (any AudioRecording)? = nil,
         systemAudioRecorder: any AudioRecording = SystemAudioRecorder(),
-        microphoneAndSystemAudioRecorder: (any AudioRecording)? = nil
+        microphoneAndSystemAudioRecorder: (any AudioRecording)? = nil,
+        recordingLogger: DiagnosticsLogger = DiagnosticsLogger(category: .recording)
     ) {
         self.settingsStore = settingsStore
         let microphoneRecorder = microphoneRecorder ?? AudioRecorder(
@@ -25,6 +27,7 @@ final class RoutingAudioRecorder: AudioRecording {
             microphoneRecorder: microphoneRecorder,
             systemAudioRecorder: systemAudioRecorder
         )
+        self.recordingLogger = recordingLogger
     }
 
     var currentDuration: TimeInterval {
@@ -102,11 +105,23 @@ final class RoutingAudioRecorder: AudioRecording {
             return nil
         }
 
+        let source = String(describing: settingsStore.recordingAudioSource)
+
         guard settingsStore.systemAudioCaptureEnabled else {
+            recordingLogger.warning(
+                "system_audio_readiness_feature_disabled",
+                "System audio recording rejected: the experimental \"System audio capture modes\" toggle in Settings is off.",
+                metadata: ["source": source]
+            )
             return .systemAudioFeatureDisabled
         }
 
         guard settingsStore.hasAcceptedSystemAudioRecordingConsent else {
+            recordingLogger.warning(
+                "system_audio_readiness_consent_required",
+                "System audio recording rejected: the recording-notice consent toggle in Settings has not been ticked.",
+                metadata: ["source": source]
+            )
             return .systemAudioConsentRequired
         }
 

--- a/Sources/BugNarrator/Services/SystemAudioTapSession.swift
+++ b/Sources/BugNarrator/Services/SystemAudioTapSession.swift
@@ -66,7 +66,7 @@ final class SystemAudioTapSession {
         var tapID = AudioObjectID(kAudioObjectUnknown)
         var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
         guard status == noErr else {
-            throw AppError.systemAudioUnavailable(Self.recoveryMessage("Core Audio tap creation failed with status \(status)."))
+            throw AppError.systemAudioUnavailable(Self.tapPermissionRecoveryMessage(status: status))
         }
 
         processTapID = tapID
@@ -177,6 +177,10 @@ final class SystemAudioTapSession {
 
     private static func recoveryMessage(_ details: String) -> String {
         "Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again. \(details)"
+    }
+
+    private static func tapPermissionRecoveryMessage(status: OSStatus) -> String {
+        "macOS refused to create the system audio tap. This usually means System Audio Recording permission has not been granted to BugNarrator yet. Open System Settings > Privacy & Security > Screen & System Audio Recording, enable BugNarrator, then try again. (Core Audio status \(status).)"
     }
 
     private func installFormatChangeListener(writer: SystemAudioFileWriter) throws {

--- a/Sources/BugNarrator/Views/Settings/SettingsAudioPanes.swift
+++ b/Sources/BugNarrator/Views/Settings/SettingsAudioPanes.swift
@@ -51,7 +51,7 @@ struct SettingsRecordingAudioPane: View {
                                 : Color.orange
                         )
                 } else if settingsStore.systemAudioCaptureEnabled {
-                    Text("System audio modes require a separate macOS permission prompt the first time capture starts.")
+                    Text("System audio modes need two things before you can record: tick the consent notice that appears once you pick a system-audio source, and grant BugNarrator access under System Settings > Privacy & Security > Screen & System Audio Recording (macOS prompts once, the first time capture starts).")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }

--- a/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
+++ b/Tests/BugNarratorTests/RoutingAudioRecorderTests.swift
@@ -39,6 +39,82 @@ final class RoutingAudioRecorderTests: XCTestCase {
         XCTAssertEqual(error, .systemAudioConsentRequired)
     }
 
+    func testMicAndSystemAudioRequiresFeatureFlag() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.recordingAudioSource = .microphoneAndSystemAudio
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: MockAudioRecorder(),
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        let error = await router.validateRecordingActivation()
+
+        XCTAssertEqual(error, .systemAudioFeatureDisabled)
+    }
+
+    func testMicAndSystemAudioRequiresConsentAcknowledgement() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .microphoneAndSystemAudio
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: MockAudioRecorder(),
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        let error = await router.validateRecordingActivation()
+
+        XCTAssertEqual(error, .systemAudioConsentRequired)
+    }
+
+    func testMicrophoneOnlySkipsSystemAudioReadiness() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.recordingAudioSource = .microphone
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: MockAudioRecorder(),
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        let error = await router.validateRecordingActivation()
+
+        XCTAssertNil(error)
+    }
+
+    func testStartRecordingSurfacesReadinessErrorBeforeInvokingSourceRecorder() async {
+        let (store, defaults, defaultsSuiteName) = makeSettingsStore()
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        store.systemAudioCaptureEnabled = true
+        store.recordingAudioSource = .systemAudio
+
+        let systemRecorder = MockAudioRecorder()
+        systemRecorder.requiresMicrophonePermission = false
+        let router = RoutingAudioRecorder(
+            settingsStore: store,
+            microphoneRecorder: MockAudioRecorder(),
+            systemAudioRecorder: systemRecorder,
+            microphoneAndSystemAudioRecorder: MockAudioRecorder()
+        )
+
+        do {
+            try await router.startRecording()
+            XCTFail("Expected startRecording to throw .systemAudioConsentRequired.")
+        } catch let error as AppError {
+            XCTAssertEqual(error, .systemAudioConsentRequired)
+        } catch {
+            XCTFail("Expected AppError, got \(error).")
+        }
+
+        XCTAssertEqual(systemRecorder.startCallCount, 0)
+    }
+
     func testRoutesSystemAudioStartAndStopToSystemRecorder() async throws {
         let (store, defaults, defaultsSuiteName) = makeSettingsStore()
         defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }


### PR DESCRIPTION
## Summary

User reported (#856): selecting **System audio only** or **Mic + system audio** in Settings > Recording Audio > Audio Source causes recording to fail. Failure can come from any of three gates and the current UX/logs make them hard to distinguish.

This slice makes the three failure paths individually diagnosable and gives users concrete recovery text, without redesigning the picker.

## Changes

- `RoutingAudioRecorder.validateSystemAudioReadiness()` now emits a reason-labelled `DiagnosticsLogger` warning (`system_audio_readiness_feature_disabled` / `system_audio_readiness_consent_required`) before returning the AppError. Feature-flag and consent-toggle failures are now visible in diagnostic bundles.
- `SystemAudioTapSession.prepare()` uses a dedicated `tapPermissionRecoveryMessage` for the `AudioHardwareCreateProcessTap` failure path — this is almost always TCC (System Audio Recording permission not granted), so the message names the exact System Settings pane instead of the generic "Core Audio tap creation failed with status N."
- `SettingsAudioPanes.swift`: expand the "System audio modes require a separate macOS permission prompt the first time capture starts." hint to spell out both prerequisites (the consent toggle + the System Settings > Privacy & Security > Screen & System Audio Recording pane) so users can preempt the failure.
- `RoutingAudioRecorderTests`: 4 new tests (5 → 9 total) covering:
  - `.microphoneAndSystemAudio` feature-flag failure path
  - `.microphoneAndSystemAudio` consent-required failure path
  - `.microphone` early-return (system-audio readiness skipped)
  - `startRecording()` gate: readiness error surfaces before the source recorder is invoked

## Scope

Small (4 files, +98/-3). No public API drift on `RoutingAudioRecorder` (the new `recordingLogger:` init parameter has a default). No new production APIs. Safe under merge queue; rollback = single-commit revert.

## Follow-ups (not in this PR)

- Pre-flight TCC prompt at picker-selection time (so users don't hit the failure at record-time).
- Auto-scroll / prominent alert on the consent toggle when a system-audio source is picked without consent.

## Test plan

- [x] Unit: `RoutingAudioRecorderTests` — 9/9 pass locally (Xcode 26.6, macOS platform destination).
- [ ] Manual smoke: enable experimental flag → pick System audio only → hit Record without ticking consent → verify diagnostic log shows `system_audio_readiness_consent_required`.
- [ ] Manual smoke: tick consent → hit Record → deny the TCC prompt → verify the error banner surfaces the new "macOS refused to create the system audio tap. This usually means System Audio Recording permission has not been granted…" text.

Closes #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)