### PR TITLE
refactor: extract JiraExportProvider+Networking (#638 slice A) (#874)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		A966688E214B8AC20FC12C22 /* SessionDataProtector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */; };
 		AA75C664726B10D24FA0393A /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8E0EE1D051EF433249045D /* TestUtilities.swift */; };
 		AB85DB15F347C75DB7C1241A /* TranscriptQualityInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04945A10C723C05805325C81 /* TranscriptQualityInspector.swift */; };
+		AB91BF15F45FBF5F28E45E7B /* JiraExportProvider+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77909EE4BE0BACFEC08EF096 /* JiraExportProvider+Networking.swift */; };
 		ABA48997F0B07377178EDEE0 /* SystemAudioTapSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2370B53FBFD009E2E27655B /* SystemAudioTapSession.swift */; };
 		AD2549206170CE4F862AD61B /* ApplicationTerminationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */; };
 		AD5CE09A6639155D68E44618 /* AppState+SupportNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7CA92ED5A94500B96290D0 /* AppState+SupportNavigation.swift */; };
@@ -500,6 +501,7 @@
 		76411B4F7BC170843D60D2A4 /* SessionDataProtector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataProtector.swift; sourceTree = "<group>"; };
 		776E95F5977423452961A52B /* AppState+IssueExportQueries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+IssueExportQueries.swift"; sourceTree = "<group>"; };
 		778F1E0C90308A1D868A187E /* AppErrorSubPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppErrorSubPresenters.swift; sourceTree = "<group>"; };
+		77909EE4BE0BACFEC08EF096 /* JiraExportProvider+Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JiraExportProvider+Networking.swift"; sourceTree = "<group>"; };
 		77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+IssueExtraction.swift"; sourceTree = "<group>"; };
 		7881C3E0425DCA7D35C6C10E /* AppState+ExportReview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+ExportReview.swift"; sourceTree = "<group>"; };
 		78DB2CC94CABCD51955891BF /* AppStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatus.swift; sourceTree = "<group>"; };
@@ -937,6 +939,7 @@
 				EE77402A6284B705F5F4984A /* IssueExtractionResponseParser.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
+				77909EE4BE0BACFEC08EF096 /* JiraExportProvider+Networking.swift */,
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
 				417CFE8D9349DE5596FD0017 /* LaunchAtLoginService.swift */,
@@ -1417,6 +1420,7 @@
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,
 				B1E0999F91F9E0236146F023 /* IssueScreenshotAnnotationTypes.swift in Sources */,
 				045DEFACC4FF761873046058 /* JiraExportConfig.swift in Sources */,
+				AB91BF15F45FBF5F28E45E7B /* JiraExportProvider+Networking.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */,
 				280973289AE78D9919ECD80C /* KeychainService.swift in Sources */,

