### PR TITLE
refactor: extract SettingsStore+Normalization extensions (#636 slice C) (#858)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		456F9629727CC070CD248B56 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AC8EFE20212B7DE69792FB /* AudioRecorder.swift */; };
 		45DE9D5541C2B8F54019E9F7 /* BugNarratorSettingsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD68D81A7568355BFAB9DF /* BugNarratorSettingsUITests.swift */; };
 		45F46F4649A31F438D58E465 /* BugNarratorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD698A35E065D940A06FB72 /* BugNarratorApp.swift */; };
+		465C1973DFA15D7501AEA274 /* SettingsStoreNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */; };
 		474596AEBE0A97F33B320E59 /* AppErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54521C239C09E5B94712EB /* AppErrorTypes.swift */; };
 		474B8B38A576590B2AB08D3F /* IssueExportReviewPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F10666DB201C6670B751FA /* IssueExportReviewPolicy.swift */; };
 		4D1C9E0E08BD5550F0A10C10 /* AppState+AIProviderCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6BBD3839BF28AC52214FEB /* AppState+AIProviderCredential.swift */; };
@@ -212,6 +213,7 @@
 		A514C06B61A203200CF118A1 /* AppBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553973ADCABF1FC298D834A1 /* AppBootstrapTests.swift */; };
 		A6922E228A52ADAA89226ED4 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3866CAAF8937969BAC3BFBC5 /* FinishedRecordingPostTranscriptionResultHandlerTests.swift */; };
 		A6AF1CAA204EF971F9417E63 /* TranscriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9009216340E4AF51C9EDBA /* TranscriptStore.swift */; };
+		A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */; };
 		A73F5969DB4A2C04BC83BF45 /* ExportReceiptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */; };
 		A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA46D23DB94BDF1609FAD9 /* IssueScreenshotAnnotationRenderer.swift */; };
 		A859F2836880F7D2596CD482 /* AudioRecorderTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7539AEF1F536E7EDB2047D7D /* AudioRecorderTypes.swift */; };
@@ -351,6 +353,7 @@
 		102DE8AAA101EED5CB2B6A11 /* ExportReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceipt.swift; sourceTree = "<group>"; };
 		104A00B74D18C9842D5BA11C /* JiraExportConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JiraExportConfig.swift; sourceTree = "<group>"; };
 		125C92DA82CC9990EA847AA7 /* RecordingStatusMessageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageProvider.swift; sourceTree = "<group>"; };
+		140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Normalization.swift"; sourceTree = "<group>"; };
 		154255C955FE33FD6D016BE9 /* PrivacyDataExportTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExportTypes.swift; sourceTree = "<group>"; };
 		1691FC9128F5B3D543C87721 /* ExportTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTestSupport.swift; sourceTree = "<group>"; };
 		16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsSection.swift; sourceTree = "<group>"; };
@@ -383,6 +386,7 @@
 		28B463E2764267ED731EDB99 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
 		2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
 		2D753EF601F00C09C7FF276C /* TransientToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToast.swift; sourceTree = "<group>"; };
+		2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreNormalizationTests.swift; sourceTree = "<group>"; };
 		2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProvider.swift; sourceTree = "<group>"; };
 		2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarkerTests.swift; sourceTree = "<group>"; };
@@ -745,6 +749,7 @@
 				AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */,
 				72E40C471334C91DCE931AA9 /* SettingsStoreDisplayMaskTests.swift */,
 				B72FED1F76E79D004AD1CF56 /* SettingsStoreDisplayTests.swift */,
+				2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
 				6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */,
@@ -952,6 +957,7 @@
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
 				606C8CCD0B75F5DF182C5033 /* SettingsStore+Display.swift */,
 				5387A1EF0439835D2E0B2AAF /* SettingsStore+DisplayMask.swift */,
+				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
 				7D40CD81DEFA2ECA16E84902 /* SupportDataTypes.swift */,
@@ -1258,6 +1264,7 @@
 				9619964E0CEE6D5A039340F7 /* SessionScreenshotTests.swift in Sources */,
 				435FE280CAB12DF2C2184BCC /* SettingsStoreDisplayMaskTests.swift in Sources */,
 				DBED32896E81F9C7422A48BC /* SettingsStoreDisplayTests.swift in Sources */,
+				465C1973DFA15D7501AEA274 /* SettingsStoreNormalizationTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
 				75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */,
@@ -1452,6 +1459,7 @@
 				D687F22809BF99AF4D202C1E /* SettingsReadinessTypes.swift in Sources */,
 				A12389B77FFD220995DDA0A4 /* SettingsStore+Display.swift in Sources */,
 				F4EA3CE8F9D57A67DDB2937D /* SettingsStore+DisplayMask.swift in Sources */,
