### PR TITLE
refactor: extract JiraExportProvider+Duplicates (#638 slice C) (#892)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		9DD9E28AE4387EAEB9C43E92 /* ScreenCapturePermissionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3D36DA7C2B60A61D7CB47 /* ScreenCapturePermissionServiceTests.swift */; };
 		9EE81A76B802435C84B8032D /* IssueExtractionResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE77402A6284B705F5F4984A /* IssueExtractionResponseParser.swift */; };
 		9F837FB17474EEB037FC01B4 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78EFF170BAD57E66A7CB20AB /* AppState.swift */; };
+		9FBE899F44D1D68C16AF1E81 /* JiraExportProvider+Duplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618959A44C78ED8FF5F4C1BE /* JiraExportProvider+Duplicates.swift */; };
 		A0CCAAA3701FF6274B792685 /* APIKeyValidationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52EDA987A6F43F0D5113D603 /* APIKeyValidationStateTests.swift */; };
 		A12389B77FFD220995DDA0A4 /* SettingsStore+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C8CCD0B75F5DF182C5033 /* SettingsStore+Display.swift */; };
 		A17B5FCA1F95211DF2321774 /* AppStateHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C367EF1F4D24E1E5819087 /* AppStateHarness.swift */; };
@@ -483,6 +484,7 @@
 		60CD6EFC4CDBFE13C31BD38D /* OpenAIErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIErrorMapper.swift; sourceTree = "<group>"; };
 		6131EA189B853D1B456A8D26 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		6161AB93D74FD6A2471534C5 /* AppState+SessionLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SessionLibrary.swift"; sourceTree = "<group>"; };
+		618959A44C78ED8FF5F4C1BE /* JiraExportProvider+Duplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JiraExportProvider+Duplicates.swift"; sourceTree = "<group>"; };
 		6346CF407E47D31933561CA1 /* HotkeySupportClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeySupportClasses.swift; sourceTree = "<group>"; };
 		64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRuntimeEnvironmentTests.swift; sourceTree = "<group>"; };
 		64F0A81E02972573D2556B85 /* AppState+RecordingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+RecordingTimer.swift"; sourceTree = "<group>"; };
@@ -963,6 +965,7 @@
 				BC6C8D8316A46CFCBF0847F2 /* IssueExtractionService.swift */,
 				F8E37090B827BA0F599EC926 /* JiraExportProvider.swift */,
 				98F6549DE55911C6918B790D /* JiraExportProvider+ADF.swift */,
+				618959A44C78ED8FF5F4C1BE /* JiraExportProvider+Duplicates.swift */,
 				77909EE4BE0BACFEC08EF096 /* JiraExportProvider+Networking.swift */,
 				CB7110BAF79EA83E3FAE6FBF /* KeychainSecretStore.swift */,
 				5C5346EDB503C6B05C81C368 /* KeychainService.swift */,
@@ -1452,6 +1455,7 @@
 				B1E0999F91F9E0236146F023 /* IssueScreenshotAnnotationTypes.swift in Sources */,
 				045DEFACC4FF761873046058 /* JiraExportConfig.swift in Sources */,
 				229822482577A3A62CB41D93 /* JiraExportProvider+ADF.swift in Sources */,
+				9FBE899F44D1D68C16AF1E81 /* JiraExportProvider+Duplicates.swift in Sources */,
 				AB91BF15F45FBF5F28E45E7B /* JiraExportProvider+Networking.swift in Sources */,
 				88462910DDACB724E646495A /* JiraExportProvider.swift in Sources */,
 				318DB7BFA958511B51F94AA8 /* KeychainSecretStore.swift in Sources */,