--- a/Sources/BugNarrator/Services/JiraExportProvider+Networking.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider+Networking.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+extension JiraExportProvider {
+    func decodeJiraPayload<T: Decodable>(
+        _ type: T.Type,
+        from data: Data,
+        description: String
+    ) throws -> T {
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw AppError.exportFailure(
+                "Jira returned \(description) in an unexpected format. \(Self.decodingFailureMessage(error))"
+            )
+        }
+    }
+
+    private static func decodingFailureMessage(_ error: Error) -> String {
+        guard case DecodingError.keyNotFound(let key, _) = error else {
+            return error.localizedDescription
+        }
+
+        return "Missing field '\(key.stringValue)'."
+    }
+
+    private func basicAuthValue(email: String, apiToken: String) -> String {
+        let rawValue = "\(email):\(apiToken)"
+        return Data(rawValue.utf8).base64EncodedString()
+    }
+
+    /// Builds a Jira request URL from the configured base URL, appending the
+    /// given path and optional query items. Throws a typed export error instead
+    /// of trapping when the base URL cannot be expressed as URL components.
+    func jiraRequestURL(
+        baseURL: URL,
+        path: String,
+        queryItems: [URLQueryItem] = []
+    ) throws -> URL {
+        guard var components = URLComponents(
+            url: baseURL.appending(path: path),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw AppError.exportFailure(
+                "Could not build a Jira request URL from the configured base URL."
+            )
+        }
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw AppError.exportFailure(
+                "Could not build a Jira request URL from the configured base URL."
+            )
+        }
+
+        return url
+    }
+
+    /// Produces a Jira REST request with the shared Basic auth, Accept, and
+    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
+    /// that carry a JSON body.
+    func authenticatedRequest(
+        url: URL,
+        httpMethod: String,
+        email: String,
+        apiToken: String,
+        includesJSONContentType: Bool
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        request.setValue(
+            "Basic \(basicAuthValue(email: email, apiToken: apiToken))",
+            forHTTPHeaderField: "Authorization"
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if includesJSONContentType {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    func mapJiraError(
+        statusCode: Int,
+        data: Data,
+        configuration: JiraExportConfiguration,
+        retryAfterSeconds: Int? = nil
+    ) -> AppError {
+        let message = decodeJiraMessage(from: data) ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        let normalizedMessage = message.lowercased()
+
+        // 429 is a rate limit, not an auth failure; map it explicitly.
+        if statusCode == 429 || normalizedMessage.contains("rate limit") {
+            return .exportFailure("Jira rate limited the request.\(TrackerExportSupport.retryAfterSuffix(retryAfterSeconds))")
+        }
+
+        if statusCode == 401 || statusCode == 403 {
+            return .exportFailure("Jira rejected the credentials for project \(configuration.projectKey).")
+        }
+
+        if statusCode == 404 {
+            return .exportFailure("Jira could not find the configured site or project \(configuration.projectKey).")
+        }
+
+        if statusCode == 400 {
+            return .exportFailure("Jira rejected the issue payload: \(message)")
+        }
+
+        return .exportFailure("Jira returned \(statusCode): \(message)")
+    }
+
+    private func decodeJiraMessage(from data: Data) -> String? {
+        if let payload = try? JSONDecoder().decode(JiraErrorResponse.self, from: data) {
+            let messages = payload.errorMessages + payload.errors.values
+            return messages.joined(separator: " ")
+        }
+
+        return nil
+    }
+}
+
+struct JiraErrorResponse: Decodable {
+    let errorMessages: [String]
+    let errors: [String: String]
+}

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -446,27 +446,7 @@ actor JiraExportProvider {
         return payload.fields.filter(\.required)
     }
 
-    private func decodeJiraPayload<T: Decodable>(
-        _ type: T.Type,
-        from data: Data,
-        description: String
-    ) throws -> T {
-        do {
-            return try JSONDecoder().decode(type, from: data)
-        } catch {
-            throw AppError.exportFailure(
-                "Jira returned \(description) in an unexpected format. \(Self.decodingFailureMessage(error))"
-            )
-        }
-    }
 
-    private static func decodingFailureMessage(_ error: Error) -> String {
-        guard case DecodingError.keyNotFound(let key, _) = error else {
-            return error.localizedDescription
-        }
-
-        return "Missing field '\(key.stringValue)'."
-    }
 
     private func makeSearchRequest(
         issue: ExtractedIssue,
@@ -512,64 +492,8 @@ actor JiraExportProvider {
         return request
     }
 
-    private func basicAuthValue(email: String, apiToken: String) -> String {
-        let rawValue = "\(email):\(apiToken)"
-        return Data(rawValue.utf8).base64EncodedString()
-    }
 
-    /// Builds a Jira request URL from the configured base URL, appending the
-    /// given path and optional query items. Throws a typed export error instead
-    /// of trapping when the base URL cannot be expressed as URL components.
-    private func jiraRequestURL(
-        baseURL: URL,
-        path: String,
-        queryItems: [URLQueryItem] = []
-    ) throws -> URL {
-        guard var components = URLComponents(
-            url: baseURL.appending(path: path),
-            resolvingAgainstBaseURL: false
-        ) else {
-            throw AppError.exportFailure(
-                "Could not build a Jira request URL from the configured base URL."
-            )
-        }
 
-        if !queryItems.isEmpty {
-            components.queryItems = queryItems
-        }
-
-        guard let url = components.url else {
-            throw AppError.exportFailure(
-                "Could not build a Jira request URL from the configured base URL."
-            )
-        }
-
-        return url
-    }
-
-    /// Produces a Jira REST request with the shared Basic auth, Accept, and
-    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
-    /// that carry a JSON body.
-    private func authenticatedRequest(
-        url: URL,
-        httpMethod: String,
-        email: String,
-        apiToken: String,
-        includesJSONContentType: Bool
-    ) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = httpMethod
-        request.setValue(
-            "Basic \(basicAuthValue(email: email, apiToken: apiToken))",
-            forHTTPHeaderField: "Authorization"
-        )
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        if includesJSONContentType {
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        }
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
-    }
 
     /// Creates one issue with bounded retry. Transient failures (network / 5xx /
     /// 429) are retried with backoff, but only after a marker reconciliation
@@ -921,43 +845,7 @@ actor JiraExportProvider {
         }
     }
 
-    private func mapJiraError(
-        statusCode: Int,
-        data: Data,
-        configuration: JiraExportConfiguration,
-        retryAfterSeconds: Int? = nil
-    ) -> AppError {
-        let message = decodeJiraMessage(from: data) ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        let normalizedMessage = message.lowercased()
 
-        // 429 is a rate limit, not an auth failure; map it explicitly.
-        if statusCode == 429 || normalizedMessage.contains("rate limit") {
-            return .exportFailure("Jira rate limited the request.\(TrackerExportSupport.retryAfterSuffix(retryAfterSeconds))")
-        }
-
-        if statusCode == 401 || statusCode == 403 {
-            return .exportFailure("Jira rejected the credentials for project \(configuration.projectKey).")
-        }
-
-        if statusCode == 404 {
-            return .exportFailure("Jira could not find the configured site or project \(configuration.projectKey).")
-        }
-
-        if statusCode == 400 {
-            return .exportFailure("Jira rejected the issue payload: \(message)")
-        }
-
-        return .exportFailure("Jira returned \(statusCode): \(message)")
-    }
-
-    private func decodeJiraMessage(from data: Data) -> String? {
-        if let payload = try? JSONDecoder().decode(JiraErrorResponse.self, from: data) {
-            let messages = payload.errorMessages + payload.errors.values
-            return messages.joined(separator: " ")
-        }
-
-        return nil
-    }
 
     private func searchJQL(for issue: ExtractedIssue, projectKey: String) -> String {
         let phrase = TrackerExportSupport.searchTerms(for: issue)
@@ -1132,10 +1020,6 @@ private struct JiraADFNode: Decodable {
     }
 }
 
-private struct JiraErrorResponse: Decodable {
-    let errorMessages: [String]
-    let errors: [String: String]
-}
 
 private struct JiraCreateMetadataProjectsResponse: Decodable {
     let projects: [JiraProjectSummary]


### PR DESCRIPTION
## Summary

First foundational slice of #638. Moves 7 auth/HTTP/JSON/error helpers from `JiraExportProvider.swift` into `Sources/BugNarrator/Services/JiraExportProvider+Networking.swift`, unlocking subsequent slices B-E to reference them from separate extension files.

## Visibility change

- **Widen `private` → `internal` (4 helpers)**: `decodeJiraPayload<T>`, `jiraRequestURL`, `authenticatedRequest`, `mapJiraError`. Required for cross-file access from the base file's remaining callers.
- **Stay `private` (3 helpers)**: `decodingFailureMessage`, `basicAuthValue`, `decodeJiraMessage`. Their sole callers move into the same new extension file, so file-scoped `private` still works.
- **`JiraErrorResponse` widens**: file-scope `private struct` → module-internal `struct`.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| JiraExportProvider.swift | 1255 | 1139 | -116 |
| JiraExportProvider+Networking.swift (new) | — | 127 | +127 |

## Pre-build review

Codex spec-review: **BLOCKERS: none**. 1 clarification finding: 2/4 widened helpers (`jiraRequestURL`, `decodeJiraPayload`) are single-cluster today (Discovery only), not fan-out as the ticket claimed. Not blocking — widening is still required because Discovery callers stay in the base file. Implementation unchanged.

## Test plan

- [x] `xcodebuild build -destination platform=macOS` succeeds.
- [x] `JiraExportProviderTests` continues to pass.

Closes #874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)