### PR TITLE
refactor: extract SettingsStore+Placeholders extensions (#636 slice F) (#866)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		19F9F231721D64A173E63F98 /* AppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B463E2764267ED731EDB99 /* AppBootstrap.swift */; };
 		1A14A6ECD74AF52C4068A1E7 /* RecordingSessionDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C18F22BDAC3501073F3803 /* RecordingSessionDraft.swift */; };
 		1A4DDBF8B434316F8BA22C2E /* RetryTranscriptionStatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D940C14237976DFE861600CE /* RetryTranscriptionStatusPresenterTests.swift */; };
+		1AE86CB911DF684680A7D85D /* SettingsStore+Placeholders.swift in Sources */ = {isa = PBXBuildFile; fileRef = A704652028D5FF7C005F44C4 /* SettingsStore+Placeholders.swift */; };
 		1B6F43DA42AC21571CE4381D /* IssueExtractionFailurePresenter+Attempt.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6EFDC92FB70AFBB28EA6CF7 /* IssueExtractionFailurePresenter+Attempt.swift */; };
 		1BCD3E21C690E06B00319440 /* AppState+IssueExportQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776E95F5977423452961A52B /* AppState+IssueExportQueries.swift */; };
 		1D215DF2182DF192A8160F22 /* ChangelogDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E210EC5ADA6A8ED8028CDA /* ChangelogDocumentTests.swift */; };
@@ -242,6 +243,7 @@
 		B771844AAE785C764AEBD7C6 /* SecretSlotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BD14AE99398DAE80181305 /* SecretSlotTests.swift */; };
 		B7CF73E927D64502C998A0BC /* SessionLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1605CDD1B7C6F848068F14 /* SessionLibrary.swift */; };
 		BA99127A39D827962D535164 /* SettingsReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */; };
+		BB1F6ABF206D70F310CFC20A /* SettingsStorePlaceholdersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06C14D0FD45D1AEF489AEB69 /* SettingsStorePlaceholdersTests.swift */; };
 		BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B578DB59431378DDC84929 /* GitHubExportConfig.swift */; };
 		BBE16FF238B059EF08346355 /* ReviewWorkspaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70C2AF1D71698B8CB98490E /* ReviewWorkspaceTypes.swift */; };
 		BC9E4D8AE8F5F1F539C5641A /* AppErrorSubPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778F1E0C90308A1D868A187E /* AppErrorSubPresenters.swift */; };
@@ -343,6 +345,7 @@
 		04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspector.swift; sourceTree = "<group>"; };
 		0564DB57CA0F960E25142103 /* ElapsedTimeFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElapsedTimeFormatterTests.swift; sourceTree = "<group>"; };
 		0599934D564C87030D294589 /* BugNarratorDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugNarratorDiagnostics.swift; sourceTree = "<group>"; };
+		06C14D0FD45D1AEF489AEB69 /* SettingsStorePlaceholdersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStorePlaceholdersTests.swift; sourceTree = "<group>"; };
 		073429BA65ECFB0B4AED9FD5 /* ScreenshotCaptureControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureControllerTests.swift; sourceTree = "<group>"; };
 		084D11633172FCB62C674D40 /* APIKeyValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationState.swift; sourceTree = "<group>"; };
 		090874D96E31365E5A10076E /* ScreenshotSelectionGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotSelectionGeometry.swift; sourceTree = "<group>"; };
@@ -550,6 +553,7 @@
 		A31B0939DF668FFC71CD64FD /* TranscriptionRecoveryControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryControllerTests.swift; sourceTree = "<group>"; };
 		A663ED1B160E290FCFAC3AED /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRecoveryAndHistoryViews.swift; sourceTree = "<group>"; };
+		A704652028D5FF7C005F44C4 /* SettingsStore+Placeholders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Placeholders.swift"; sourceTree = "<group>"; };
 		A78CE9DC8EFA97D0320943DC /* RoutingAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorder.swift; sourceTree = "<group>"; };
 		A8E2942C142197B34696946C /* TranscriptSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSection.swift; sourceTree = "<group>"; };
 		A98A6F8F6072E7B0276FB5A9 /* AtomicBundleDirectoryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicBundleDirectoryWriter.swift; sourceTree = "<group>"; };
@@ -758,6 +762,7 @@
 				72E40C471334C91DCE931AA9 /* SettingsStoreDisplayMaskTests.swift */,
 				B72FED1F76E79D004AD1CF56 /* SettingsStoreDisplayTests.swift */,
 				2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */,