--- a/Sources/BugNarrator/Services/JiraExportProvider+Duplicates.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider+Duplicates.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+extension JiraExportProvider {
+    func findOpenIssues(
+        matching issue: ExtractedIssue,
+        configuration: JiraExportConfiguration
+    ) async throws -> [TrackerIssueCandidate] {
+        guard configuration.isComplete else {
+            throw AppError.exportConfigurationMissing(
+                "Jira export requires a base URL, email, API token, project key, and issue type."
+            )
+        }
+
+        let request = try makeSearchRequest(issue: issue, configuration: configuration)
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError.exportFailure("Jira returned an invalid response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw mapJiraError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
+        }
+
+        let payload = try JSONDecoder().decode(JiraSearchResponse.self, from: data)
+        return payload.issues.map { issue in
+            TrackerIssueCandidate(
+                remoteIdentifier: issue.key,
+                title: issue.fields.summary,
+                summary: issue.fields.description?.plainText ?? "",
+                remoteURL: configuration.baseURL.appending(path: "browse/\(issue.key)")
+            )
+        }
+    }
+
+    private func makeSearchRequest(
+        issue: ExtractedIssue,
+        configuration: JiraExportConfiguration
+    ) throws -> URLRequest {
+        let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: true
+        )
+        request.httpBody = try JSONEncoder().encode(
+            JiraSearchRequest(
+                jql: searchJQL(for: issue, projectKey: configuration.projectKey),
+                maxResults: 5,
+                fields: ["summary", "description"]
+            )
+        )
+        return request
+    }
+
+    private func makeExportFingerprintSearchRequest(
+        fingerprint: String,
+        configuration: JiraExportConfiguration
+    ) throws -> URLRequest {
+        let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
+        var request = authenticatedRequest(
+            url: endpoint,
+            httpMethod: "POST",
+            email: configuration.email,
+            apiToken: configuration.apiToken,
+            includesJSONContentType: true
+        )
+        request.httpBody = try JSONEncoder().encode(
+            JiraSearchRequest(
+                jql: #"\#(Self.jqlProjectClause(configuration.projectKey)) AND description ~ "\"\#(TrackerExportFingerprint.marker(for: fingerprint))\"" ORDER BY created DESC"#,
+                maxResults: 1,
+                fields: ["summary", "description"]
+            )
+        )
+        return request
+    }
+
+    func existingExportResult(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        configuration: JiraExportConfiguration
+    ) async throws -> ExportResult? {
+        if let receipt = try await receiptStore.receipt(for: fingerprint),
+           let exportResult = receipt.asExportResult() {
+            return exportResult
+        }
+
+        guard let receipt = try await receiptStore.receipt(for: fingerprint),
+              receipt.state == .pending else {
+            return nil
+        }
+
+        return try await reconcilePendingExport(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            configuration: configuration
+        )
+    }
+
+    func reconcilePendingExport(
+        fingerprint: String,
+        sourceIssueID: UUID,
+        configuration: JiraExportConfiguration
+    ) async throws -> ExportResult? {
+        guard let candidate = try await findExportedIssue(
+            fingerprint: fingerprint,
+            configuration: configuration
+        ) else {
+            return nil
+        }
+
+        try await receiptStore.markSucceeded(
+            fingerprint: fingerprint,
+            sourceIssueID: sourceIssueID,
+            destination: .jira,
+            targetIdentity: configuration.targetIdentity,
+            remoteIdentifier: candidate.remoteIdentifier,
+            remoteURL: candidate.remoteURL
+        )
+
+        return ExportResult(
+            sourceIssueID: sourceIssueID,
+            destination: .jira,
+            remoteIdentifier: candidate.remoteIdentifier,
+            remoteURL: candidate.remoteURL
+        )
+    }
+
+    private func findExportedIssue(
+        fingerprint: String,
+        configuration: JiraExportConfiguration
+    ) async throws -> TrackerIssueCandidate? {
+        let request = try makeExportFingerprintSearchRequest(
+            fingerprint: fingerprint,
+            configuration: configuration
+        )
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AppError.exportFailure("Jira returned an invalid response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw mapJiraError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
+        }
+
+        let payload = try JSONDecoder().decode(JiraSearchResponse.self, from: data)
+        guard let issue = payload.issues.first else {
+            return nil
+        }
+
+        return TrackerIssueCandidate(
+            remoteIdentifier: issue.key,
+            title: issue.fields.summary,
+            summary: issue.fields.description?.plainText ?? "",
+            remoteURL: configuration.baseURL.appending(path: "browse/\(issue.key)")
+        )
+    }
+
+    private func searchJQL(for issue: ExtractedIssue, projectKey: String) -> String {
+        let phrase = TrackerExportSupport.searchTerms(for: issue)
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        return """
+        \(Self.jqlProjectClause(projectKey)) AND statusCategory != Done AND (summary ~ "\\"\(phrase)\\"" OR description ~ "\\"\(phrase)\\"") ORDER BY updated DESC
+        """
+    }
+}
+
+struct JiraSearchRequest: Encodable {
+    let jql: String
+    let maxResults: Int
+    let fields: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case jql
+        case maxResults = "maxResults"
+        case fields
+    }
+}
+
+struct JiraSearchResponse: Decodable {
+    let issues: [JiraSearchIssue]
+}
+
+struct JiraSearchIssue: Decodable {
+    let key: String
+    let fields: JiraSearchIssueFields
+}
+
+struct JiraSearchIssueFields: Decodable {
+    let summary: String
+    let description: JiraADFNode?
+}

