### PR TITLE
refactor: extract SettingsStore+Tokens extensions (#636 slice E) (#864)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		68D411F355E3ED698E688D86 /* PermissionRecoveryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4AF819B9841925ACD930D0 /* PermissionRecoveryController.swift */; };
 		69F0F76E67B312F356DE7354 /* AppState+PermissionRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */; };
 		6AC08ACF1118EF6BDAD2E6BA /* DiagnosticsRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A78A37219AC79F3307E725 /* DiagnosticsRedactor.swift */; };
+		6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */; };
 		6B52833F68E7F99EE7D2FE07 /* AppState+IssueExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */; };
 		6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */; };
 		6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */; };
@@ -521,6 +522,7 @@
 		8B9EE251C9CCE29EDED45889 /* IssueExtractionResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionResponseParserTests.swift; sourceTree = "<group>"; };
 		8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscription.swift; sourceTree = "<group>"; };
 		8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewComponents.swift; sourceTree = "<group>"; };
+		8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Tokens.swift"; sourceTree = "<group>"; };
 		8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilderTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		8FB75074747EE722764CC071 /* IssueExportPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportPresenters.swift; sourceTree = "<group>"; };
@@ -965,6 +967,7 @@
 				5387A1EF0439835D2E0B2AAF /* SettingsStore+DisplayMask.swift */,
 				90A1DC62D67ECDE64E5F8A17 /* SettingsStore+Models.swift */,
 				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
+				8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
 				7D40CD81DEFA2ECA16E84902 /* SupportDataTypes.swift */,
@@ -1472,6 +1475,7 @@
 				F4EA3CE8F9D57A67DDB2937D /* SettingsStore+DisplayMask.swift in Sources */,
 				D726FDF0E6E8E4600ECDEC63 /* SettingsStore+Models.swift in Sources */,
 				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
+				6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+Tokens.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+Tokens.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension SettingsStore {
+    var trimmedAPIKey: String {
+        apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var trimmedGitHubToken: String {
+        githubToken.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var hasGitHubToken: Bool {
+        !trimmedGitHubToken.isEmpty
+    }
+
+    var githubDefaultLabelsList: [String] {
+        githubDefaultLabels
+            .split(whereSeparator: \.isNewline)
+            .flatMap { $0.split(separator: ",") }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    var trimmedJiraAPIToken: String {
+        jiraAPIToken.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var hasJiraAPIToken: Bool {
+        !trimmedJiraAPIToken.isEmpty
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -316,9 +316,6 @@ final class SettingsStore: ObservableObject {
         openAtStartupSupported
     }
 
-    var trimmedAPIKey: String {
-        apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 
     var hotkeyAssignments: [(action: HotkeyAction, shortcut: HotkeyShortcut)] {
         [
@@ -637,13 +634,6 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var trimmedGitHubToken: String {
-        githubToken.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var hasGitHubToken: Bool {
-        !trimmedGitHubToken.isEmpty
-    }
 
     var gitHubRepositoryDiscoveryIsReady: Bool {
         credentialIsAvailableForUserAction(
@@ -660,13 +650,6 @@ final class SettingsStore: ObservableObject {
             !normalizedGitHubRepositoryName.isEmpty
     }
 
-    var githubDefaultLabelsList: [String] {
-        githubDefaultLabels
-            .split(whereSeparator: \.isNewline)
-            .flatMap { $0.split(separator: ",") }
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-    }
 
     var githubExportConfiguration: GitHubExportConfiguration? {
         let configuration = GitHubExportConfiguration(
@@ -680,13 +663,6 @@ final class SettingsStore: ObservableObject {
         return configuration.isComplete ? configuration : nil
     }
 
-    var trimmedJiraAPIToken: String {
-        jiraAPIToken.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var hasJiraAPIToken: Bool {
-        !trimmedJiraAPIToken.isEmpty
-    }
 
 
 


### PR DESCRIPTION
## Summary

Fifth slice of #636. Byte-preserving move of 6 token-related accessors (`trimmedAPIKey`, `trimmedGitHubToken`, `hasGitHubToken`, `githubDefaultLabelsList`, `trimmedJiraAPIToken`, `hasJiraAPIToken`) into `SettingsStore+Tokens.swift`. Zero visibility widening; every accessor depends only on public `@Published var` state.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| SettingsStore.swift | 1698 | 1674 | -24 |
| SettingsStore+Tokens.swift (new) | — | 31 | +31 |

## Test plan

- [x] `xcodebuild build -destination platform=macOS` succeeds.
- [x] `SettingsStoreTests` passes.

Closes #864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)