### PR TITLE
refactor: extract GitHubExportProvider+Duplicates (#639 slice C) (#880)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0D3E82C811F386795DBE5D82 /* ExportReceiptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */; };
 		0E06D8F0874CB1CBB2FEA135 /* AppState+ExportReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7881C3E0425DCA7D35C6C10E /* AppState+ExportReview.swift */; };
 		107C848CCE79FCFD13E3751F /* HotkeySupportClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346CF407E47D31933561CA1 /* HotkeySupportClasses.swift */; };
+		1134B796398DF1FFBC51E738 /* GitHubExportProvider+Duplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAF2A9878CBA298777A5677 /* GitHubExportProvider+Duplicates.swift */; };
 		11935BB2070F2A08AB015BD9 /* DiagnosticsLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */; };
 		11D0925211E3A8D0AC8FF219 /* AppLifecycleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FA8C32EF0CB342E6EF41E9 /* AppLifecycleDelegate.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
@@ -574,6 +575,7 @@
 		AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionRecoveryTypes.swift; sourceTree = "<group>"; };
 		AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionScreenshotTests.swift; sourceTree = "<group>"; };
 		AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProviderTests.swift; sourceTree = "<group>"; };
+		AFAF2A9878CBA298777A5677 /* GitHubExportProvider+Duplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubExportProvider+Duplicates.swift"; sourceTree = "<group>"; };
 		B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionDraftTests.swift; sourceTree = "<group>"; };
 		B065A5B9BE084EFE0BFE1D48 /* SettingsReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsReadiness.swift; sourceTree = "<group>"; };
 		B09CA463A8DF59221937A2C7 /* TranscriptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptView.swift; sourceTree = "<group>"; };
@@ -928,6 +930,7 @@
 				DC8C8AA3B4EEED739F198572 /* ExportReceiptStore.swift */,
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
+				AFAF2A9878CBA298777A5677 /* GitHubExportProvider+Duplicates.swift */,
 				7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */,
 				4B5B6268846602D2E2CC2102 /* GitHubExportProvider+WireTypes.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
@@ -1399,6 +1402,7 @@
 				5839C40FC99D94A9C910A218 /* ExportReviewSheet.swift in Sources */,
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
 				BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */,