--- a/Sources/BugNarrator/Services/JiraExportProvider.swift
+++ b/Sources/BugNarrator/Services/JiraExportProvider.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 actor JiraExportProvider {
-    private let session: URLSession
-    private let receiptStore: any ExportReceiptStoring
+    let session: URLSession
+    let receiptStore: any ExportReceiptStoring
     private let retryConfiguration: ExportRetryConfiguration
     private let logger = DiagnosticsLogger(category: .export)
     private let annotationRenderer = IssueScreenshotAnnotationRenderer()
@@ -238,37 +238,6 @@ actor JiraExportProvider {
         }
     }
 
-    func findOpenIssues(
-        matching issue: ExtractedIssue,
-        configuration: JiraExportConfiguration
-    ) async throws -> [TrackerIssueCandidate] {
-        guard configuration.isComplete else {
-            throw AppError.exportConfigurationMissing(
-                "Jira export requires a base URL, email, API token, project key, and issue type."
-            )
-        }
-
-        let request = try makeSearchRequest(issue: issue, configuration: configuration)
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AppError.exportFailure("Jira returned an invalid response.")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            throw mapJiraError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
-        }
-
-        let payload = try JSONDecoder().decode(JiraSearchResponse.self, from: data)
-        return payload.issues.map { issue in
-            TrackerIssueCandidate(
-                remoteIdentifier: issue.key,
-                title: issue.fields.summary,
-                summary: issue.fields.description?.plainText ?? "",
-                remoteURL: configuration.baseURL.appending(path: "browse/\(issue.key)")
-            )
-        }
-    }
 
     func makeURLRequest(
         issue: ExtractedIssue,
@@ -448,49 +417,7 @@ actor JiraExportProvider {
 
 
 
-    private func makeSearchRequest(
-        issue: ExtractedIssue,
-        configuration: JiraExportConfiguration
-    ) throws -> URLRequest {
-        let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
-        var request = authenticatedRequest(
-            url: endpoint,
-            httpMethod: "POST",
-            email: configuration.email,
-            apiToken: configuration.apiToken,
-            includesJSONContentType: true
-        )
-        request.httpBody = try JSONEncoder().encode(
-            JiraSearchRequest(
-                jql: searchJQL(for: issue, projectKey: configuration.projectKey),
-                maxResults: 5,
-                fields: ["summary", "description"]
-            )
-        )
-        return request
-    }
 
-    private func makeExportFingerprintSearchRequest(
-        fingerprint: String,
-        configuration: JiraExportConfiguration
-    ) throws -> URLRequest {
-        let endpoint = configuration.baseURL.appending(path: "rest/api/3/search/jql")
-        var request = authenticatedRequest(
-            url: endpoint,
-            httpMethod: "POST",
-            email: configuration.email,
-            apiToken: configuration.apiToken,
-            includesJSONContentType: true
-        )
-        request.httpBody = try JSONEncoder().encode(
-            JiraSearchRequest(
-                jql: #"\#(Self.jqlProjectClause(configuration.projectKey)) AND description ~ "\"\#(TrackerExportFingerprint.marker(for: fingerprint))\"" ORDER BY created DESC"#,
-                maxResults: 1,
-                fields: ["summary", "description"]
-            )
-        )
-        return request
-    }
 
 
 
@@ -577,87 +504,8 @@ actor JiraExportProvider {
         }
     }
 
-    private func existingExportResult(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        configuration: JiraExportConfiguration
-    ) async throws -> ExportResult? {
-        if let receipt = try await receiptStore.receipt(for: fingerprint),
-           let exportResult = receipt.asExportResult() {
-            return exportResult
-        }
 
-        guard let receipt = try await receiptStore.receipt(for: fingerprint),
-              receipt.state == .pending else {
-            return nil
-        }
 
-        return try await reconcilePendingExport(
-            fingerprint: fingerprint,
-            sourceIssueID: sourceIssueID,
-            configuration: configuration
-        )
-    }
-
-    private func reconcilePendingExport(
-        fingerprint: String,
-        sourceIssueID: UUID,
-        configuration: JiraExportConfiguration
-    ) async throws -> ExportResult? {
-        guard let candidate = try await findExportedIssue(
-            fingerprint: fingerprint,
-            configuration: configuration
-        ) else {
-            return nil
-        }
-
-        try await receiptStore.markSucceeded(
-            fingerprint: fingerprint,
-            sourceIssueID: sourceIssueID,
-            destination: .jira,
-            targetIdentity: configuration.targetIdentity,
-            remoteIdentifier: candidate.remoteIdentifier,
-            remoteURL: candidate.remoteURL
-        )
-
-        return ExportResult(
-            sourceIssueID: sourceIssueID,
-            destination: .jira,
-            remoteIdentifier: candidate.remoteIdentifier,
-            remoteURL: candidate.remoteURL
-        )
-    }
-
-    private func findExportedIssue(
-        fingerprint: String,
-        configuration: JiraExportConfiguration
-    ) async throws -> TrackerIssueCandidate? {
-        let request = try makeExportFingerprintSearchRequest(
-            fingerprint: fingerprint,
-            configuration: configuration
-        )
-        let (data, response) = try await session.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AppError.exportFailure("Jira returned an invalid response.")
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            throw mapJiraError(statusCode: httpResponse.statusCode, data: data, configuration: configuration)
-        }
-
-        let payload = try JSONDecoder().decode(JiraSearchResponse.self, from: data)
-        guard let issue = payload.issues.first else {
-            return nil
-        }
-
-        return TrackerIssueCandidate(
-            remoteIdentifier: issue.key,
-            title: issue.fields.summary,
-            summary: issue.fields.description?.plainText ?? "",
-            remoteURL: configuration.baseURL.appending(path: "browse/\(issue.key)")
-        )
-    }
 
     private func makeDescription(
         issue: ExtractedIssue,
@@ -813,15 +661,6 @@ actor JiraExportProvider {
 
 
 
-    private func searchJQL(for issue: ExtractedIssue, projectKey: String) -> String {
-        let phrase = TrackerExportSupport.searchTerms(for: issue)
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-
-        return """
-        \(Self.jqlProjectClause(projectKey)) AND statusCategory != Done AND (summary ~ "\\"\(phrase)\\"" OR description ~ "\\"\(phrase)\\"") ORDER BY updated DESC
-        """
-    }
 
     /// Builds the `project = "KEY"` JQL clause with the project key quoted and
     /// backslash/quote-escaped. Jira accepts a quoted project key, so quoting is
@@ -887,31 +726,9 @@ private struct JiraIssueResponse: Decodable {
     let key: String
 }
 
-private struct JiraSearchRequest: Encodable {
-    let jql: String
-    let maxResults: Int
-    let fields: [String]
 
-    enum CodingKeys: String, CodingKey {
-        case jql
-        case maxResults = "maxResults"
-        case fields
-    }
-}
 
-private struct JiraSearchResponse: Decodable {
-    let issues: [JiraSearchIssue]
-}
 
-private struct JiraSearchIssue: Decodable {
-    let key: String
-    let fields: JiraSearchIssueFields
-}
-
-private struct JiraSearchIssueFields: Decodable {
-    let summary: String
-    let description: JiraADFNode?
-}
 
 
 


### PR DESCRIPTION
## Summary

Third slice of #638 (sibling of GitHub's #881). ~185 lines moved: 6 methods + 4 search wire types.

## Visibility change

- **Method widenings**: `existingExportResult`, `reconcilePendingExport` (both `private → internal`).
- **Struct widenings**: 4 search wire types (file-scope `private → internal`).
- **Stored-prop widenings** (found by codex + agy pre-review): `session` and `receiptStore` (`private let → let`) — Jira actor hadn't had these widened yet.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| JiraExportProvider.swift | 1033 | 850 | -183 |
| JiraExportProvider+Duplicates.swift (new) | — | 197 | +197 |

## Pre-build reviews

- Codex: 1 finding (session/receiptStore widening needed) — ACTIONED in build.
- Agy (Gemini): 2 findings (same session/receiptStore + confirmed existingExportResult widening) — ACTIONED in build.

## Test plan

- [x] `xcodebuild build` succeeds.
- [x] `JiraExportProviderTests` passes.

Closes #892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)