### PR TITLE
refactor: extract GitHubExportProvider+RepositoryDiscovery (#639 slice E) (#884)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		58EC7D523A59A198A2138974 /* ExportHistoryControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69C850A45D2A71DC2FDCB9 /* ExportHistoryControllerTests.swift */; };
 		594983777A69A4D70F71653D /* GitHubExportProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFACC7533D24E7C572F411A1 /* GitHubExportProviderTests.swift */; };
 		5956B9999301BDED53F3B1EC /* TransientToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D753EF601F00C09C7FF276C /* TransientToast.swift */; };
+		596BBC26EE7C650862F4F22E /* GitHubExportProvider+RepositoryDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80315D4B806299BDB1449641 /* GitHubExportProvider+RepositoryDiscovery.swift */; };
 		5A0B0CC8B83B83D9C0180ECD /* LaunchContinuityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F86DC1FE575150583FFC4 /* LaunchContinuityMonitorTests.swift */; };
 		5A66763E99DF7E735CF49D26 /* MenuSessionLibraryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD665F70FE94CB539A21B1B4 /* MenuSessionLibraryCardView.swift */; };
 		5AC3F76F7DCE14EA3E8D8303 /* IssueExportController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49B2B79731E3A62B083174 /* IssueExportController.swift */; };
@@ -523,6 +524,7 @@
 		7EFD71FC016C2F699D022EDB /* RecordingPreferencesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingPreferencesStore.swift; sourceTree = "<group>"; };
 		7F271FCF4D5A2759B4D6DCE4 /* TranscriptionRecoveryPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryPresenters.swift; sourceTree = "<group>"; };
 		800BFCC6407B534886C65D77 /* TranscriptionClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionClient.swift; sourceTree = "<group>"; };
+		80315D4B806299BDB1449641 /* GitHubExportProvider+RepositoryDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitHubExportProvider+RepositoryDiscovery.swift"; sourceTree = "<group>"; };
 		811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturePermissionService.swift; sourceTree = "<group>"; };
 		820D9C79E98BC63EC8CEF7E3 /* MenuBarLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarLabelView.swift; sourceTree = "<group>"; };
 		83CE91359103D30C04663766 /* TranscriptionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionModels.swift; sourceTree = "<group>"; };
@@ -935,6 +937,7 @@
 				AFAF2A9878CBA298777A5677 /* GitHubExportProvider+Duplicates.swift */,
 				5258D51E9104DDABF9CFD179 /* GitHubExportProvider+IssueBody.swift */,
 				7E7D91DB9FF4F48F3285C634 /* GitHubExportProvider+Networking.swift */,
+				80315D4B806299BDB1449641 /* GitHubExportProvider+RepositoryDiscovery.swift */,
 				4B5B6268846602D2E2CC2102 /* GitHubExportProvider+WireTypes.swift */,
 				6FB4BF3587D332E1E9B2D70F /* HotkeyManager.swift */,
 				6346CF407E47D31933561CA1 /* HotkeySupportClasses.swift */,
@@ -1408,6 +1411,7 @@
 				1134B796398DF1FFBC51E738 /* GitHubExportProvider+Duplicates.swift in Sources */,
 				E74889E8810164E6EA9DCE75 /* GitHubExportProvider+IssueBody.swift in Sources */,
 				9270FCD8927ABF43CE704BD1 /* GitHubExportProvider+Networking.swift in Sources */,
+				596BBC26EE7C650862F4F22E /* GitHubExportProvider+RepositoryDiscovery.swift in Sources */,
 				A386A52717B012400A5E4F09 /* GitHubExportProvider+WireTypes.swift in Sources */,
 				2D3A2043E5E03245791F0AF5 /* GitHubExportProvider.swift in Sources */,
 				6F50D0E752BEA3CECA1517A4 /* HotkeyAction.swift in Sources */,

