### PR TITLE
refactor: extract GitHubExportProvider+Networking (#639 slice B) (#878)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		8E7D49E7CCF528ACD4607327 /* DebugSessionContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE3DDA88B639E750CD0700F /* DebugSessionContextProviderTests.swift */; };
 		8F3D88D73F1560365347F711 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B1D06622F36D479935B7D /* ProductInfoTests.swift */; };
 		8F4B3823ACB48DDF270E2BAE /* AppStateIssueExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8498A39301CC9F88F45A4D5A /* AppStateIssueExportTests.swift */; };
+		9270FCD8927ABF43CE704BD1 /* GitHubExportProvider+Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */; };
 		93057BE64347AD1BF43F4FF0 /* ExportHistoryController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70F3DD1ED69F4EF96A4BD44A /* ExportHistoryController.swift */; };
 		93561F8BD8484E68D3E96012 /* RecordingSessionPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC99B0BEF616AC7161FBBC89 /* RecordingSessionPresenters.swift */; };
 		9453CE97ECC7AFBB6F35F74A /* TranscriptSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6A14B5D110D6E584678A83 /* TranscriptSession.swift */; };
@@ -513,6 +514,7 @@
 		7CE7687249AD70EDFF06A569 /* SystemAudioAggregateDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioAggregateDevice.swift; sourceTree = "<group>"; };
 		7D40CD81DEFA2ECA16E84902 /* SupportDataTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDataTypes.swift; sourceTree = "<group>"; };
 		7E6BBD3839BF28AC52214FEB /* AppState+AIProviderCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+AIProviderCredential.swift"; sourceTree = "<group>"; };
+		7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubExportProvider+Networking.swift"; sourceTree = "<group>"; };
 		7EF107719ECC19DBE07A1046 /* AppSupportLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSupportLocationTests.swift; sourceTree = "<group>"; };
 		7EF4558D78ECC185ECA6ED10 /* TranscriptExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporterTests.swift; sourceTree = "<group>"; };
 		7EFD71FC016C2F699D022EDB /* RecordingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingPreferencesStore.swift; sourceTree = "<group>"; };
@@ -926,6 +928,7 @@
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
+				7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */,
 				4B5B6268846602D2E2CC2102 /* GitHubExportProvider+WireTypes.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
 				6346CF407E47D31933561CA1 /* HotkeySupportClasses.swift */,
@@ -1396,6 +1399,7 @@
 				5839C40FC99D94A9C910A218 /* ExportReviewSheet.swift in Sources */,
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
 				BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */,
+				9270FCD8927ABF43CE704BD1 /* GitHubExportProvider+Networking.swift in Sources */,
 				A386A52717B012400A5E4F09 /* GitHubExportProvider+WireTypes.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,
 				6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */,

--- a/Sources/BugNarrator/Services/GitHubExportProvider+Networking.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider+Networking.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+extension GitHubExportProvider {
+    func mapGitHubError(
+        statusCode: Int,
+        data: Data,
+        configuration: GitHubExportConfiguration,
+        retryAfterSeconds: Int? = nil
+    ) -> AppError {
+        let message = decodeGitHubMessage(from: data) ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        let normalizedMessage = message.lowercased()
+
+        // A secondary rate limit returns 429 (not 401/403); map it explicitly so
+        // the user gets a "wait and retry" message rather than a token/auth error.
+        if statusCode == 429 || normalizedMessage.contains("rate limit") {
+            return .exportFailure("GitHub rate limited the request.\(TrackerExportSupport.retryAfterSuffix(retryAfterSeconds))")
+        }
+
+        if statusCode == 401 || statusCode == 403 {
+            return .exportFailure("GitHub rejected the token or repository access for \(configuration.owner)/\(configuration.repository).")
+        }
+
+        if statusCode == 404 {
+            return .exportFailure("GitHub could not find \(configuration.owner)/\(configuration.repository). Check the owner, repository name, and token permissions.")
+        }
+
+        if statusCode == 422 {
+            return .exportFailure("GitHub rejected the issue payload: \(message)")
+        }
+
+        return .exportFailure("GitHub returned \(statusCode): \(message)")
+    }
+
+    private func decodeGitHubMessage(from data: Data) -> String? {
+        (try? JSONDecoder().decode(GitHubErrorResponse.self, from: data))?.message
+    }
+
+    func url(from components: URLComponents) throws -> URL {
+        guard let url = components.url else {
+            throw AppError.exportFailure("GitHub search query could not be constructed.")
+        }
+
+        return url
+    }
+
+    /// Produces a GitHub REST request with the shared Bearer auth, Accept, and
+    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
+    /// that carry a JSON body.
+    func authenticatedRequest(
+        url: URL,
+        httpMethod: String,
+        token: String,
+        includesJSONContentType: Bool
+    ) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = httpMethod
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        if includesJSONContentType {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    func repositoryEndpoint(configuration: GitHubExportConfiguration) -> URL {
+        let owner = configuration.owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+            ?? configuration.owner
+        let repository = configuration.repository.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+            ?? configuration.repository
+        return URL(string: "https://api.github.com/repos/\(owner)/\(repository)")!
+    }
+
+    func issueEndpoint(configuration: GitHubExportConfiguration) -> URL {
+        repositoryEndpoint(configuration: configuration).appendingPathComponent("issues")
+    }
+}

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -658,77 +658,8 @@ actor GitHubExportProvider {
         }
     }
 
