### PR TITLE
refactor: extract GitHubExportProvider+IssueBody (#639 slice D) (#882)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		E4FADD1D63CEA498E41886BD /* LaunchContinuityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F537B313D8FFBF8B7A5F75C0 /* LaunchContinuityMonitor.swift */; };
 		E5C5391682011DD604C60825 /* AudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CB27F6773CD9753A00DB79 /* AudioRecorderTests.swift */; };
 		E60F34C1E0FED78A8F28FFDE /* PermissionRecoveryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE18D1E8901BEF5AE218942B /* PermissionRecoveryTypes.swift */; };
+		E74889E8810164E6EA9DCE75 /* GitHubExportProvider+IssueBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5258D51E9104DDABF9CFD179 /* GitHubExportProvider+IssueBody.swift */; };
 		E7512039897A180D1EC9DF3D /* RecordingSessionDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05AAC9DC376BDD9A17732C3 /* RecordingSessionDraftTests.swift */; };
 		E7F9190637C0AE98A0164B39 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */; };
 		E8037E3123427D9DE61D3BE7 /* MenuBarLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */; };
@@ -442,6 +443,7 @@
 		4FD6EC791976A8AD3A45D1E3 /* RoutingAudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAudioRecorderTests.swift; sourceTree = "<group>"; };
 		518C6045D8668A1179198A6D /* MultipartFormDataBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormDataBuilder.swift; sourceTree = "<group>"; };
 		51C800B9028E34058B3B1544 /* RecordingStatusMessageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingStatusMessageBuilderTests.swift; sourceTree = "<group>"; };
+		5258D51E9104DDABF9CFD179 /* GitHubExportProvider+IssueBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubExportProvider+IssueBody.swift"; sourceTree = "<group>"; };
 		527C2EB86F851CAA53F3E4D3 /* ExportReceiptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportReceiptStoreTests.swift; sourceTree = "<group>"; };
 		52EB292B3C69DEF8CC080283 /* SessionLibraryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryController.swift; sourceTree = "<group>"; };
 		52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyValidationStateTests.swift; sourceTree = "<group>"; };
@@ -931,6 +933,7 @@
 				7322F6B6A58542DEDFC76CCA /* ExportService.swift */,
 				2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */,
 				AFAF2A9878CBA298777A5677 /* GitHubExportProvider+Duplicates.swift */,
+				5258D51E9104DDABF9CFD179 /* GitHubExportProvider+IssueBody.swift */,
 				7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */,
 				4B5B6268846602D2E2CC2102 /* GitHubExportProvider+WireTypes.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
@@ -1403,6 +1406,7 @@
 				5E539B43126F28E1607B5FC8 /* ExportService.swift in Sources */,
 				BB84DD19E311E979D03B0147 /* GitHubExportConfig.swift in Sources */,
 				1134B796398DF1FFBC51E738 /* GitHubExportProvider+Duplicates.swift in Sources */,