--- a/Sources/BugNarrator/Services/GitHubExportProvider+RepositoryDiscovery.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider+RepositoryDiscovery.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+extension GitHubExportProvider {
+    func fetchRepositories(token: String) async throws -> [GitHubRepositoryOption] {
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AppError.exportConfigurationMissing(
+                "GitHub repository discovery requires a personal access token."
+            )
+        }
+
+        var page = 1
+        var repositories: [GitHubRepositoryOption] = []
+
+        while true {
+            let request = try makeRepositoryListRequest(token: token, page: page)
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw AppError.exportFailure("GitHub returned an invalid response.")
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                throw mapGitHubError(
+                    statusCode: httpResponse.statusCode,
+                    data: data,
+                    configuration: GitHubExportConfiguration(
+                        token: token,
+                        owner: "",
+                        repository: "",
+                        labels: []
+                    )
+                )
+            }
+
+            let payload = try JSONDecoder().decode([GitHubRepositoryListItem].self, from: data)
+            repositories.append(
+                contentsOf: payload.compactMap { repo in
+                    guard repo.hasIssues else {
+                        return nil
+                    }
+
+                    if let permissions = repo.permissions,
+                       !permissions.canCreateIssues {
+                        return nil
+                    }
+
+                    return GitHubRepositoryOption(
+                        repositoryID: repo.nodeID,
+                        owner: repo.owner.login,
+                        name: repo.name,
+                        description: repo.description?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+                    )
+                }
+            )
+
+            if payload.count < 100 {
+                break
+            }
+
+            page += 1
+        }
+
+        return repositories.sorted {
+            $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
+        }
+    }
+
+    private func makeRepositoryListRequest(
+        token: String,
+        page: Int
+    ) throws -> URLRequest {
+        var components = URLComponents(string: "https://api.github.com/user/repos")!
+        components.queryItems = [
+            .init(name: "affiliation", value: "owner,collaborator,organization_member"),
+            .init(name: "sort", value: "updated"),
+            .init(name: "per_page", value: "100"),
+            .init(name: "page", value: "\(page)")
+        ]
+
+        return authenticatedRequest(
+            url: try url(from: components),
+            httpMethod: "GET",
+            token: token,
+            includesJSONContentType: false
+        )
+    }
+}

--- a/Sources/BugNarrator/Services/GitHubExportProvider.swift
+++ b/Sources/BugNarrator/Services/GitHubExportProvider.swift
@@ -24,69 +24,6 @@ actor GitHubExportProvider {
         self.retryConfiguration = retryConfiguration
     }
 
-    func fetchRepositories(token: String) async throws -> [GitHubRepositoryOption] {
-        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw AppError.exportConfigurationMissing(
-                "GitHub repository discovery requires a personal access token."
-            )
-        }
-
-        var page = 1
-        var repositories: [GitHubRepositoryOption] = []
-
-        while true {
-            let request = try makeRepositoryListRequest(token: token, page: page)
-            let (data, response) = try await session.data(for: request)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw AppError.exportFailure("GitHub returned an invalid response.")
-            }
-
-            guard (200...299).contains(httpResponse.statusCode) else {
-                throw mapGitHubError(
-                    statusCode: httpResponse.statusCode,
-                    data: data,
-                    configuration: GitHubExportConfiguration(
-                        token: token,
-                        owner: "",
-                        repository: "",
-                        labels: []
-                    )
-                )
-            }
-
-            let payload = try JSONDecoder().decode([GitHubRepositoryListItem].self, from: data)
-            repositories.append(
-                contentsOf: payload.compactMap { repo in
-                    guard repo.hasIssues else {
-                        return nil
-                    }
-
-                    if let permissions = repo.permissions,
-                       !permissions.canCreateIssues {
-                        return nil
-                    }
-
-                    return GitHubRepositoryOption(
-                        repositoryID: repo.nodeID,
-                        owner: repo.owner.login,
-                        name: repo.name,
-                        description: repo.description?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-                    )
-                }
-            )
-
-            if payload.count < 100 {
-                break
-            }
-
-            page += 1
-        }
-
-        return repositories.sorted {
-            $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
-        }
-    }
 
     func export(
         issues: [ExtractedIssue],
@@ -236,25 +173,6 @@ actor GitHubExportProvider {
         )
     }
 
-    private func makeRepositoryListRequest(
-        token: String,
-        page: Int
-    ) throws -> URLRequest {
-        var components = URLComponents(string: "https://api.github.com/user/repos")!
-        components.queryItems = [
-            .init(name: "affiliation", value: "owner,collaborator,organization_member"),
-            .init(name: "sort", value: "updated"),
-            .init(name: "per_page", value: "100"),
-            .init(name: "page", value: "\(page)")
-        ]
-
-        return authenticatedRequest(
-            url: try url(from: components),
-            httpMethod: "GET",
-            token: token,
-            includesJSONContentType: false
-        )
-    }
 
 
 


### PR DESCRIPTION
## Summary

Fifth slice of #639. Small clean move: `fetchRepositories` + `makeRepositoryListRequest` → `+RepositoryDiscovery.swift`. **Zero visibility widenings** (session was widened in #880).

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| GitHubExportProvider.swift | 354 | 272 | -82 |
| GitHubExportProvider+RepositoryDiscovery.swift (new) | — | 87 | +87 |

## Pre-build review

Codex: **BLOCKERS: none**, 7 OK claims. Line ranges exact; single-caller graph correct; only `session` used from actor storage (already widened); no orphan doc comment; external refs unaffected.

## Test plan

- [x] `xcodebuild build` succeeds.
- [x] `GitHubExportProviderTests` passes.

Closes #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)