### PR TITLE
refactor: extract SettingsStore+TranscriptionInput extensions (#636 slice G) (#869)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		2CDA374600484F9DF4079AB5 /* VerboseTranscriptionResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE6A1D707211E467BFD8EF0 /* VerboseTranscriptionResponseParser.swift */; };
 		2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */; };
 		30018202D1990BA2524B2CD6 /* RecordingAudioSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13FAD167DA9EEEC9E83F41 /* RecordingAudioSource.swift */; };
+		300699DE1A6404DE829D5BAC /* SettingsStore+TranscriptionInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB98E3B2E52CC5AC4BBBE84 /* SettingsStore+TranscriptionInput.swift */; };
 		318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */; };
 		31A36AA0F41DF712DD79262B /* TranscriptStoreRecoveryEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E813CF73D0B819D24B8C81 /* TranscriptStoreRecoveryEvent.swift */; };
 		31D0FF8CFB99E767103A0561 /* AppErrorPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2173ED04BA5467313B6261 /* AppErrorPresenterTests.swift */; };
@@ -103,6 +104,7 @@
 		525C328F410D5C0BAF88FE99 /* LocalDataDeletionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F534B2AFBEFF7F1351A4C9 /* LocalDataDeletionController.swift */; };
 		52C0B842187598C05C4C39D2 /* ScreenshotCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D924BFCEE1A248BC6FEED6 /* ScreenshotCoordinatorTests.swift */; };
 		5347CDF5BF237A76998D261A /* DebugBundleExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68E6CA27B77C4512FB158FC /* DebugBundleExporterTests.swift */; };
+		541309790B4F2C31555FE97C /* SettingsStoreTranscriptionInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F840A9A735AEF19BA7966A5 /* SettingsStoreTranscriptionInputTests.swift */; };
 		544FA33C107DC4D4AA136D2B /* SystemAudioFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D6357236D21D641327DEE /* SystemAudioFileWriterTests.swift */; };
 		562BF7C0BF2A8D013BA2F63F /* BugNarratorMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2739FAF7F679C31F04058E0 /* BugNarratorMetadata.swift */; };
 		567F87EB07251F21C61234A7 /* AppUtilityActionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A98C939A6ECBB0132C0305 /* AppUtilityActionControllerTests.swift */; };
@@ -354,6 +356,7 @@
 		0BEE7BE23DD7A74982179B08 /* IssueExportTargetEditors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportTargetEditors.swift; sourceTree = "<group>"; };
 		0C6FB57EE70D75E47710D667 /* SettingsGeneralPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGeneralPanes.swift; sourceTree = "<group>"; };
 		0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAudioRecorder.swift; sourceTree = "<group>"; };
+		0DB98E3B2E52CC5AC4BBBE84 /* SettingsStore+TranscriptionInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+TranscriptionInput.swift"; sourceTree = "<group>"; };
 		0DF81E6E8D3A702691797E56 /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		0E4DEAD3D9703348B84229AC /* SettingsIntegrationsPanes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsIntegrationsPanes.swift; sourceTree = "<group>"; };
 		0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsLogEntry.swift; sourceTree = "<group>"; };
@@ -456,6 +459,7 @@
 		5F27EE86CDB87DABC7401E8E /* KeychainTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTestSupport.swift; sourceTree = "<group>"; };
 		5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrophonePermissionResolverTests.swift; sourceTree = "<group>"; };
 		5F7F5FB0F3460F31156FC805 /* AppServiceContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServiceContainer.swift; sourceTree = "<group>"; };
+		5F840A9A735AEF19BA7966A5 /* SettingsStoreTranscriptionInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreTranscriptionInputTests.swift; sourceTree = "<group>"; };
 		5FC9AEF9C67019E23C116896 /* SessionLibraryPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryPresenters.swift; sourceTree = "<group>"; };
 		6047FAC93EEF81B1DB450003 /* SystemAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioRecorder.swift; sourceTree = "<group>"; };
 		606C8CCD0B75F5DF182C5033 /* SettingsStore+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Display.swift"; sourceTree = "<group>"; };
@@ -764,6 +768,7 @@
 				2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */,
 				06C14D0FD45D1AEF489AEB69 /* SettingsStorePlaceholdersTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
+				5F840A9A735AEF19BA7966A5 /* SettingsStoreTranscriptionInputTests.swift */,
 				3ED47247E62B3FD1B25A6C8E /* SingleInstanceControllerTests.swift */,
 				6090889796738DBC320B2BC4 /* SupportDataControllerTests.swift */,
 				4F967DF7EA1081CFFF0E55EE /* SystemAudioAggregateDeviceTests.swift */,
@@ -974,6 +979,7 @@
 				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
 				A704652028D5FF7C005F44C4 /* SettingsStore+Placeholders.swift */,
 				8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */,
+				0DB98E3B2E52CC5AC4BBBE84 /* SettingsStore+TranscriptionInput.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
 				7D40CD81DEFA2ECA16E84902 /* SupportDataTypes.swift */,
@@ -1285,6 +1291,7 @@
 				465C1973DFA15D7501AEA274 /* SettingsStoreNormalizationTests.swift in Sources */,
 				BB1F6ABF206D70F310CFC20A /* SettingsStorePlaceholdersTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,
+				541309790B4F2C31555FE97C /* SettingsStoreTranscriptionInputTests.swift in Sources */,
 				8419388E08492DBAC01BEEE8 /* SingleInstanceControllerTests.swift in Sources */,
 				75A0FDFC72E6DE5AC8B06BE7 /* SupportDataControllerTests.swift in Sources */,
 				DA404465664E7425E991C177 /* SystemAudioAggregateDeviceTests.swift in Sources */,