+				E74889E8810164E6EA9DCE75 /* GitHubExportProvider+IssueBody.swift in Sources */,
 				9270FCD8927ABF43CE704BD1 /* GitHubExportProvider+Networking.swift in Sources */,
 				A386A52717B012400A5E4F09 /* GitHubExportProvider+WireTypes.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,

--- a/Sources/BugNarrator/Services/GitHubExportProvider+IssueBody.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider+IssueBody.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+extension GitHubExportProvider {
+    static func neutralizingUntrustedMarkdown(_ text: String) -> String {
+        let lines = text.components(separatedBy: "\n").map { line -> String in
+            var escaped = line
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+                // A zero-width space after @/# breaks GitHub's mention and issue
+                // autolinks (and defeats `# heading` injection) while leaving the
+                // text visually identical.
+                .replacingOccurrences(of: "@", with: "@\u{200B}")
+                .replacingOccurrences(of: "#", with: "#\u{200B}")
+            if let first = escaped.first, "-*+|=`~".contains(first) {
+                escaped = "\\" + escaped
+            }
+            return escaped
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    func makeIssueBody(
+        issue: ExtractedIssue,
+        session: TranscriptSession,
+        exportFingerprint: String?
+    ) throws -> String {
+        var lines: [String] = [
+            "## Summary",
+            Self.neutralizingUntrustedMarkdown(
+                TrackerExportPayloadBudget.truncated(
+                    issue.summary,
+                    maxCharacters: TrackerExportPayloadBudget.issueSummaryLimit
+                )
+            ),
+            "",
+            "## Evidence",
+            Self.neutralizingUntrustedMarkdown(
+                TrackerExportPayloadBudget.truncated(
+                    issue.evidenceExcerpt,
+                    maxCharacters: TrackerExportPayloadBudget.evidenceLimit
+                )
+            ),
+            ""
+        ]
+
+        if let timestampLabel = issue.timestampLabel {
+            lines.append("- Transcript time: `\(timestampLabel)`")
+        }
+
+        lines.append("- Severity: \(issue.severity.rawValue)")
+
+        if let component = issue.component?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !component.isEmpty {
+            lines.append("- Component: \(Self.neutralizingUntrustedMarkdown(component))")
+        }
+
+        lines.append("- Deduplication hint: `\(issue.deduplicationHint)`")
+
+        if let sectionTitle = issue.sectionTitle, !sectionTitle.isEmpty {
+            lines.append("- Transcript section: \(Self.neutralizingUntrustedMarkdown(sectionTitle))")
+        }
+
+        if let confidenceLabel = issue.confidenceLabel {
+            lines.append("- Confidence: \(confidenceLabel)")
+        }
+
+        if issue.requiresReview {
+            lines.append("- Review needed: Yes")
+        }
+
+        if let note = issue.note?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !note.isEmpty {
+            lines.append("")
+            // `note` is set by our own dedup policy (trackerContextNote) and may
+            // deliberately contain a "Related to #123" cross-link, so it is not
+            // neutralized here.
+            lines.append("## Tracker Context")
+            lines.append(
+                TrackerExportPayloadBudget.truncated(
+                    note,
+                    maxCharacters: TrackerExportPayloadBudget.noteLimit
+                )
+            )
+        }
+
+        if !issue.reproductionSteps.isEmpty {
+            lines.append("")
+            lines.append("## Reproduction Steps")
+
+            for (index, step) in issue.reproductionSteps.prefix(TrackerExportPayloadBudget.reproductionStepLimit).enumerated() {
+                lines.append(
+                    "\(index + 1). \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(step.instruction, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))"
+                )
+
+                if let expectedResult = step.expectedResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !expectedResult.isEmpty {
+                    lines.append("   - Expected: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(expectedResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
+                }
+
+                if let actualResult = step.actualResult?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !actualResult.isEmpty {
+                    lines.append("   - Actual: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(actualResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
+                }
+
+                if let reference = reproductionStepReference(step, session: session) {
+                    lines.append("   - Reference: \(reference)")
+                }
+            }
+        }
+
+        let annotationLines = try annotatedScreenshotLines(issue: issue, session: session)
+        if !annotationLines.isEmpty {
+            lines.append("")
+            lines.append("## Annotated Screenshots")
+            lines.append(
+                contentsOf: TrackerExportPayloadBudget.limitedList(
+                    annotationLines,
+                    maxItems: TrackerExportPayloadBudget.screenshotListLimit,
+                    maxCharactersPerItem: TrackerExportPayloadBudget.listEntryLimit
+                )
+            )
+        }
+
+        let screenshots = session.screenshots(for: issue)
+        if !screenshots.isEmpty {
+            lines.append("")
+            lines.append("## Related Screenshots")
+            for screenshot in screenshots.prefix(TrackerExportPayloadBudget.screenshotListLimit) {
+                lines.append("- \(screenshot.fileName) (`\(screenshot.timeLabel)`) - attach manually from the exported session bundle if needed.")
+            }
+        }
+
+        lines.append("")
+        lines.append("## Source")
+        lines.append("Exported from BugNarrator. Review against the raw transcript before triage.")
+
+        let footer = exportFingerprint.map { "\n\n\(TrackerExportFingerprint.marker(for: $0))" } ?? ""
+        return TrackerExportPayloadBudget.hardLimitMarkdown(
+            lines.joined(separator: "\n"),
+            maxCharacters: TrackerExportPayloadBudget.gitHubBodyLimit - footer.count
+        ) + footer
+    }
+
+    private func reproductionStepReference(_ step: IssueReproductionStep, session: TranscriptSession) -> String? {
+        var parts: [String] = []
+
+        if let timestampLabel = step.timestampLabel {
+            parts.append("Transcript `\(timestampLabel)`")
+        }
+
+        if let screenshotID = step.screenshotID,
+           let screenshot = session.screenshot(with: screenshotID) {
+            parts.append("Screenshot `\(screenshot.fileName)` (`\(screenshot.timeLabel)`)")
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: "  •  ")
+    }
+
+    private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
+        try annotationRenderer.annotatedScreenshotExports(for: issue, session: session).map { export in
+            if let renderedFileName = export.renderedFileName {
+                return "- \(renderedFileName) from `\(export.screenshotFileName)` (`\(export.timeLabel)`) — \(export.summaries)"
+            }
+
+            return "- \(export.screenshotFileName) (`\(export.timeLabel)`) — \(export.summaries)"
+        }
+    }
+}

--- a/Sources/BugNarrator/Services/GitHubExportProvider+IssueBody.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider+IssueBody.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 extension GitHubExportProvider {
+    /// Neutralizes untrusted (LLM-derived) text so it renders as literal content
+    /// in a GitHub Markdown issue body: it cannot trigger `@mentions` or `#issue`
+    /// cross-links, inject raw HTML, or start new block-level structure
+    /// (headings, quotes, lists, tables, code fences).
     static func neutralizingUntrustedMarkdown(_ text: String) -> String {
         let lines = text.components(separatedBy: "\n").map { line -> String in
             var escaped = line

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -5,7 +5,7 @@ actor GitHubExportProvider {
     let receiptStore: any ExportReceiptStoring
     private let retryConfiguration: ExportRetryConfiguration
     private let logger = DiagnosticsLogger(category: .export)
-    private let annotationRenderer = IssueScreenshotAnnotationRenderer()
+    let annotationRenderer = IssueScreenshotAnnotationRenderer()
 
     init(
         session: URLSession? = nil,
@@ -262,145 +262,7 @@ actor GitHubExportProvider {
     /// in a GitHub Markdown issue body: it cannot trigger `@mentions` or `#issue`
     /// cross-links, inject raw HTML, or start new block-level structure
     /// (headings, quotes, lists, tables, code fences).
-    static func neutralizingUntrustedMarkdown(_ text: String) -> String {
-        let lines = text.components(separatedBy: "\n").map { line -> String in
-            var escaped = line
-                .replacingOccurrences(of: "<", with: "&lt;")
-                .replacingOccurrences(of: ">", with: "&gt;")
-                // A zero-width space after @/# breaks GitHub's mention and issue
-                // autolinks (and defeats `# heading` injection) while leaving the
-                // text visually identical.
-                .replacingOccurrences(of: "@", with: "@\u{200B}")
-                .replacingOccurrences(of: "#", with: "#\u{200B}")
-            if let first = escaped.first, "-*+|=`~".contains(first) {
-                escaped = "\\" + escaped
-            }
-            return escaped
-        }
-        return lines.joined(separator: "\n")
-    }
 
-    private func makeIssueBody(
-        issue: ExtractedIssue,
-        session: TranscriptSession,
-        exportFingerprint: String?
-    ) throws -> String {
-        var lines: [String] = [
-            "## Summary",
-            Self.neutralizingUntrustedMarkdown(
-                TrackerExportPayloadBudget.truncated(
-                    issue.summary,
-                    maxCharacters: TrackerExportPayloadBudget.issueSummaryLimit
-                )
-            ),
-            "",
-            "## Evidence",
-            Self.neutralizingUntrustedMarkdown(
-                TrackerExportPayloadBudget.truncated(
-                    issue.evidenceExcerpt,
-                    maxCharacters: TrackerExportPayloadBudget.evidenceLimit
-                )
-            ),
-            ""
-        ]
-
-        if let timestampLabel = issue.timestampLabel {
-            lines.append("- Transcript time: `\(timestampLabel)`")
-        }
-
-        lines.append("- Severity: \(issue.severity.rawValue)")
-
-        if let component = issue.component?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !component.isEmpty {
-            lines.append("- Component: \(Self.neutralizingUntrustedMarkdown(component))")
-        }
-
-        lines.append("- Deduplication hint: `\(issue.deduplicationHint)`")
-
-        if let sectionTitle = issue.sectionTitle, !sectionTitle.isEmpty {
-            lines.append("- Transcript section: \(Self.neutralizingUntrustedMarkdown(sectionTitle))")
-        }
-
-        if let confidenceLabel = issue.confidenceLabel {
-            lines.append("- Confidence: \(confidenceLabel)")
-        }
-
-        if issue.requiresReview {
-            lines.append("- Review needed: Yes")
-        }
-
-        if let note = issue.note?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !note.isEmpty {
-            lines.append("")
-            // `note` is set by our own dedup policy (trackerContextNote) and may
-            // deliberately contain a "Related to #123" cross-link, so it is not
-            // neutralized here.
-            lines.append("## Tracker Context")
-            lines.append(
-                TrackerExportPayloadBudget.truncated(
-                    note,
-                    maxCharacters: TrackerExportPayloadBudget.noteLimit
-                )
-            )
-        }
-
-        if !issue.reproductionSteps.isEmpty {
-            lines.append("")
-            lines.append("## Reproduction Steps")
-
-            for (index, step) in issue.reproductionSteps.prefix(TrackerExportPayloadBudget.reproductionStepLimit).enumerated() {
-                lines.append(
-                    "\(index + 1). \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(step.instruction, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))"
-                )
-
-                if let expectedResult = step.expectedResult?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !expectedResult.isEmpty {
-                    lines.append("   - Expected: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(expectedResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
-                }
-
-                if let actualResult = step.actualResult?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !actualResult.isEmpty {
-                    lines.append("   - Actual: \(Self.neutralizingUntrustedMarkdown(TrackerExportPayloadBudget.truncated(actualResult, maxCharacters: TrackerExportPayloadBudget.listEntryLimit)))")
-                }
-
-                if let reference = reproductionStepReference(step, session: session) {
-                    lines.append("   - Reference: \(reference)")
-                }
-            }
-        }
-
-        let annotationLines = try annotatedScreenshotLines(issue: issue, session: session)
-        if !annotationLines.isEmpty {
-            lines.append("")
-            lines.append("## Annotated Screenshots")
-            lines.append(
-                contentsOf: TrackerExportPayloadBudget.limitedList(
-                    annotationLines,
-                    maxItems: TrackerExportPayloadBudget.screenshotListLimit,
-                    maxCharactersPerItem: TrackerExportPayloadBudget.listEntryLimit
-                )
-            )
-        }
-
-        let screenshots = session.screenshots(for: issue)
-        if !screenshots.isEmpty {
-            lines.append("")
-            lines.append("## Related Screenshots")
-            for screenshot in screenshots.prefix(TrackerExportPayloadBudget.screenshotListLimit) {
-                lines.append("- \(screenshot.fileName) (`\(screenshot.timeLabel)`) - attach manually from the exported session bundle if needed.")
-            }
-        }
-
-        lines.append("")
-        lines.append("## Source")
-        lines.append("Exported from BugNarrator. Review against the raw transcript before triage.")
-
-        let footer = exportFingerprint.map { "\n\n\(TrackerExportFingerprint.marker(for: $0))" } ?? ""
-        return TrackerExportPayloadBudget.hardLimitMarkdown(
-            lines.joined(separator: "\n"),
-            maxCharacters: TrackerExportPayloadBudget.gitHubBodyLimit - footer.count
-        ) + footer
-    }
 
     /// Creates one issue with bounded retry. Transient failures (network / 5xx /
     /// 429) are retried with backoff, but ONLY after a marker reconciliation
@@ -487,30 +349,7 @@ actor GitHubExportProvider {
 
 
 
-    private func reproductionStepReference(_ step: IssueReproductionStep, session: TranscriptSession) -> String? {
-        var parts: [String] = []
 
-        if let timestampLabel = step.timestampLabel {
-            parts.append("Transcript `\(timestampLabel)`")
-        }
-
-        if let screenshotID = step.screenshotID,
-           let screenshot = session.screenshot(with: screenshotID) {
-            parts.append("Screenshot `\(screenshot.fileName)` (`\(screenshot.timeLabel)`)")
-        }
-
-        return parts.isEmpty ? nil : parts.joined(separator: "  •  ")
-    }
-
-    private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
-        try annotationRenderer.annotatedScreenshotExports(for: issue, session: session).map { export in
-            if let renderedFileName = export.renderedFileName {
-                return "- \(renderedFileName) from `\(export.screenshotFileName)` (`\(export.timeLabel)`) — \(export.summaries)"
-            }
-
-            return "- \(export.screenshotFileName) (`\(export.timeLabel)`) — \(export.summaries)"
-        }
-    }
 
 
 

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -258,10 +258,6 @@ actor GitHubExportProvider {
 
 
 
-    /// Neutralizes untrusted (LLM-derived) text so it renders as literal content
-    /// in a GitHub Markdown issue body: it cannot trigger `@mentions` or `#issue`
-    /// cross-links, inject raw HTML, or start new block-level structure
-    /// (headings, quotes, lists, tables, code fences).
 
 
     /// Creates one issue with bounded retry. Transient failures (network / 5xx /


### PR DESCRIPTION
## Summary

Fourth slice of #639 (after #873/#878/#880). Moves Markdown-body composition into `+IssueBody.swift`.

## Visibility change

- **Widen `private` → `internal`**: `makeIssueBody` (called from base file's `makeURLRequest`).
- **Stay `private`**: `reproductionStepReference`, `annotatedScreenshotLines` (single-caller, move with).
- **Unchanged**: `neutralizingUntrustedMarkdown` (already `internal static`).
- **Stored-property widening**: `annotationRenderer: private let → let` (extension file needs cross-file access).

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| GitHubExportProvider.swift | 519 | 358 | -161 |
| GitHubExportProvider+IssueBody.swift (new) | — | 168 | +168 |

## Pre-build review

Codex spec-review: **2 findings**, both already addressed in AC (`neutralizingUntrustedMarkdown` external test refs unaffected — visibility unchanged; `annotationRenderer` widening explicitly planned).

## Test plan

- [x] `xcodebuild build` succeeds.
- [x] `GitHubExportProviderTests` passes.

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)