### PR TITLE
ci: probe [self-hosted, Linux, ARM64] for runtime-guardrails (#868)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,10 @@ jobs:
   # effort-leak-audit, etc.). Delete this job in the follow-up flip PR once the
   # probe is proven green on 2+ consecutive PRs.
   runtime-guardrails-linux-probe:
-    needs:
-      - detect-ci-changes
-    if: needs.detect-ci-changes.outputs.swift_changed == 'true' || needs.detect-ci-changes.outputs.docs_changed == 'true'
+    # Runs unconditionally to match the source `runtime-guardrails` job's
+    # coverage — otherwise a scripts-only or root-config PR would exercise
+    # `runtime-guardrails` but skip the probe, leaving the flip-PR without
+    # parity evidence for that PR shape.
     runs-on: [self-hosted, Linux, ARM64]
     continue-on-error: true
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,59 @@ jobs:
           git fetch --no-tags --depth=1 origin "${{ steps.base.outputs.ref }}"
           ./scripts/validate.sh "${{ steps.base.outputs.ref }}"
 
+  # Probe (#868, first slice of the org-runner migration): dual-run the runtime
+  # guardrails validator on the org's self-hosted `[self-hosted, Linux, ARM64]`
+  # runner (`docker-linux-arm64-orc-studio-macbookprom5`) alongside the existing
+  # `runtime-guardrails` job on `ubuntu-latest`. Marked `continue-on-error: true`
+  # so a probe failure does NOT block PR merges while we observe. Uploads
+  # `artifacts/validation/*.txt` so we can inspect what pass/skip states the
+  # probe produced (semgrep docker vs. local fallback, gh-CLI availability for
+  # effort-leak-audit, etc.). Delete this job in the follow-up flip PR once the
+  # probe is proven green on 2+ consecutive PRs.
+  runtime-guardrails-linux-probe:
+    needs:
+      - detect-ci-changes
+    if: needs.detect-ci-changes.outputs.swift_changed == 'true' || needs.detect-ci-changes.outputs.docs_changed == 'true'
+    runs-on: [self-hosted, Linux, ARM64]
+    continue-on-error: true
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Resolve base ref
+        id: base
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "ref=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.event.before }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run runtime guardrails validator (probe)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ steps.base.outputs.ref }}"
+          ./scripts/validate.sh "${{ steps.base.outputs.ref }}"
+
+      - name: Upload validation status artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-guardrails-linux-probe-artifacts
+          path: artifacts/validation/
+          if-no-files-found: warn
+          retention-days: 7
+
   docs-site-validation:
     needs:
       - detect-ci-changes


### PR DESCRIPTION
## Summary

First slice of the org-runner migration (#868). Adds a **non-blocking probe** job `runtime-guardrails-linux-probe` to `.github/workflows/ci.yml` that dual-runs `./scripts/validate.sh` on the org's self-hosted `[self-hosted, Linux, ARM64]` runner (`docker-linux-arm64-orc-studio-macbookprom5`) alongside the existing `runtime-guardrails` job on `ubuntu-latest`.

Follow-up (the actual flip) is tracked as #872.

## Design

- Runs unconditionally to match the source `runtime-guardrails` job's coverage (post-review actioned; earlier version had a swift/docs gate that would have missed scripts-only or root-config PRs).
- `continue-on-error: true` at job level → probe failure will NOT block PR merges while we observe.
- Uploads `artifacts/validation/*.txt` so we can inspect pass/skip states across PRs (which semgrep path fired — Docker vs local — whether `gh` CLI was available for `effort-leak-audit.sh`, etc.).
- Label combo `[self-hosted, Linux, ARM64]` matches only `docker-linux-arm64-orc-studio-macbookprom5` in this org today (the Mac runners advertise `macOS` not `Linux`), so routing is unambiguous.
- No other jobs modified. Zero blast radius on the existing merge gate.

## Post-build reviews

- **Codex (gpt-5.5)**: VERDICT initially BLOCK on probe-gating being too narrow → actioned in commit ee203aa (dropped `needs`+`if` gate).
- **Claude (opus-4.7 subagent)**: VERDICT SHIP with 2 findings; the probe-coverage one was already actioned, second was a cosmetic nit.

## Test plan

- [x] Local: YAML parses.
- [ ] Post-merge (blocking the follow-up #872): verify probe job appears in this repo's next 1-2 PR runs, records conclusion, and produces artifact bundles for inspection.
- [ ] Post-merge: confirm the runner label `[self-hosted, Linux, ARM64]` actually schedules on `docker-linux-arm64-orc-studio-macbookprom5` (visible in job log's runner-name line).

Closes #868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)