### PR TITLE
refactor: extract JiraExportProvider+ADF (#638 slice B) (#890)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		1F758F881FC9E36B8EB89C18 /* IssueExtractionRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EF5167B9226AE01E478075 /* IssueExtractionRequestBuilder.swift */; };
 		20CFCC7656BA4B234DBE8004 /* IssueExportPresenters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB75074747EE722764CC071 /* IssueExportPresenters.swift */; };
 		2286D25AE254328242252388 /* RawTranscriptSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F39D0F0D8152AB34E5CC2EB /* RawTranscriptSection.swift */; };
+		229822482577A3A62CB41D93 /* JiraExportProvider+ADF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F6549DE55911C6918B790D /* JiraExportProvider+ADF.swift */; };
 		231AC81D88405F6044354D75 /* SystemAudioAggregateDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE7687249AD70EDFF06A569 /* SystemAudioAggregateDevice.swift */; };
 		2455C6B282EF275B5B55F591 /* TelemetryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D05D14432F331F83DB44AD9 /* TelemetryTypes.swift */; };
 		24EAF9A3DAF9624979F3F358 /* IssueExportTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D566BDB865CF9FF245BB283 /* IssueExportTestSupport.swift */; };
@@ -559,6 +560,7 @@
 		95694D28269EE30BBED24AFE /* TranscriptionRecoverySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoverySupport.swift; sourceTree = "<group>"; };
 		97D1FA8DAF455B144969DFA6 /* PrivacyDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyDataExporter.swift; sourceTree = "<group>"; };
 		98A652F7AA9829954147C9A1 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
+		98F6549DE55911C6918B790D /* JiraExportProvider+ADF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JiraExportProvider+ADF.swift"; sourceTree = "<group>"; };
 		998C4703160B45E816CF929F /* ScreenshotCaptureSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotCaptureSupport.swift; sourceTree = "<group>"; };
 		99BC67525B274B5A01ADACF9 /* AIProviderSettingsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProviderSettingsController.swift; sourceTree = "<group>"; };
 		9AFA7A7FD4F1B6ACB5E3D70F /* AsyncTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTimeoutTests.swift; sourceTree = "<group>"; };
@@ -960,6 +962,7 @@
 				EE77402A6284B705F5F4984A /* IssueExtractionResponseParser.swift */,
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
+				98F6549DE55911C6918B790D /* JiraExportProvider+ADF.swift */,
 				77909EE4BE0BACFEC08EF096 /* JiraExportProvider+Networking.swift */,
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
@@ -1448,6 +1451,7 @@
 				A82C126F44F43B42D82EA0DF /* IssueScreenshotAnnotationRenderer.swift in Sources */,
 				B1E0999F91F9E0236146F023 /* IssueScreenshotAnnotationTypes.swift in Sources */,
 				045DEFACC4FF761873046058 /* JiraExportConfig.swift in Sources */,
+				229822482577A3A62CB41D93 /* JiraExportProvider+ADF.swift in Sources */,
 				AB91BF15F45FBF5F28E45E7B /* JiraExportProvider+Networking.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */,

--- a/Sources/BugNarrator/Services/JiraExportProvider+ADF.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider+ADF.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+extension JiraExportProvider {
+    func hardLimit(
+        _ blocks: [JiraBlock],
+        maxCharacters: Int
+    ) -> [JiraBlock] {
+        var characterBudget = 0
+        var limitedBlocks: [JiraBlock] = []
+
+        for block in blocks {
+            let blockText = block.plainText
+            let blockLength = blockText.count
+            if characterBudget + blockLength <= maxCharacters {
+                limitedBlocks.append(block)
+                characterBudget += blockLength
+                continue
+            }
+
+            let remainingCharacters = max(0, maxCharacters - characterBudget)
+            guard remainingCharacters > 0 else {
+                break
+            }
+
+            limitedBlocks.append(
+                .paragraph(
+                    text: TrackerExportPayloadBudget.truncated(
+                        blockText,
+                        maxCharacters: remainingCharacters
+                    )
+                )
+            )
+            break
+        }
+
+        return limitedBlocks
+    }
+}
+
+struct JiraDocument: Encodable {
+    let type = "doc"
+    let version = 1
+    let content: [JiraBlock]
+}
+
+struct JiraBlock: Encodable {
+    let type: String
+    let content: [JiraInline]?
+
+    static func paragraph(text: String) -> JiraBlock {
+        JiraBlock(type: "paragraph", content: [.text(text)])
+    }
+
+    static func bulletList(items: [String]) -> JiraBlock {
+        JiraBlock(
+            type: "bulletList",
+            content: items.map { item in
+                JiraInline.listItem(
+                    JiraBlock(type: "paragraph", content: [.text(item)])
+                )
+            }
+        )
+    }
+
+    var plainText: String {
+        content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
+    }
+}
+
+struct JiraInline: Encodable {
+    let type: String
+    let text: String?
+    let content: [JiraBlock]?
+
+    static func text(_ value: String) -> JiraInline {
+        JiraInline(type: "text", text: value, content: nil)
+    }
+
+    static func listItem(_ block: JiraBlock) -> JiraInline {
+        JiraInline(type: "listItem", text: nil, content: [block])
+    }
+
+    var plainText: String {
+        let childText = content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
+        if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+            if childText.isEmpty {
+                return text
+            }
+
+            return "\(text) \(childText)"
+        }
+
+        return childText
+    }
+}
+
+struct JiraADFNode: Decodable {
+    let type: String?
+    let text: String?
+    let content: [JiraADFNode]?
+
+    var plainText: String {
+        let childText = content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
+        if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+            if childText.isEmpty {
+                return text
+            }
+
+            return [text, childText].joined(separator: " ")
+        }
+
+        return childText
+    }
+}

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -800,40 +800,6 @@ actor JiraExportProvider {
         return parts.joined(separator: " | ")
     }
 