+				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+Normalization.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+Normalization.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension SettingsStore {
+    var normalizedGitHubRepositoryOwner: String {
+        githubRepositoryOwner.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedGitHubRepositoryName: String {
+        githubRepositoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedGitHubRepositoryID: String {
+        githubRepositoryID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedJiraBaseURL: String {
+        jiraBaseURL
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+
+    var normalizedJiraEmail: String {
+        jiraEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedJiraProjectKey: String {
+        jiraProjectKey.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    }
+
+    var normalizedJiraProjectID: String {
+        jiraProjectID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedJiraIssueType: String {
+        jiraIssueType.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedJiraIssueTypeID: String {
+        jiraIssueTypeID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -717,18 +717,6 @@ final class SettingsStore: ObservableObject {
 
 
 
-    var normalizedGitHubRepositoryOwner: String {
-        githubRepositoryOwner.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var normalizedGitHubRepositoryName: String {
-        githubRepositoryName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var normalizedGitHubRepositoryID: String {
-        githubRepositoryID.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     var gitHubConfigurationValidationIsReady: Bool {
         gitHubRepositoryDiscoveryIsReady &&
             !normalizedGitHubRepositoryOwner.isEmpty &&
@@ -764,16 +752,6 @@ final class SettingsStore: ObservableObject {
     }
 
 
-
-    var normalizedJiraBaseURL: String {
-        jiraBaseURL
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    }
-
-    var normalizedJiraEmail: String {
-        jiraEmail.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 
     var jiraProjectDiscoveryIsReady: Bool {
         credentialIsAvailableForUserAction(
@@ -826,22 +804,6 @@ final class SettingsStore: ObservableObject {
         }
 
         return components.url
-    }
-
-    var normalizedJiraProjectKey: String {
-        jiraProjectKey.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-    }
-
-    var normalizedJiraProjectID: String {
-        jiraProjectID.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var normalizedJiraIssueType: String {
-        jiraIssueType.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var normalizedJiraIssueTypeID: String {
-        jiraIssueTypeID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     var jiraExportConfiguration: JiraExportConfiguration? {

--- a/Tests/BugNarratorTests/SettingsStoreNormalizationTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreNormalizationTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class SettingsStoreNormalizationTests: XCTestCase {
+    // MARK: - Whitespace-only input → empty string
+
+    func test_normalizedGitHubRepositoryOwner_whitespaceOnly_returnsEmpty() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.githubRepositoryOwner = "   \n\t  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedGitHubRepositoryOwner, "")
+    }
+
+    func test_normalizedJiraBaseURL_whitespaceAndSlashOnly_returnsEmpty() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraBaseURL = "  //  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraBaseURL, "")
+    }
+
+    func test_normalizedJiraProjectKey_whitespaceOnly_returnsEmpty() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraProjectKey = "   "
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraProjectKey, "")
+    }
+
+    // MARK: - Leading/trailing whitespace → trimmed
+
+    func test_normalizedGitHubRepositoryOwner_leadingTrailingWhitespace_isTrimmed() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.githubRepositoryOwner = "  ABD-Enterprises  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedGitHubRepositoryOwner, "ABD-Enterprises")
+    }
+
+    func test_normalizedJiraBaseURL_leadingTrailingWhitespace_isTrimmed() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraBaseURL = "  https://acme.atlassian.net  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraBaseURL, "https://acme.atlassian.net")
+    }
+
+    func test_normalizedJiraProjectKey_leadingTrailingWhitespace_isTrimmed() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraProjectKey = "  bug  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraProjectKey, "BUG")
+    }
+
+    // MARK: - Special-case transforms
+
+    func test_normalizedJiraBaseURL_stripsTrailingSlash() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraBaseURL = "https://acme.atlassian.net/"
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraBaseURL, "https://acme.atlassian.net")
+    }
+
+    func test_normalizedJiraBaseURL_stripsMultipleTrailingSlashes() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraBaseURL = "https://acme.atlassian.net///"
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraBaseURL, "https://acme.atlassian.net")
+    }
+
+    func test_normalizedJiraProjectKey_uppercasesResult() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.jiraProjectKey = "bugsCoolProject"
+
+        XCTAssertEqual(harness.settingsStore.normalizedJiraProjectKey, "BUGSCOOLPROJECT")
+    }
+}


### PR DESCRIPTION
## Summary

Byte-preserving move of 9 `normalized*` accessors from `SettingsStore` main class body into a new `SettingsStore+Normalization.swift` extension file. Continues #636 (SettingsStore decomposition) after slice A (PR #853) and slice B (PR #855).

Because every accessor depends only on public `@Published var` state, no visibility widening is required and no call site changes.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| SettingsStore.swift | 1845 | 1807 | -38 |
| SettingsStore+Normalization.swift (new) | — | 41 | +41 |

## Test plan

- [x] `Tests/BugNarratorTests/SettingsStoreNormalizationTests.swift` — 9 new tests covering whitespace-only, leading/trailing whitespace, and the two special-case transforms (`normalizedJiraBaseURL` trailing-slash strip; `normalizedJiraProjectKey` uppercasing). All 9 pass locally on macOS (Xcode 26.6).
- [x] Full `xcodebuild` succeeds; no call site regressions.
- [ ] Manual smoke: Settings > Integrations (GitHub, Jira) sections render identically.

Closes #858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)