+				06C14D0FD45D1AEF489AEB69 /* SettingsStorePlaceholdersTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
 				6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */,
@@ -967,6 +972,7 @@
 				5387A1EF0439835D2E0B2AAF /* SettingsStore+DisplayMask.swift */,
 				90A1DC62D67ECDE64E5F8A17 /* SettingsStore+Models.swift */,
 				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
+				A704652028D5FF7C005F44C4 /* SettingsStore+Placeholders.swift */,
 				8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
@@ -1277,6 +1283,7 @@
 				435FE280CAB12DF2C2184BCC /* SettingsStoreDisplayMaskTests.swift in Sources */,
 				DBED32896E81F9C7422A48BC /* SettingsStoreDisplayTests.swift in Sources */,
 				465C1973DFA15D7501AEA274 /* SettingsStoreNormalizationTests.swift in Sources */,
+				BB1F6ABF206D70F310CFC20A /* SettingsStorePlaceholdersTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
 				75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */,
@@ -1475,6 +1482,7 @@
 				F4EA3CE8F9D57A67DDB2937D /* SettingsStore+DisplayMask.swift in Sources */,
 				D726FDF0E6E8E4600ECDEC63 /* SettingsStore+Models.swift in Sources */,
 				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
+				1AE86CB911DF684680A7D85D /* SettingsStore+Placeholders.swift in Sources */,
 				6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+Placeholders.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+Placeholders.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension SettingsStore {
+    var supportsIssueExtraction: Bool {
+        aiProvider != .parakeetLocal
+    }
+
+    var transcriptionModelPlaceholder: String {
+        switch aiProvider {
+        case .openAI:
+            return Self.openAITranscriptionModel
+        case .openAICompatible:
+            return "Provider transcription model"
+        case .localCompatible:
+            return "Local transcription model"
+        case .parakeetLocal:
+            return Self.parakeetTranscriptionModel
+        }
+    }
+
+    var issueExtractionModelPlaceholder: String {
+        switch aiProvider {
+        case .openAI:
+            return Self.openAIIssueExtractionModel
+        case .openAICompatible:
+            return "Provider chat model"
+        case .localCompatible:
+            return "Local chat model"
+        case .parakeetLocal:
+            return "Not available"
+        }
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -527,35 +527,6 @@ final class SettingsStore: ObservableObject {
         )
     }
 
-    var supportsIssueExtraction: Bool {
-        aiProvider != .parakeetLocal
-    }
-
-    var transcriptionModelPlaceholder: String {
-        switch aiProvider {
-        case .openAI:
-            return Self.openAITranscriptionModel
-        case .openAICompatible:
-            return "Provider transcription model"
-        case .localCompatible:
-            return "Local transcription model"
-        case .parakeetLocal:
-            return Self.parakeetTranscriptionModel
-        }
-    }
-
-    var issueExtractionModelPlaceholder: String {
-        switch aiProvider {
-        case .openAI:
-            return Self.openAIIssueExtractionModel
-        case .openAICompatible:
-            return "Provider chat model"
-        case .localCompatible:
-            return "Local chat model"
-        case .parakeetLocal:
-            return "Not available"
-        }
-    }
 
     var hasAPIKey: Bool {
         credentialIsAvailableForUserAction(

--- a/Tests/BugNarratorTests/SettingsStorePlaceholdersTests.swift
+++ b/Tests/BugNarratorTests/SettingsStorePlaceholdersTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class SettingsStorePlaceholdersTests: XCTestCase {
+    // MARK: - supportsIssueExtraction
+
+    func test_supportsIssueExtraction_openAI_returnsTrue() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAI
+
+        XCTAssertTrue(harness.settingsStore.supportsIssueExtraction)
+    }
+
+    func test_supportsIssueExtraction_openAICompatible_returnsTrue() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAICompatible
+
+        XCTAssertTrue(harness.settingsStore.supportsIssueExtraction)
+    }
+
+    func test_supportsIssueExtraction_localCompatible_returnsTrue() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .localCompatible
+
+        XCTAssertTrue(harness.settingsStore.supportsIssueExtraction)
+    }
+
+    func test_supportsIssueExtraction_parakeetLocal_returnsFalse() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .parakeetLocal
+
+        XCTAssertFalse(harness.settingsStore.supportsIssueExtraction)
+    }
+
+    // MARK: - transcriptionModelPlaceholder
+
+    func test_transcriptionModelPlaceholder_openAI_returnsWhisper1() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAI
+
+        XCTAssertEqual(harness.settingsStore.transcriptionModelPlaceholder, "whisper-1")
+    }
+
+    func test_transcriptionModelPlaceholder_openAICompatible_returnsProviderModelHint() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAICompatible
+
+        XCTAssertEqual(harness.settingsStore.transcriptionModelPlaceholder, "Provider transcription model")
+    }
+
+    func test_transcriptionModelPlaceholder_localCompatible_returnsLocalModelHint() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .localCompatible
+
+        XCTAssertEqual(harness.settingsStore.transcriptionModelPlaceholder, "Local transcription model")
+    }
+
+    func test_transcriptionModelPlaceholder_parakeetLocal_returnsParakeetModelID() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .parakeetLocal
+
+        XCTAssertEqual(harness.settingsStore.transcriptionModelPlaceholder, "parakeet-tdt-0.6b-v3")
+    }
+
+    // MARK: - issueExtractionModelPlaceholder
+
+    func test_issueExtractionModelPlaceholder_openAI_returnsGpt41Mini() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAI
+
+        XCTAssertEqual(harness.settingsStore.issueExtractionModelPlaceholder, "gpt-4.1-mini")
+    }
+
+    func test_issueExtractionModelPlaceholder_openAICompatible_returnsProviderChatHint() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAICompatible
+
+        XCTAssertEqual(harness.settingsStore.issueExtractionModelPlaceholder, "Provider chat model")
+    }
+
+    func test_issueExtractionModelPlaceholder_localCompatible_returnsLocalChatHint() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .localCompatible
+
+        XCTAssertEqual(harness.settingsStore.issueExtractionModelPlaceholder, "Local chat model")
+    }
+
+    func test_issueExtractionModelPlaceholder_parakeetLocal_returnsNotAvailable() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .parakeetLocal
+
+        XCTAssertEqual(harness.settingsStore.issueExtractionModelPlaceholder, "Not available")
+    }
+}


### PR DESCRIPTION
## Summary

Sixth slice of #636. Byte-preserving move of 3 accessors (`supportsIssueExtraction`, `transcriptionModelPlaceholder`, `issueExtractionModelPlaceholder`) into `SettingsStore+Placeholders.swift`. Zero new visibility widening; every accessor depends only on `aiProvider` and 3 constants already made module-internal by slice D.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| SettingsStore.swift | 1674 | 1645 | -29 |
| SettingsStore+Placeholders.swift (new) | — | 33 | +33 |

## Test plan

- [x] 12 new unit tests in `SettingsStorePlaceholdersTests.swift` cover all 4 `aiProvider` branches × 3 accessors. All pass.
- [x] Existing `SettingsStoreTests` continue to pass (they cover `.supportsIssueExtraction` at lines 805/826/844 already).
- [x] Full `xcodebuild test` on macOS destination succeeds locally.
- [ ] Manual smoke: Settings > AI provider selection — placeholders render identically.

Closes #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)