+				1134B796398DF1FFBC51E738 /* GitHubExportProvider+Duplicates.swift in Sources */,
 				9270FCD8927ABF43CE704BD1 /* GitHubExportProvider+Networking.swift in Sources */,
 				A386A52717B012400A5E4F09 /* GitHubExportProvider+WireTypes.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,

--- a/Sources/BugNarrator/Services/GitHubExportProvider+Duplicates.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider+Duplicates.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+extension GitHubExportProvider {
+    func findOpenIssues(
+        matching issue: ExtractedIssue,
+        configuration: GitHubExportConfiguration
+    ) async throws -> [TrackerIssueCandidate] {
+        guard configuration.isComplete else {
+            throw AppError.exportConfigurationMissing(
+                "GitHub export requires a personal access token, repository owner, and repository name."
+            )
+        }
+
+        let request = try makeSearchRequest(issue: issue, configuration: configuration)
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError.exportFailure("GitHub returned an invalid response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw mapGitHubError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
+        }
+
+        let payload = try JSONDecoder().decode(GitHubSearchResponse.self, from: data)
+        return payload.items.map { item in
+            TrackerIssueCandidate(
+                remoteIdentifier: "#\(item.number)",
+                title: item.title,
+                summary: item.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+                remoteURL: item.htmlURL
+            )
+        }
+    }
+
+    private func makeSearchRequest(
+        issue: ExtractedIssue,
+        configuration: GitHubExportConfiguration
+    ) throws -> URLRequest {
+        var components = URLComponents(string: "https://api.github.com/search/issues")!
+        let searchTerms = TrackerExportSupport.searchTerms(for: issue)
+        let query = "repo:\(configuration.owner)/\(configuration.repository) is:issue is:open \(searchTerms)"
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "per_page", value: "5")
+        ]
+
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: configuration.token,
+            includesJSONContentType: false
+        )
+    }
+
+    private func makeExportFingerprintSearchRequest(
+        fingerprint: String,
+        configuration: GitHubExportConfiguration
+    ) throws -> URLRequest {
+        var components = URLComponents(string: "https://api.github.com/search/issues")!
+        let query = #"repo:\#(configuration.owner)/\#(configuration.repository) is:issue "\#(TrackerExportFingerprint.marker(for: fingerprint))""#
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "per_page", value: "1")
+        ]
+
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: configuration.token,
+            includesJSONContentType: false
+        )
+    }
+
+    func existingExportResult(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        configuration: GitHubExportConfiguration
+    ) async throws -> ExportResult? {
+        if let receipt = try await receiptStore.receipt(for: fingerprint),
+           let exportResult = receipt.asExportResult() {
+            return exportResult
+        }
+
+        guard try await receiptStore.receipt(for: fingerprint)?.state == .pending else {
+            return nil
+        }
+
+        return try await reconcilePendingExport(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            configuration: configuration
+        )
+    }
+
+    func reconcilePendingExport(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        configuration: GitHubExportConfiguration
+    ) async throws -> ExportResult? {
+        guard let candidate = try await findExportedIssue(
+            fingerprint: fingerprint,
+            configuration: configuration
+        ) else {
+            return nil
+        }
+
+        try await receiptStore.markSucceeded(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            destination: .github,
+            targetIdentity: configuration.targetIdentity,
+            remoteIdentifier: candidate.remoteIdentifier,
+            remoteURL: candidate.remoteURL
+        )
+
+        return ExportResult(
+            sourceIssueID: sourceIssueID,
+            destination: .github,
+            remoteIdentifier: candidate.remoteIdentifier,
+            remoteURL: candidate.remoteURL
+        )
+    }
+
+    private func findExportedIssue(
+        fingerprint: String,
+        configuration: GitHubExportConfiguration
+    ) async throws -> TrackerIssueCandidate? {
+        let request = try makeExportFingerprintSearchRequest(
+            fingerprint: fingerprint,
+            configuration: configuration
+        )
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError.exportFailure("GitHub returned an invalid response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw mapGitHubError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
+        }
+
+        let payload = try JSONDecoder().decode(GitHubSearchResponse.self, from: data)
+        guard let item = payload.items.first else {
+            return nil
+        }
+
+        return TrackerIssueCandidate(
+            remoteIdentifier: "#\(item.number)",
+            title: item.title,
+            summary: item.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
+            remoteURL: item.htmlURL
+        )
+    }
+}

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 actor GitHubExportProvider {
-    private let session: URLSession
-    private let receiptStore: any ExportReceiptStoring
+    let session: URLSession
+    let receiptStore: any ExportReceiptStoring
     private let retryConfiguration: ExportRetryConfiguration
     private let logger = DiagnosticsLogger(category: .export)
     private let annotationRenderer = IssueScreenshotAnnotationRenderer()
@@ -196,37 +196,6 @@ actor GitHubExportProvider {
         }
     }
 
-    func findOpenIssues(
-        matching issue: ExtractedIssue,
-        configuration: GitHubExportConfiguration
-    ) async throws -> [TrackerIssueCandidate] {
-        guard configuration.isComplete else {
-            throw AppError.exportConfigurationMissing(
-                "GitHub export requires a personal access token, repository owner, and repository name."
-            )
-        }
-
-        let request = try makeSearchRequest(issue: issue, configuration: configuration)
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AppError.exportFailure("GitHub returned an invalid response.")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            throw mapGitHubError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
-        }
-
-        let payload = try JSONDecoder().decode(GitHubSearchResponse.self, from: data)
-        return payload.items.map { item in
-            TrackerIssueCandidate(
-                remoteIdentifier: "#\(item.number)",
-                title: item.title,
-                summary: item.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
-                remoteURL: item.htmlURL
-            )
-        }
-    }
 
     func makeURLRequest(
         issue: ExtractedIssue,
@@ -287,44 +256,7 @@ actor GitHubExportProvider {
         )
     }
 
-    private func makeSearchRequest(
-        issue: ExtractedIssue,
-        configuration: GitHubExportConfiguration
-    ) throws -> URLRequest {
-        var components = URLComponents(string: "https://api.github.com/search/issues")!
-        let searchTerms = TrackerExportSupport.searchTerms(for: issue)
-        let query = "repo:\(configuration.owner)/\(configuration.repository) is:issue is:open \(searchTerms)"
-        components.queryItems = [
-            URLQueryItem(name: "q", value: query),
-            URLQueryItem(name: "per_page", value: "5")
-        ]
 
-        return authenticatedRequest(
-            url: try url(from: components),
-            httpMethod: "GET",
-            token: configuration.token,
-            includesJSONContentType: false
-        )
-    }
-
-    private func makeExportFingerprintSearchRequest(
-        fingerprint: String,
-        configuration: GitHubExportConfiguration
-    ) throws -> URLRequest {
-        var components = URLComponents(string: "https://api.github.com/search/issues")!
-        let query = #"repo:\#(configuration.owner)/\#(configuration.repository) is:issue "\#(TrackerExportFingerprint.marker(for: fingerprint))""#
-        components.queryItems = [
-            URLQueryItem(name: "q", value: query),
-            URLQueryItem(name: "per_page", value: "1")
-        ]
-
-        return authenticatedRequest(
-            url: try url(from: components),
-            httpMethod: "GET",
-            token: configuration.token,
-            includesJSONContentType: false
-        )
-    }
 
     /// Neutralizes untrusted (LLM-derived) text so it renders as literal content
     /// in a GitHub Markdown issue body: it cannot trigger `@mentions` or `#issue`
@@ -552,86 +484,8 @@ actor GitHubExportProvider {
         }
     }
 
-    private func existingExportResult(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        configuration: GitHubExportConfiguration
-    ) async throws -> ExportResult? {
-        if let receipt = try await receiptStore.receipt(for: fingerprint),
-           let exportResult = receipt.asExportResult() {
-            return exportResult
-        }
 
-        guard try await receiptStore.receipt(for: fingerprint)?.state == .pending else {
-            return nil
-        }
 
-        return try await reconcilePendingExport(
-            fingerprint: fingerprint,
-            sourceIssueID: sourceIssueID,
-            configuration: configuration
-        )
-    }
-
-    private func reconcilePendingExport(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        configuration: GitHubExportConfiguration
-    ) async throws -> ExportResult? {
-        guard let candidate = try await findExportedIssue(
-            fingerprint: fingerprint,
-            configuration: configuration
-        ) else {
-            return nil
-        }
-
-        try await receiptStore.markSucceeded(
-            fingerprint: fingerprint,
-            sourceIssueID: sourceIssueID,
-            destination: .github,
-            targetIdentity: configuration.targetIdentity,
-            remoteIdentifier: candidate.remoteIdentifier,
-            remoteURL: candidate.remoteURL
-        )
-
-        return ExportResult(
-            sourceIssueID: sourceIssueID,
-            destination: .github,
-            remoteIdentifier: candidate.remoteIdentifier,
-            remoteURL: candidate.remoteURL
-        )
-    }
-
-    private func findExportedIssue(
-        fingerprint: String,
-        configuration: GitHubExportConfiguration
-    ) async throws -> TrackerIssueCandidate? {
-        let request = try makeExportFingerprintSearchRequest(
-            fingerprint: fingerprint,
-            configuration: configuration
-        )
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AppError.exportFailure("GitHub returned an invalid response.")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            throw mapGitHubError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
-        }
-
-        let payload = try JSONDecoder().decode(GitHubSearchResponse.self, from: data)
-        guard let item = payload.items.first else {
-            return nil
-        }
-
-        return TrackerIssueCandidate(
-            remoteIdentifier: "#\(item.number)",
-            title: item.title,
-            summary: item.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "",
-            remoteURL: item.htmlURL
-        )
-    }
 
     private func reproductionStepReference(_ step: IssueReproductionStep, session: TranscriptSession) -> String? {
         var parts: [String] = []


### PR DESCRIPTION
## Summary

Third slice of #639 (after #873 WireTypes, #878 Networking). Moves the dup-detection + reconcile-pending cluster into `+Duplicates.swift`.

## Visibility change

- **Widen `private` → `internal`**: `existingExportResult`, `reconcilePendingExport` (helpers, called from base file).
- **Stay `private`**: `makeSearchRequest`, `makeExportFingerprintSearchRequest`, `findExportedIssue` (single-caller, moves with).
- **Public unchanged**: `findOpenIssues`.
- **Actor stored-property widening (discovered by build check)**: `session` and `receiptStore` widen from `private let` → `let`. `reconcilePendingExport` reads `receiptStore.markSucceeded`; `findExportedIssue` reads `session.data(for:)`. Minimal widening; `retryConfiguration`, `logger`, `annotationRenderer` stay private.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| GitHubExportProvider.swift | 665 | 519 | -146 |
| GitHubExportProvider+Duplicates.swift (new) | — | 155 | +155 |

## Pre-build review

Codex flagged the widenings on existingExportResult / reconcilePendingExport (already planned in AC) and the external refs to findOpenIssues (already public, no change). Missed the actor stored-property dependencies — caught by build.

## Test plan

- [x] `xcodebuild build` succeeds after stored-property widening.
- [x] `GitHubExportProviderTests` passes.

Closes #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)