-    private func hardLimit(
-        _ blocks: [JiraBlock],
-        maxCharacters: Int
-    ) -> [JiraBlock] {
-        var characterBudget = 0
-        var limitedBlocks: [JiraBlock] = []
-
-        for block in blocks {
-            let blockText = block.plainText
-            let blockLength = blockText.count
-            if characterBudget + blockLength <= maxCharacters {
-                limitedBlocks.append(block)
-                characterBudget += blockLength
-                continue
-            }
-
-            let remainingCharacters = max(0, maxCharacters - characterBudget)
-            guard remainingCharacters > 0 else {
-                break
-            }
-
-            limitedBlocks.append(
-                .paragraph(
-                    text: TrackerExportPayloadBudget.truncated(
-                        blockText,
-                        maxCharacters: remainingCharacters
-                    )
-                )
-            )
-            break
-        }
-
-        return limitedBlocks
-    }
 
     private func annotatedScreenshotLines(issue: ExtractedIssue, session: TranscriptSession) throws -> [String] {
         try annotationRenderer.annotatedScreenshotExports(for: issue, session: session).map { export in
@@ -913,62 +879,8 @@ private struct JiraIssueTypeField: Encodable {
     }
 }
 
-private struct JiraDocument: Encodable {
-    let type = "doc"
-    let version = 1
-    let content: [JiraBlock]
-}
 
-private struct JiraBlock: Encodable {
-    let type: String
-    let content: [JiraInline]?
 
-    static func paragraph(text: String) -> JiraBlock {
-        JiraBlock(type: "paragraph", content: [.text(text)])
-    }
-
-    static func bulletList(items: [String]) -> JiraBlock {
-        JiraBlock(
-            type: "bulletList",
-            content: items.map { item in
-                JiraInline.listItem(
-                    JiraBlock(type: "paragraph", content: [.text(item)])
-                )
-            }
-        )
-    }
-
-    var plainText: String {
-        content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
-    }
-}
-
-private struct JiraInline: Encodable {
-    let type: String
-    let text: String?
-    let content: [JiraBlock]?
-
-    static func text(_ value: String) -> JiraInline {
-        JiraInline(type: "text", text: value, content: nil)
-    }
-
-    static func listItem(_ block: JiraBlock) -> JiraInline {
-        JiraInline(type: "listItem", text: nil, content: [block])
-    }
-
-    var plainText: String {
-        let childText = content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
-        if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
-            if childText.isEmpty {
-                return text
-            }
-
-            return "\(text) \(childText)"
-        }
-
-        return childText
-    }
-}
 
 private struct JiraIssueResponse: Decodable {
     let id: String
@@ -1001,24 +913,6 @@ private struct JiraSearchIssueFields: Decodable {
     let description: JiraADFNode?
 }
 
-private struct JiraADFNode: Decodable {
-    let type: String?
-    let text: String?
-    let content: [JiraADFNode]?
-
-    var plainText: String {
-        let childText = content?.map(\.plainText).filter { !$0.isEmpty }.joined(separator: " ") ?? ""
-        if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
-            if childText.isEmpty {
-                return text
-            }
-
-            return [text, childText].joined(separator: " ")
-        }
-
-        return childText
-    }
-}
 
 
 private struct JiraCreateMetadataProjectsResponse: Decodable {


### PR DESCRIPTION
## Summary

Second slice of #638 (after #874 Networking, PR #877). ADF payload models + hardLimit helper → `+ADF.swift`.

## Visibility change

5 widenings:
- `hardLimit`: `private func` → `internal func`
- `JiraDocument`, `JiraBlock`, `JiraInline`, `JiraADFNode`: file-scope `private struct` → module-internal `struct`

Zero external references confirmed by grep.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| JiraExportProvider.swift | 1139 | 1033 | -106 |
| JiraExportProvider+ADF.swift (new) | — | 114 | +114 |

## Pre-build review

Codex: **BLOCKERS: none**. 6 OK claims verified.

## Test plan

- [x] `xcodebuild build` succeeds.
- [x] `JiraExportProviderTests` passes.

Closes #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)