### PR TITLE
refactor: extract SettingsStore+Models extensions (#636 slice D) (#862)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		D2AEB3EA7C80F6B47D0193C5 /* SimilarIssueReviewService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */; };
 		D45CDD4575F06E502855F652 /* MicrophonePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEDE046F0F85BBC5DD5D7D7 /* MicrophonePermissionService.swift */; };
 		D687F22809BF99AF4D202C1E /* SettingsReadinessTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05CD611B03D4E8792F7CD35 /* SettingsReadinessTypes.swift */; };
+		D726FDF0E6E8E4600ECDEC63 /* SettingsStore+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A1DC62D67ECDE64E5F8A17 /* SettingsStore+Models.swift */; };
 		D759CEA88F50769454691AFC /* SettingsIntegrationsPanes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */; };
 		D7D868701BE0B53E59DD6DFD /* TranscriptQualityFindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC896693FCB08C685103A65B /* TranscriptQualityFindingTests.swift */; };
 		D8438A30A02978B808CE9040 /* IssueExtractionCompletionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6D695E380D1F9B3D04BD68 /* IssueExtractionCompletionLog.swift */; };
@@ -523,6 +524,7 @@
 		8FB75074747EE722764CC071 /* IssueExportPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportPresenters.swift; sourceTree = "<group>"; };
 		90290C4DCECF33FD204DE2ED /* MenuProductInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuProductInfoView.swift; sourceTree = "<group>"; };
 		90525B5087DEF339430AF999 /* ApplicationTerminationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationController.swift; sourceTree = "<group>"; };
+		90A1DC62D67ECDE64E5F8A17 /* SettingsStore+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Models.swift"; sourceTree = "<group>"; };
 		92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+PermissionRecovery.swift"; sourceTree = "<group>"; };
 		92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCoordinatorTests.swift; sourceTree = "<group>"; };
 		93A78A37219AC79F3307E725 /* DiagnosticsRedactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRedactor.swift; sourceTree = "<group>"; };
@@ -959,6 +961,7 @@
 				2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */,
 				606C8CCD0B75F5DF182C5033 /* SettingsStore+Display.swift */,
 				5387A1EF0439835D2E0B2AAF /* SettingsStore+DisplayMask.swift */,
+				90A1DC62D67ECDE64E5F8A17 /* SettingsStore+Models.swift */,
 				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
@@ -1463,6 +1466,7 @@
 				D687F22809BF99AF4D202C1E /* SettingsReadinessTypes.swift in Sources */,
 				A12389B77FFD220995DDA0A4 /* SettingsStore+Display.swift in Sources */,
 				F4EA3CE8F9D57A67DDB2937D /* SettingsStore+DisplayMask.swift in Sources */,