@@ -1484,6 +1491,7 @@
 				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
 				1AE86CB911DF684680A7D85D /* SettingsStore+Placeholders.swift in Sources */,
 				6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */,
+				300699DE1A6404DE829D5BAC /* SettingsStore+TranscriptionInput.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,
 				8E21137F54B8CC5D96258B8D /* SettingsViewComponents.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+TranscriptionInput.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+TranscriptionInput.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension SettingsStore {
+    var normalizedLanguageHint: String? {
+        normalizeOptional(languageHint)
+    }
+
+    var normalizedPrompt: String? {
+        normalizeOptional(transcriptionPrompt)
+    }
+
+    var transcriptionRequest: TranscriptionRequest {
+        TranscriptionRequest(
+            model: preferredModelValue,
+            languageHint: normalizedLanguageHint,
+            prompt: normalizedPrompt,
+            apiBaseURL: openAIBaseURLValue
+        )
+    }
+
+    private func normalizeOptional(_ value: String) -> String? {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -510,22 +510,6 @@ final class SettingsStore: ObservableObject {
             + "unless this is a trusted local server."
     }
 
-    var normalizedLanguageHint: String? {
-        normalizeOptional(languageHint)
-    }
-
-    var normalizedPrompt: String? {
-        normalizeOptional(transcriptionPrompt)
-    }
-
-    var transcriptionRequest: TranscriptionRequest {
-        TranscriptionRequest(
-            model: preferredModelValue,
-            languageHint: normalizedLanguageHint,
-            prompt: normalizedPrompt,
-            apiBaseURL: openAIBaseURLValue
-        )
-    }
 
 
     var hasAPIKey: Bool {
@@ -1521,10 +1505,6 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    private func normalizeOptional(_ value: String) -> String? {
-        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmedValue.isEmpty ? nil : trimmedValue
-    }
 
     private func stringValue(forKey key: String, legacyKeys: [String] = []) -> String? {
         if let value = defaults.string(forKey: key) {

--- a/Tests/BugNarratorTests/SettingsStoreTranscriptionInputTests.swift
+++ b/Tests/BugNarratorTests/SettingsStoreTranscriptionInputTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import BugNarrator
+
+@MainActor
+final class SettingsStoreTranscriptionInputTests: XCTestCase {
+    // MARK: - normalizedLanguageHint
+
+    func test_normalizedLanguageHint_whitespaceOnly_returnsNil() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.languageHint = "   \n\t  "
+
+        XCTAssertNil(harness.settingsStore.normalizedLanguageHint)
+    }
+
+    func test_normalizedLanguageHint_leadingTrailingWhitespace_isTrimmed() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.languageHint = "  fr  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedLanguageHint, "fr")
+    }
+
+    func test_normalizedLanguageHint_normalValue_returnsUnchanged() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.languageHint = "es"
+
+        XCTAssertEqual(harness.settingsStore.normalizedLanguageHint, "es")
+    }
+
+    // MARK: - normalizedPrompt
+
+    func test_normalizedPrompt_whitespaceOnly_returnsNil() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.transcriptionPrompt = "   "
+
+        XCTAssertNil(harness.settingsStore.normalizedPrompt)
+    }
+
+    func test_normalizedPrompt_leadingTrailingWhitespace_isTrimmed() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.transcriptionPrompt = "  Focus on user story keywords.  "
+
+        XCTAssertEqual(harness.settingsStore.normalizedPrompt, "Focus on user story keywords.")
+    }
+
+    func test_normalizedPrompt_normalValue_returnsUnchanged() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.transcriptionPrompt = "Prefer engineering vocabulary."
+
+        XCTAssertEqual(harness.settingsStore.normalizedPrompt, "Prefer engineering vocabulary.")
+    }
+
+    // MARK: - transcriptionRequest composition
+
+    func test_transcriptionRequest_composesFieldsFromNormalizedAccessorsForOpenAIDefault() throws {
+        let harness = AppStateHarness()
+        harness.settingsStore.aiProvider = .openAI
+        harness.settingsStore.preferredModel = "whisper-1"
+        harness.settingsStore.languageHint = "  en  "
+        harness.settingsStore.transcriptionPrompt = ""
+
+        let request = harness.settingsStore.transcriptionRequest
+
+        XCTAssertEqual(request.model, "whisper-1")
+        XCTAssertEqual(request.languageHint, "en")
+        XCTAssertNil(request.prompt)
+        XCTAssertEqual(request.apiBaseURL, harness.settingsStore.openAIBaseURLValue)
+    }
+}


### PR DESCRIPTION
## Summary

Seventh slice of #636. Byte-preserving move of the transcription-input cluster (`normalizedLanguageHint`, `normalizedPrompt`, `transcriptionRequest`, `private func normalizeOptional`) into `SettingsStore+TranscriptionInput.swift`. `normalizeOptional` moves into the same file as its 2 callers, so it stays `private` — zero visibility widening.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| SettingsStore.swift | 1645 | 1625 | -20 |
| SettingsStore+TranscriptionInput.swift (new) | — | 25 | +25 |

## Test plan

- [x] 7 new tests in `SettingsStoreTranscriptionInputTests.swift` cover the trim-to-optional contract + `transcriptionRequest` composition. All pass locally.
- [x] Existing `SettingsStoreTests` continue to pass unchanged.
- [x] Full `xcodebuild test -destination platform=macOS` on the relevant suites succeeds.

## Pre-build review

Codex spec-review: **BLOCKERS: none, OK: 5 claims** (line ranges byte-verbatim; `normalizeOptional` only called by the 2 accessors; `transcriptionRequest` deps all cross-file accessible).

Closes #869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)