-    private func mapGitHubError(
-        statusCode: Int,
-        data: Data,
-        configuration: GitHubExportConfiguration,
-        retryAfterSeconds: Int? = nil
-    ) -> AppError {
-        let message = decodeGitHubMessage(from: data) ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        let normalizedMessage = message.lowercased()
 
-        // A secondary rate limit returns 429 (not 401/403); map it explicitly so
-        // the user gets a "wait and retry" message rather than a token/auth error.
-        if statusCode == 429 || normalizedMessage.contains("rate limit") {
-            return .exportFailure("GitHub rate limited the request.\(TrackerExportSupport.retryAfterSuffix(retryAfterSeconds))")
-        }
 
-        if statusCode == 401 || statusCode == 403 {
-            return .exportFailure("GitHub rejected the token or repository access for \(configuration.owner)/\(configuration.repository).")
-        }
 
-        if statusCode == 404 {
-            return .exportFailure("GitHub could not find \(configuration.owner)/\(configuration.repository). Check the owner, repository name, and token permissions.")
-        }
 
-        if statusCode == 422 {
-            return .exportFailure("GitHub rejected the issue payload: \(message)")
-        }
-
-        return .exportFailure("GitHub returned \(statusCode): \(message)")
-    }
-
-    private func decodeGitHubMessage(from data: Data) -> String? {
-        (try? JSONDecoder().decode(GitHubErrorResponse.self, from: data))?.message
-    }
-
-    private func url(from components: URLComponents) throws -> URL {
-        guard let url = components.url else {
-            throw AppError.exportFailure("GitHub search query could not be constructed.")
-        }
-
-        return url
-    }
-
-    /// Produces a GitHub REST request with the shared Bearer auth, Accept, and
-    /// User-Agent headers applied. Pass `includesJSONContentType` for requests
-    /// that carry a JSON body.
-    private func authenticatedRequest(
-        url: URL,
-        httpMethod: String,
-        token: String,
-        includesJSONContentType: Bool
-    ) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = httpMethod
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        if includesJSONContentType {
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        }
-        request.setValue("BugNarrator", forHTTPHeaderField: "User-Agent")
-        return request
-    }
-
-    private func repositoryEndpoint(configuration: GitHubExportConfiguration) -> URL {
-        let owner = configuration.owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
-            ?? configuration.owner
-        let repository = configuration.repository.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
-            ?? configuration.repository
-        return URL(string: "https://api.github.com/repos/\(owner)/\(repository)")!
-    }
-
-    private func issueEndpoint(configuration: GitHubExportConfiguration) -> URL {
-        repositoryEndpoint(configuration: configuration).appendingPathComponent("issues")
-    }
 }


### PR DESCRIPTION
## Summary

Second slice of #639 (after #873 WireTypes). Sibling of #874 (JiraExportProvider+Networking, PR #877) — same shape.

## Visibility change

- **Widen `private` → `internal` (5 helpers)**: `mapGitHubError`, `url(from:)`, `authenticatedRequest`, `repositoryEndpoint`, `issueEndpoint`. Required for cross-file access from base file's remaining callers.
- **Stays `private` (1 helper)**: `decodeGitHubMessage`. Sole caller (`mapGitHubError`) moves into the same new extension file.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| GitHubExportProvider.swift | 734 | 665 | -69 |
| GitHubExportProvider+Networking.swift (new) | — | 77 | +77 |

## Pre-build review

Codex spec-review: **BLOCKERS: none**. 5 OK claims verified — line ranges exact; all 5 widened helpers have cross-cluster callers; decodeGitHubMessage single-caller confirmed; no external references; no missing dependencies.

## Test plan

- [x] `xcodebuild build -destination platform=macOS` succeeds.
- [x] `GitHubExportProviderTests` continues to pass.

Closes #878.

🤖 Generated with [Claude Code](https://claude.com/claude-code)