+				D726FDF0E6E8E4600ECDEC63 /* SettingsStore+Models.swift in Sources */,
 				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+Models.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+Models.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+extension SettingsStore {
+    private static let openAITranscriptionModelChoices = [
+        AIModelChoice(
+            id: "whisper-1",
+            title: "Whisper",
+            detail: "Stable default"
+        ),
+        AIModelChoice(
+            id: "gpt-4o-mini-transcribe",
+            title: "GPT-4o mini Transcribe",
+            detail: "Lower cost, newer speech-to-text"
+        ),
+        AIModelChoice(
+            id: "gpt-4o-transcribe",
+            title: "GPT-4o Transcribe",
+            detail: "Higher accuracy speech-to-text"
+        ),
+        AIModelChoice(
+            id: "gpt-4o-transcribe-diarize",
+            title: "GPT-4o Transcribe Diarize",
+            detail: "Adds speaker labels"
+        )
+    ]
+    static let parakeetTranscriptionModel = "parakeet-tdt-0.6b-v3"
+    private static let parakeetTranscriptionModelChoices = [
+        AIModelChoice(
+            id: parakeetTranscriptionModel,
+            title: "Parakeet TDT 0.6B v3",
+            detail: "Local transcription server"
+        )
+    ]
+    private static let openAIIssueExtractionModelChoices = [
+        AIModelChoice(
+            id: "gpt-4.1-mini",
+            title: "GPT-4.1 mini",
+            detail: "Recommended default"
+        ),
+        AIModelChoice(
+            id: "gpt-4.1-nano",
+            title: "GPT-4.1 nano",
+            detail: "Fastest and lowest cost"
+        ),
+        AIModelChoice(
+            id: "gpt-4.1",
+            title: "GPT-4.1",
+            detail: "Higher quality issue extraction"
+        )
+    ]
+
+    var preferredModelValue: String {
+        Self.normalizedTranscriptionModel(preferredModel, for: aiProvider)
+    }
+
+    var issueExtractionModelValue: String {
+        Self.normalizedIssueExtractionModel(issueExtractionModel, for: aiProvider)
+    }
+
+    var transcriptionModelChoices: [AIModelChoice] {
+        Self.transcriptionModelChoices(for: aiProvider)
+    }
+
+    var issueExtractionModelChoices: [AIModelChoice] {
+        Self.issueExtractionModelChoices(for: aiProvider)
+    }
+
+    static func transcriptionModelChoices(for provider: AIProvider) -> [AIModelChoice] {
+        switch provider {
+        case .openAI:
+            return openAITranscriptionModelChoices
+        case .parakeetLocal:
+            return parakeetTranscriptionModelChoices
+        case .openAICompatible, .localCompatible:
+            return []
+        }
+    }
+
+    static func issueExtractionModelChoices(for provider: AIProvider) -> [AIModelChoice] {
+        switch provider {
+        case .openAI:
+            return openAIIssueExtractionModelChoices
+        case .openAICompatible, .localCompatible, .parakeetLocal:
+            return []
+        }
+    }
+
+    static func normalizedTranscriptionModel(_ rawValue: String, for provider: AIProvider) -> String {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch provider {
+        case .openAI:
+            let allowedModels = Set(openAITranscriptionModelChoices.map(\.id))
+            return allowedModels.contains(value) ? value : openAITranscriptionModel
+        case .parakeetLocal:
+            return parakeetTranscriptionModel
+        case .openAICompatible, .localCompatible:
+            return value.isEmpty ? openAITranscriptionModel : value
+        }
+    }
+
+    static func normalizedIssueExtractionModel(_ rawValue: String, for provider: AIProvider) -> String {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch provider {
+        case .openAI:
+            let allowedModels = Set(openAIIssueExtractionModelChoices.map(\.id))
+            return allowedModels.contains(value) ? value : openAIIssueExtractionModel
+        case .openAICompatible, .localCompatible, .parakeetLocal:
+            return value.isEmpty ? openAIIssueExtractionModel : value
+        }
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -12,56 +12,9 @@ final class SettingsStore: ObservableObject {
         "com.abdenterprises.sessionmic"
     ]
 
-    private static let openAITranscriptionModel = "whisper-1"
+    static let openAITranscriptionModel = "whisper-1"
     private static let defaultLanguageHint = "en"
-    private static let parakeetTranscriptionModel = "parakeet-tdt-0.6b-v3"
-    private static let openAIIssueExtractionModel = "gpt-4.1-mini"
-    private static let openAITranscriptionModelChoices = [
-        AIModelChoice(
-            id: "whisper-1",
-            title: "Whisper",
-            detail: "Stable default"
-        ),
-        AIModelChoice(
-            id: "gpt-4o-mini-transcribe",
-            title: "GPT-4o mini Transcribe",
-            detail: "Lower cost, newer speech-to-text"
-        ),
-        AIModelChoice(
-            id: "gpt-4o-transcribe",
-            title: "GPT-4o Transcribe",
-            detail: "Higher accuracy speech-to-text"
-        ),
-        AIModelChoice(
-            id: "gpt-4o-transcribe-diarize",
-            title: "GPT-4o Transcribe Diarize",
-            detail: "Adds speaker labels"
-        )
-    ]
-    private static let parakeetTranscriptionModelChoices = [
-        AIModelChoice(
-            id: parakeetTranscriptionModel,
-            title: "Parakeet TDT 0.6B v3",
-            detail: "Local transcription server"
-        )
-    ]
-    private static let openAIIssueExtractionModelChoices = [
-        AIModelChoice(
-            id: "gpt-4.1-mini",
-            title: "GPT-4.1 mini",
-            detail: "Recommended default"
-        ),
-        AIModelChoice(
-            id: "gpt-4.1-nano",
-            title: "GPT-4.1 nano",
-            detail: "Fastest and lowest cost"
-        ),
-        AIModelChoice(
-            id: "gpt-4.1",
-            title: "GPT-4.1",
-            detail: "Higher quality issue extraction"
-        )
-    ]
+    static let openAIIssueExtractionModel = "gpt-4.1-mini"
 
     private let logger = DiagnosticsLogger(category: .settings)
 
@@ -560,10 +513,6 @@ final class SettingsStore: ObservableObject {
             + "unless this is a trusted local server."
     }
 
-    var preferredModelValue: String {
-        Self.normalizedTranscriptionModel(preferredModel, for: aiProvider)
-    }
-
     var normalizedLanguageHint: String? {
         normalizeOptional(languageHint)
     }
@@ -579,18 +528,6 @@ final class SettingsStore: ObservableObject {
             prompt: normalizedPrompt,
             apiBaseURL: openAIBaseURLValue
         )
-    }
-
-    var issueExtractionModelValue: String {
-        Self.normalizedIssueExtractionModel(issueExtractionModel, for: aiProvider)
-    }
-
-    var transcriptionModelChoices: [AIModelChoice] {
-        Self.transcriptionModelChoices(for: aiProvider)
-    }
-
-    var issueExtractionModelChoices: [AIModelChoice] {
-        Self.issueExtractionModelChoices(for: aiProvider)
     }
 
     var supportsIssueExtraction: Bool {
@@ -864,52 +801,6 @@ final class SettingsStore: ObservableObject {
 
         load()
         hasLoaded = true
-    }
-
-    private static func transcriptionModelChoices(for provider: AIProvider) -> [AIModelChoice] {
-        switch provider {
-        case .openAI:
-            return openAITranscriptionModelChoices
-        case .parakeetLocal:
-            return parakeetTranscriptionModelChoices
-        case .openAICompatible, .localCompatible:
-            return []
-        }
-    }
-
-    private static func issueExtractionModelChoices(for provider: AIProvider) -> [AIModelChoice] {
-        switch provider {
-        case .openAI:
-            return openAIIssueExtractionModelChoices
-        case .openAICompatible, .localCompatible, .parakeetLocal:
-            return []
-        }
-    }
-
-    private static func normalizedTranscriptionModel(_ rawValue: String, for provider: AIProvider) -> String {
-        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        switch provider {
-        case .openAI:
-            let allowedModels = Set(openAITranscriptionModelChoices.map(\.id))
-            return allowedModels.contains(value) ? value : openAITranscriptionModel
-        case .parakeetLocal:
-            return parakeetTranscriptionModel
-        case .openAICompatible, .localCompatible:
-            return value.isEmpty ? openAITranscriptionModel : value
-        }
-    }
-
-    private static func normalizedIssueExtractionModel(_ rawValue: String, for provider: AIProvider) -> String {
-        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        switch provider {
-        case .openAI:
-            let allowedModels = Set(openAIIssueExtractionModelChoices.map(\.id))
-            return allowedModels.contains(value) ? value : openAIIssueExtractionModel
-        case .openAICompatible, .localCompatible, .parakeetLocal:
-            return value.isEmpty ? openAIIssueExtractionModel : value
-        }
     }
 
     private func normalizeTranscriptionModelForCurrentProvider(persist: Bool) {


### PR DESCRIPTION
## Summary

Fourth slice of #636. Extracts the model-choice cluster (4 accessors + 4 static helpers + 4 constants) into `SettingsStore+Models.swift`. Continues after PRs #853/#855/#859.

## Visibility changes (minor)

The move required widening 5 symbols by one notch (`private static` → `static`) so cross-file property-observer and placeholder-accessor callers still work:
- 4 static helpers: `transcriptionModelChoices(for:)`, `issueExtractionModelChoices(for:)`, `normalizedTranscriptionModel`, `normalizedIssueExtractionModel`
- 1 constant: `parakeetTranscriptionModel` (referenced by `transcriptionModelPlaceholder` in main class body)
- 2 constants that stay in the main class body: `openAITranscriptionModel`, `openAIIssueExtractionModel` (referenced from moved helpers)

Zero external test callers of any widened symbol.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| SettingsStore.swift | 1807 | 1698 | -109 |
| SettingsStore+Models.swift (new) | — | 113 | +113 |

## Test plan

- [x] `xcodebuild build -destination platform=macOS` succeeds.
- [x] `SettingsStoreTests` passes (covers `store.transcriptionModelChoices`, `store.issueExtractionModelChoices`, `transcriptionRequest.model` via `preferredModelValue`).

Closes #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)