### PR TITLE
refactor: extract SessionListSidebar + SessionLibraryViewModel (#631, closes #401)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		11935BB2070F2A08AB015BD9 /* DiagnosticsLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E89C1E4E72D830539D76274 /* DiagnosticsLogEntry.swift */; };
 		11D0925211E3A8D0AC8FF219 /* AppLifecycleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FA8C32EF0CB342E6EF41E9 /* AppLifecycleDelegate.swift */; };
 		134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6131EA189B853D1B456A8D26 /* SettingsView.swift */; };
+		134D37C557D8E97533691019 /* SessionLibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D87482555BCEBC9C4114BA3 /* SessionLibraryViewModel.swift */; };
 		14EB1BCFF0ADCB436C5A9451 /* MicrophonePermissionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F444FA9FBF8F33C48106BB9 /* MicrophonePermissionResolverTests.swift */; };
 		15409A450769B9F9DBA0DF59 /* PostTranscriptionPipelineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84646A0490F119BBE0BBE5C9 /* PostTranscriptionPipelineControllerTests.swift */; };
 		15C768D62CC7119DC6F212E2 /* DiagnosticsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3114A162C2D284BD173DBC9 /* DiagnosticsTypes.swift */; };
@@ -172,6 +173,7 @@
 		7A9EE56958CFB17D59BD1253 /* TranscriptQualityFinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3104282993DE974208688237 /* TranscriptQualityFinding.swift */; };
 		7B0DA8E96C26D94D71FA557E /* MixedAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDF1C66361AB34654415655 /* MixedAudioRecorder.swift */; };
 		7BDE1E7353588D5B33CB71D9 /* PrivacyDataExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF829EF7F67E44EA637F4A4 /* PrivacyDataExporterTests.swift */; };
+		7F3C56383F0FE7EBA4C6C749 /* SessionListSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F865A8D011F361AC33ED2C9 /* SessionListSidebar.swift */; };
 		7FC6E70710547A486C4ED5BA /* AboutBugNarratorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B0A4E5E69C1FD99320DDB2 /* AboutBugNarratorView.swift */; };
 		806F6B3953A77B84672AD2DA /* AppRuntimeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64113E8532E84371F91096AF /* AppRuntimeEnvironmentTests.swift */; };
 		8124F6AEFE87F470DE1D3B56 /* IssueExtractionRequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */; };
@@ -410,10 +412,12 @@
 		28B463E2764267ED731EDB99 /* AppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBootstrap.swift; sourceTree = "<group>"; };
 		2C79C7B495FC353122C29F0B /* TranscriptionRecoveryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionRecoveryController.swift; sourceTree = "<group>"; };
 		2D753EF601F00C09C7FF276C /* TransientToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransientToast.swift; sourceTree = "<group>"; };
+		2D87482555BCEBC9C4114BA3 /* SessionLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionLibraryViewModel.swift; sourceTree = "<group>"; };
 		2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreNormalizationTests.swift; sourceTree = "<group>"; };
 		2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStore.swift; sourceTree = "<group>"; };
 		2EE656D8E103CE32761B9567 /* GitHubExportProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubExportProvider.swift; sourceTree = "<group>"; };
 		2F0110337CFF56AF5224956A /* SessionMarkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMarkerTests.swift; sourceTree = "<group>"; };
+		2F865A8D011F361AC33ED2C9 /* SessionListSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListSidebar.swift; sourceTree = "<group>"; };
 		2FA72EF162C4C4AF53D2CB41 /* DebugBundleExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBundleExporter.swift; sourceTree = "<group>"; };
 		305726D5E9A576C4C9729670 /* TranscriptionSessionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionSessionBuilder.swift; sourceTree = "<group>"; };
 		3104282993DE974208688237 /* TranscriptQualityFinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityFinding.swift; sourceTree = "<group>"; };
@@ -1119,6 +1123,8 @@
 				1F39D0F0D8152AB34E5CC2EB /* RawTranscriptSection.swift */,
 				73EE04400BDA66A1C4B97D19 /* ReviewWorkspaceShell.swift */,
 				16D050A90CD83BD3C04D0487 /* ScreenshotsSection.swift */,
+				2D87482555BCEBC9C4114BA3 /* SessionLibraryViewModel.swift */,
+				2F865A8D011F361AC33ED2C9 /* SessionListSidebar.swift */,
 				EE629842187FE002FE2DE05D /* SessionRow.swift */,
 				C33C8794A9B95C9AF44798E3 /* TranscriptSharedHelpers.swift */,
 			);
@@ -1528,6 +1534,8 @@
 				C177672680CF960A0A36F3D0 /* SessionLibraryPresenters.swift in Sources */,
 				521B9ADF01AF367133FF5FE1 /* SessionLibraryQuery.swift in Sources */,
 				CD22DEA9761A7BAD23814D52 /* SessionLibraryStatusPresenter+Attempt.swift in Sources */,
+				134D37C557D8E97533691019 /* SessionLibraryViewModel.swift in Sources */,
+				7F3C56383F0FE7EBA4C6C749 /* SessionListSidebar.swift in Sources */,
 				6DDE29389B4D58A9BD6CD115 /* SessionMarker.swift in Sources */,
 				F0C234F3BD7753A09B98A332 /* SessionRow.swift in Sources */,
 				99268A7BF811CD29DB330195 /* SessionScreenshot.swift in Sources */,

--- a/Sources/BugNarrator/Views/Transcript/SessionLibraryViewModel.swift
+++ b/Sources/BugNarrator/Views/Transcript/SessionLibraryViewModel.swift
@@ -1,0 +1,173 @@
+import Foundation
+import SwiftUI
+
+/// View model for the session library sidebar (#631, closes #401 slice d).
+/// Owns the filter/search/sort/date-range state and the derived query
+/// helpers. Both `SessionListSidebar` and `TranscriptView.detailPane`
+/// observe the same VM so the detail pane sees the same `selectedSession`
+/// / `emptyState` that the sidebar produces.
+@MainActor
+final class SessionLibraryViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published var sortOrder: SessionLibrarySortOrder = .newestFirst
+    @Published var selectedFilter: SessionLibraryDateFilter = .today
+    @Published var customStartDate: Date = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
+    @Published var customEndDate: Date = Date()
+    @Published private(set) var hasResolvedInitialFilter: Bool = false
+
+    let calendar: Calendar
+
+    private unowned let appState: AppState
+    private unowned let transcriptStore: TranscriptStore
+
+    init(
+        appState: AppState,
+        transcriptStore: TranscriptStore,
+        calendar: Calendar = .current
+    ) {
+        self.appState = appState
+        self.transcriptStore = transcriptStore
+        self.calendar = calendar
+    }
+
+    // MARK: - Derived state (read by sidebar + detail pane)
+
+    var allSessions: [TranscriptSession] {
+        var sessions = transcriptStore.sessions
+
+        if let currentTranscript = appState.currentTranscript {
+            if let existingIndex = sessions.firstIndex(where: { $0.id == currentTranscript.id }) {
+                sessions[existingIndex] = currentTranscript
+            } else if !appState.currentTranscriptIsPersisted {
+                sessions.insert(currentTranscript, at: 0)
+            }
+        }
+
+        return sessions
+    }
+
+    var allSessionEntries: [SessionLibraryEntry] {
+        var entries = transcriptStore.libraryEntries
+
+        if let currentTranscript = appState.currentTranscript {
+            let entry = SessionLibraryEntry(session: currentTranscript)
+            if let existingIndex = entries.firstIndex(where: { $0.id == currentTranscript.id }) {
+                entries[existingIndex] = entry
+            } else if !appState.currentTranscriptIsPersisted {
+                entries.insert(entry, at: 0)
+            }
+        }
+
+        return entries
+    }
+
+    var query: SessionLibraryQuery {
+        SessionLibraryQuery(
+            filter: selectedFilter,
+            customDateRange: SessionLibraryDateRange(startDate: customStartDate, endDate: customEndDate),
+            searchText: searchText,
+            sortOrder: sortOrder
+        )
+    }
+
+    var librarySnapshot: SessionLibrarySnapshot<SessionLibraryEntry> {
+        SessionLibrary.snapshot(
+            from: allSessionEntries,
+            query: query,
+            calendar: calendar
+        )
+    }
+
+    var filteredEntries: [SessionLibraryEntry] {
+        librarySnapshot.filteredItems
+    }
+
+    var selectedSession: TranscriptSession? {
+        guard let selectedTranscriptID = appState.selectedTranscriptID else {
+            return filteredEntries.first.flatMap { resolveSession(for: $0) }
+        }
+
+        guard let selectedEntry = filteredEntries.first(where: { $0.id == selectedTranscriptID }) else {
+            return filteredEntries.first.flatMap { resolveSession(for: $0) }
+        }
+
+        return resolveSession(for: selectedEntry)
+    }
+
+    var emptyState: SessionLibraryEmptyState? {
+        librarySnapshot.emptyState
+    }
+
+    var sessionCountSummary: String {
+        let count = filteredEntries.count
+        let pendingRetryCount = transcriptStore.pendingTranscriptionSessionCount
+        let pendingRetrySuffix: String
+        if pendingRetryCount > 0 {
+            pendingRetrySuffix = pendingRetryCount == 1
+                ? " • 1 needs retry"
+                : " • \(pendingRetryCount) need retry"
+        } else {
+            pendingRetrySuffix = ""
+        }
+
+        if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return (count == 1 ? "1 session" : "\(count) sessions") + pendingRetrySuffix
+        }
+
+        return (count == 1 ? "1 result for “\(searchText)”" : "\(count) results for “\(searchText)”") + pendingRetrySuffix
+    }
+
+    var sessionIDSignature: String {
+        allSessionEntries.map(\.id.uuidString).joined(separator: "|")
+    }
+
+    func count(for filter: SessionLibraryDateFilter) -> Int {
+        librarySnapshot.counts[filter] ?? 0
+    }
+
+    // MARK: - Callbacks
+
+    func resolveInitialFilterIfNeeded() {
+        guard !hasResolvedInitialFilter else {
+            return
+        }
+
+        hasResolvedInitialFilter = true
+        if count(for: .today) == 0, count(for: .retryNeeded) > 0 {
+            selectedFilter = .retryNeeded
+        } else if count(for: .today) == 0, !allSessionEntries.isEmpty {
+            selectedFilter = .allSessions
+        }
+    }
+
+    func syncSelection() {
+        guard !filteredEntries.isEmpty else {
+            appState.selectedTranscriptID = nil
+            return
+        }
+
+        if let selectedTranscriptID = appState.selectedTranscriptID,
+           filteredEntries.contains(where: { $0.id == selectedTranscriptID }) {
+            return
+        }
+
+        appState.selectedTranscriptID = filteredEntries.first?.id
+    }
+
+    func openLatestPendingTranscriptionSession() {
+        selectedFilter = .retryNeeded
+        searchText = ""
+        appState.selectedTranscriptID = transcriptStore.latestPendingTranscriptionSession?.id
+        syncSelection()
+    }
+
+    // MARK: - Session resolution (mirrors TranscriptSharedHelpers)
+
+    private func resolveSession(for entry: SessionLibraryEntry) -> TranscriptSession? {
+        if appState.currentTranscript?.id == entry.id {
+            return appState.currentTranscript
+        }
+
+        return transcriptStore.session(with: entry.id)
+    }
+}

--- a/Sources/BugNarrator/Views/Transcript/SessionListSidebar.swift
+++ b/Sources/BugNarrator/Views/Transcript/SessionListSidebar.swift
@@ -1,0 +1,291 @@
+import AppKit
+import SwiftUI
+
+/// The session library sidebar + session-list column extracted from
+/// `TranscriptView` (#631, closes #401 slice d).
+///
+/// Owns no `@State` itself; the filter/search/sort/date-range state lives
+/// on `SessionLibraryViewModel` (a `@StateObject` on `TranscriptView`).
+/// Deletion state stays on `TranscriptView`; this view calls back via the
+/// `requestDeletion` closure. Selection is threaded via
+/// `Binding<UUID?>` derived from `appState.selectedTranscriptID`.
+///
+/// Pixel-preserving: the sidebar layout (filter chip stack, custom date
+/// range section, sort menu, session list header, banners) is a byte-
+/// verbatim relocation of the pre-#631 code — same column widths,
+/// paddings, spacings, corner radii, and backgrounds.
+struct SessionListSidebar: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var transcriptStore: TranscriptStore
+    @ObservedObject var viewModel: SessionLibraryViewModel
+
+    let requestDeletion: (Set<UUID>) -> Void
+
+    /// Left column: session-library brand + filter chips + custom range.
+    var sidebar: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Session Library")
+                        .font(.title3.weight(.semibold))
+
+                    Text("A durable archive for recorded feedback sessions, summaries, screenshots, and extracted issues.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(SessionLibraryDateFilter.allCases) { filter in
+                        filterButton(for: filter)
+                    }
+                }
+
+                if viewModel.selectedFilter == .customRange {
+                    customRangeSection
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+        }
+        .accessibilityLabel("Session filters")
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    /// Middle column: session-list header + banners + list-or-empty-state.
+    var sessionListColumn: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sessionListHeader
+            storageRecoveryBanner
+            pendingTranscriptionBanner
+
+            if let emptyState = viewModel.emptyState {
+                ContentUnavailableView {
+                    Label(emptyState.title, systemImage: emptyState.systemImage)
+                } description: {
+                    Text(emptyState.description)
+                } actions: {
+                    if emptyState == .noSearchResults {
+                        Button("Clear Search") {
+                            viewModel.searchText = ""
+                        }
+                    } else if viewModel.selectedFilter != .allSessions {
+                        Button("Show All Sessions") {
+                            viewModel.selectedFilter = .allSessions
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(selection: selectionBinding) {
+                    ForEach(viewModel.filteredEntries) { entry in
+                        SessionRow(entry: entry, appState: appState, transcriptStore: transcriptStore)
+                            .tag(Optional(entry.id))
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+                            .listRowBackground(Color.clear)
+                            .contextMenu {
+                                Button("Copy Transcript") {
+                                    appState.selectedTranscriptID = entry.id
+                                    appState.copyDisplayedTranscript()
+                                }
+
+                                Divider()
+
+                                Button("Delete Session", role: .destructive) {
+                                    requestDeletion(Set([entry.id]))
+                                }
+                            }
+                    }
+                }
+                .listStyle(.plain)
+                .accessibilityLabel("Session list")
+            }
+        }
+        .padding(16)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    private var sessionListHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(viewModel.selectedFilter.rawValue)
+                        .font(.title3.weight(.semibold))
+
+                    Text(viewModel.sessionCountSummary)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                sortMenu
+            }
+
+            HStack(spacing: 10) {
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+
+                    TextField("Search title, transcript, or summary", text: $viewModel.searchText)
+                        .textFieldStyle(.plain)
+                        .accessibilityLabel("Search sessions")
+                        .accessibilityIdentifier("session-library-search-field")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                if !viewModel.searchText.isEmpty {
+                    Button("Clear") {
+                        viewModel.searchText = ""
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityLabel("Clear search")
+                }
+
+                Button(role: .destructive) {
+                    requestDeletion(viewModel.selectedSession.map { Set([$0.id]) } ?? [])
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+                .disabled(viewModel.selectedSession == nil)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pendingTranscriptionBanner: some View {
+        if transcriptStore.pendingTranscriptionSessionCount > 0 {
+            PendingTranscriptionBanner(
+                count: transcriptStore.pendingTranscriptionSessionCount,
+                requiresProviderSetup: appState.needsAPIKeySetup,
+                provider: appState.settingsStore.aiProvider,
+                openLatest: viewModel.openLatestPendingTranscriptionSession,
+                openSettings: appState.openSettings
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var storageRecoveryBanner: some View {
+        if let message = appState.storageRecoveryMessage {
+            StorageRecoveryBanner(message: message)
+        }
+    }
+
+    private var sortMenu: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            Text("Sort")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Menu {
+                ForEach(SessionLibrarySortOrder.allCases) { order in
+                    Button {
+                        viewModel.sortOrder = order
+                    } label: {
+                        if order == viewModel.sortOrder {
+                            Label(order.rawValue, systemImage: "checkmark")
+                        } else {
+                            Text(order.rawValue)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(viewModel.sortOrder.rawValue)
+                        .lineLimit(1)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .font(.subheadline.weight(.medium))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityLabel("Sort sessions")
+            .accessibilityValue(viewModel.sortOrder.rawValue)
+        }
+    }
+
+    private var customRangeSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Custom Date Range")
+                .font(.subheadline.weight(.semibold))
+
+            DatePicker("Start", selection: $viewModel.customStartDate, displayedComponents: .date)
+                .datePickerStyle(.field)
+
+            DatePicker("End", selection: $viewModel.customEndDate, displayedComponents: .date)
+                .datePickerStyle(.field)
+
+            Text("\(viewModel.count(for: .customRange)) sessions in range")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func filterButton(for filter: SessionLibraryDateFilter) -> some View {
+        Button {
+            viewModel.selectedFilter = filter
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: filter.systemImage)
+                    .frame(width: 18)
+                    .foregroundStyle(viewModel.selectedFilter == filter ? Color.accentColor : .secondary)
+
+                Text(filter.rawValue)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                Text("\(viewModel.count(for: filter))")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(viewModel.selectedFilter == filter ? Color.accentColor : .secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        viewModel.selectedFilter == filter
+                            ? Color.accentColor.opacity(0.12)
+                            : Color(nsColor: .separatorColor).opacity(0.18),
+                        in: Capsule()
+                    )
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+                .background(
+                    viewModel.selectedFilter == filter
+                    ? Color.accentColor.opacity(0.09)
+                    : .clear,
+                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(filter.rawValue)
+        .accessibilityValue("\(viewModel.count(for: filter)) sessions")
+        .accessibilityHint(viewModel.selectedFilter == filter ? "Current session filter." : "Filters the session list.")
+        .accessibilityAddTraits(viewModel.selectedFilter == filter ? .isSelected : [])
+    }
+
+    private var selectionBinding: Binding<UUID?> {
+        Binding(
+            get: { appState.selectedTranscriptID },
+            set: { appState.selectedTranscriptID = $0 }
+        )
+    }
+
+    var body: some View {
+        EmptyView()
+    }
+}

--- a/Sources/BugNarrator/Views/TranscriptView.swift
+++ b/Sources/BugNarrator/Views/TranscriptView.swift
@@ -6,25 +6,45 @@ struct TranscriptView: View {
     @ObservedObject var recordingTimer: RecordingTimerViewModel
     @ObservedObject var transcriptStore: TranscriptStore
 
+    @StateObject private var libraryVM: SessionLibraryViewModel
+
     @State private var exportErrorMessage: String?
     @State private var pendingDeletionIDs: Set<UUID> = []
     @State private var showDeletionConfirmation = false
-    @State private var searchText = ""
-    @State private var sortOrder: SessionLibrarySortOrder = .newestFirst
-    @State private var selectedFilter: SessionLibraryDateFilter = .today
-    @State private var customStartDate = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
-    @State private var customEndDate = Date()
-    @State private var hasResolvedInitialFilter = false
 
     private let exporter = TranscriptExporter()
-    private let calendar = Calendar.current
+
+    init(
+        appState: AppState,
+        recordingTimer: RecordingTimerViewModel,
+        transcriptStore: TranscriptStore
+    ) {
+        self.appState = appState
+        self.recordingTimer = recordingTimer
+        self.transcriptStore = transcriptStore
+        _libraryVM = StateObject(
+            wrappedValue: SessionLibraryViewModel(
+                appState: appState,
+                transcriptStore: transcriptStore
+            )
+        )
+    }
+
+    private var sidebarView: SessionListSidebar {
+        SessionListSidebar(
+            appState: appState,
+            transcriptStore: transcriptStore,
+            viewModel: libraryVM,
+            requestDeletion: { requestDeletion(for: $0) }
+        )
+    }
 
     var body: some View {
         NavigationSplitView {
-            sidebar
+            sidebarView.sidebar
                 .navigationSplitViewColumnWidth(min: 210, ideal: 232, max: 260)
         } content: {
-            sessionListColumn
+            sidebarView.sessionListColumn
                 .navigationSplitViewColumnWidth(min: 300, ideal: 360, max: 420)
         } detail: {
             detailPane
@@ -34,11 +54,11 @@ struct TranscriptView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button(role: .destructive) {
-                    requestDeletion(for: selectedSession.map { Set([$0.id]) } ?? [])
+                    requestDeletion(for: libraryVM.selectedSession.map { Set([$0.id]) } ?? [])
                 } label: {
                     Label("Delete Session", systemImage: "trash")
                 }
-                .disabled(selectedSession == nil)
+                .disabled(libraryVM.selectedSession == nil)
             }
         }
         .alert(deletionAlertTitle, isPresented: $showDeletionConfirmation) {
@@ -65,123 +85,42 @@ struct TranscriptView: View {
             exportReviewSheet(review)
         }
         .onAppear {
-            resolveInitialFilterIfNeeded()
-            syncSelection()
+            libraryVM.resolveInitialFilterIfNeeded()
+            libraryVM.syncSelection()
             Task {
                 await appState.refreshExportHistory()
             }
         }
-        .onChange(of: selectedFilter) { _, _ in
-            syncSelection()
+        .onChange(of: libraryVM.selectedFilter) { _, _ in
+            libraryVM.syncSelection()
         }
-        .onChange(of: searchText) { _, _ in
-            syncSelection()
+        .onChange(of: libraryVM.searchText) { _, _ in
+            libraryVM.syncSelection()
         }
-        .onChange(of: sortOrder) { _, _ in
-            syncSelection()
+        .onChange(of: libraryVM.sortOrder) { _, _ in
+            libraryVM.syncSelection()
         }
-        .onChange(of: customStartDate) { _, _ in
-            selectedFilter = .customRange
-            syncSelection()
+        .onChange(of: libraryVM.customStartDate) { _, _ in
+            libraryVM.selectedFilter = .customRange
+            libraryVM.syncSelection()
         }
-        .onChange(of: customEndDate) { _, _ in
-            selectedFilter = .customRange
-            syncSelection()
+        .onChange(of: libraryVM.customEndDate) { _, _ in
+            libraryVM.selectedFilter = .customRange
+            libraryVM.syncSelection()
         }
-        .onChange(of: sessionIDSignature) { _, _ in
-            resolveInitialFilterIfNeeded()
-            syncSelection()
+        .onChange(of: libraryVM.sessionIDSignature) { _, _ in
+            libraryVM.resolveInitialFilterIfNeeded()
+            libraryVM.syncSelection()
         }
     }
 
-    private var sidebar: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Session Library")
-                        .font(.title3.weight(.semibold))
 
-                    Text("A durable archive for recorded feedback sessions, summaries, screenshots, and extracted issues.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    ForEach(SessionLibraryDateFilter.allCases) { filter in
-                        filterButton(for: filter)
-                    }
-                }
-
-                if selectedFilter == .customRange {
-                    customRangeSection
-                }
-
-                Spacer(minLength: 0)
-            }
-            .padding(16)
-        }
-        .accessibilityLabel("Session filters")
-        .background(Color(nsColor: .windowBackgroundColor))
-    }
-
-    private var sessionListColumn: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sessionListHeader
-            storageRecoveryBanner
-            pendingTranscriptionBanner
-
-            if let emptyState {
-                ContentUnavailableView {
-                    Label(emptyState.title, systemImage: emptyState.systemImage)
-                } description: {
-                    Text(emptyState.description)
-                } actions: {
-                    if emptyState == .noSearchResults {
-                        Button("Clear Search") {
-                            searchText = ""
-                        }
-                    } else if selectedFilter != .allSessions {
-                        Button("Show All Sessions") {
-                            selectedFilter = .allSessions
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                List(selection: selectionBinding) {
-                    ForEach(filteredEntries) { entry in
-                        SessionRow(entry: entry, appState: appState, transcriptStore: transcriptStore)
-                            .tag(Optional(entry.id))
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
-                            .listRowBackground(Color.clear)
-                            .contextMenu {
-                                Button("Copy Transcript") {
-                                    appState.selectedTranscriptID = entry.id
-                                    appState.copyDisplayedTranscript()
-                                }
-
-                                Divider()
-
-                                Button("Delete Session", role: .destructive) {
-                                    requestDeletion(for: Set([entry.id]))
-                                }
-                            }
-                    }
-                }
-                .listStyle(.plain)
-                .accessibilityLabel("Session list")
-            }
-        }
-        .padding(16)
-        .background(Color(nsColor: .controlBackgroundColor))
-    }
 
     private var detailPane: some View {
         Group {
-            if let selectedSession {
+            if let selectedSession = libraryVM.selectedSession {
                 transcriptDetail(for: selectedSession)
-            } else if allSessions.isEmpty, appState.needsAPIKeySetup {
+            } else if libraryVM.allSessions.isEmpty, appState.needsAPIKeySetup {
                 ContentUnavailableView {
                     Label(emptyLibrarySetupTitle, systemImage: emptyLibrarySetupSymbol)
                 } description: {
@@ -191,7 +130,7 @@ struct TranscriptView: View {
                         appState.openSettings()
                     }
                 }
-            } else if allSessions.isEmpty {
+            } else if libraryVM.allSessions.isEmpty {
                 ContentUnavailableView {
                     Label("No sessions yet", systemImage: "waveform")
                 } description: {
@@ -201,7 +140,7 @@ struct TranscriptView: View {
                         appState.openRecordingControls()
                     }
                 }
-            } else if let emptyState {
+            } else if let emptyState = libraryVM.emptyState {
                 ContentUnavailableView {
                     Label(emptyState.title, systemImage: emptyState.systemImage)
                 } description: {
@@ -218,184 +157,12 @@ struct TranscriptView: View {
         .background(Color(nsColor: .textBackgroundColor))
     }
 
-    private var sessionListHeader: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(selectedFilter.rawValue)
-                        .font(.title3.weight(.semibold))
 
-                    Text(sessionCountSummary)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
 
-                Spacer()
 
-                sortMenu
-            }
 
-            HStack(spacing: 10) {
-                HStack(spacing: 6) {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
 
-                    TextField("Search title, transcript, or summary", text: $searchText)
-                        .textFieldStyle(.plain)
-                        .accessibilityLabel("Search sessions")
-                        .accessibilityIdentifier("session-library-search-field")
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
 
-                if !searchText.isEmpty {
-                    Button("Clear") {
-                        searchText = ""
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .accessibilityLabel("Clear search")
-                }
-
-                Button(role: .destructive) {
-                    requestDeletion(for: selectedSession.map { Set([$0.id]) } ?? [])
-                } label: {
-                    Label("Delete", systemImage: "trash")
-                }
-                .disabled(selectedSession == nil)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var pendingTranscriptionBanner: some View {
-        if transcriptStore.pendingTranscriptionSessionCount > 0 {
-            PendingTranscriptionBanner(
-                count: transcriptStore.pendingTranscriptionSessionCount,
-                requiresProviderSetup: appState.needsAPIKeySetup,
-                provider: appState.settingsStore.aiProvider,
-                openLatest: openLatestPendingTranscriptionSession,
-                openSettings: appState.openSettings
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var storageRecoveryBanner: some View {
-        if let message = appState.storageRecoveryMessage {
-            StorageRecoveryBanner(message: message)
-        }
-    }
-
-    private var sortMenu: some View {
-        VStack(alignment: .trailing, spacing: 6) {
-            Text("Sort")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Menu {
-                ForEach(SessionLibrarySortOrder.allCases) { order in
-                    Button {
-                        sortOrder = order
-                    } label: {
-                        if order == sortOrder {
-                            Label(order.rawValue, systemImage: "checkmark")
-                        } else {
-                            Text(order.rawValue)
-                        }
-                    }
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    Text(sortOrder.rawValue)
-                        .lineLimit(1)
-
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .font(.subheadline.weight(.medium))
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize(horizontal: true, vertical: false)
-            .accessibilityLabel("Sort sessions")
-            .accessibilityValue(sortOrder.rawValue)
-        }
-    }
-
-    private var customRangeSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Custom Date Range")
-                .font(.subheadline.weight(.semibold))
-
-            DatePicker("Start", selection: $customStartDate, displayedComponents: .date)
-                .datePickerStyle(.field)
-
-            DatePicker("End", selection: $customEndDate, displayedComponents: .date)
-                .datePickerStyle(.field)
-
-            Text("\(count(for: .customRange)) sessions in range")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-        }
-        .padding(12)
-        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
-
-    private func filterButton(for filter: SessionLibraryDateFilter) -> some View {
-        Button {
-            selectedFilter = filter
-        } label: {
-            HStack(spacing: 10) {
-                Image(systemName: filter.systemImage)
-                    .frame(width: 18)
-                    .foregroundStyle(selectedFilter == filter ? Color.accentColor : .secondary)
-
-                Text(filter.rawValue)
-                    .foregroundStyle(.primary)
-
-                Spacer()
-
-                Text("\(count(for: filter))")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(selectedFilter == filter ? Color.accentColor : .secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        selectedFilter == filter
-                            ? Color.accentColor.opacity(0.12)
-                            : Color(nsColor: .separatorColor).opacity(0.18),
-                        in: Capsule()
-                    )
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-                .background(
-                    selectedFilter == filter
-                    ? Color.accentColor.opacity(0.09)
-                    : .clear,
-                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-            )
-        }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(filter.rawValue)
-        .accessibilityValue("\(count(for: filter)) sessions")
-        .accessibilityHint(selectedFilter == filter ? "Current session filter." : "Filters the session list.")
-        .accessibilityAddTraits(selectedFilter == filter ? .isSelected : [])
-    }
-
-    private var selectionBinding: Binding<UUID?> {
-        Binding(
-            get: { appState.selectedTranscriptID },
-            set: { appState.selectedTranscriptID = $0 }
-        )
-    }
 
     private var exportErrorBinding: Binding<Bool> {
         Binding(
@@ -419,101 +186,21 @@ struct TranscriptView: View {
         )
     }
 
-    private var allSessions: [TranscriptSession] {
-        var sessions = transcriptStore.sessions
 
-        if let currentTranscript = appState.currentTranscript {
-            if let existingIndex = sessions.firstIndex(where: { $0.id == currentTranscript.id }) {
-                sessions[existingIndex] = currentTranscript
-            } else if !appState.currentTranscriptIsPersisted {
-                sessions.insert(currentTranscript, at: 0)
-            }
-        }
 
-        return sessions
-    }
 
-    private var allSessionEntries: [SessionLibraryEntry] {
-        var entries = transcriptStore.libraryEntries
 
-        if let currentTranscript = appState.currentTranscript {
-            let entry = SessionLibraryEntry(session: currentTranscript)
-            if let existingIndex = entries.firstIndex(where: { $0.id == currentTranscript.id }) {
-                entries[existingIndex] = entry
-            } else if !appState.currentTranscriptIsPersisted {
-                entries.insert(entry, at: 0)
-            }
-        }
 
-        return entries
-    }
 
-    private var query: SessionLibraryQuery {
-        SessionLibraryQuery(
-            filter: selectedFilter,
-            customDateRange: SessionLibraryDateRange(startDate: customStartDate, endDate: customEndDate),
-            searchText: searchText,
-            sortOrder: sortOrder
-        )
-    }
 
-    private var librarySnapshot: SessionLibrarySnapshot<SessionLibraryEntry> {
-        SessionLibrary.snapshot(
-            from: allSessionEntries,
-            query: query,
-            calendar: calendar
-        )
-    }
 
-    private var filteredEntries: [SessionLibraryEntry] {
-        librarySnapshot.filteredItems
-    }
-
-    private var selectedSession: TranscriptSession? {
-        guard let selectedTranscriptID = appState.selectedTranscriptID else {
-            return filteredEntries.first.flatMap(resolveSession(for:))
-        }
-
-        guard let selectedEntry = filteredEntries.first(where: { $0.id == selectedTranscriptID }) else {
-            return filteredEntries.first.flatMap(resolveSession(for:))
-        }
-
-        return resolveSession(for: selectedEntry)
-    }
-
-    private var emptyState: SessionLibraryEmptyState? {
-        librarySnapshot.emptyState
-    }
-
-    private var sessionCountSummary: String {
-        let count = filteredEntries.count
-        let pendingRetryCount = transcriptStore.pendingTranscriptionSessionCount
-        let pendingRetrySuffix: String
-        if pendingRetryCount > 0 {
-            pendingRetrySuffix = pendingRetryCount == 1
-                ? " • 1 needs retry"
-                : " • \(pendingRetryCount) need retry"
-        } else {
-            pendingRetrySuffix = ""
-        }
-
-        if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return (count == 1 ? "1 session" : "\(count) sessions") + pendingRetrySuffix
-        }
-
-        return (count == 1 ? "1 result for “\(searchText)”" : "\(count) results for “\(searchText)”") + pendingRetrySuffix
-    }
-
-    private var sessionIDSignature: String {
-        allSessionEntries.map(\.id.uuidString).joined(separator: "|")
-    }
 
     private var deletionAlertTitle: String {
         pendingDeletionIDs.count == 1 ? "Delete Session?" : "Delete \(pendingDeletionIDs.count) Sessions?"
     }
 
     private var deletionAlertMessage: String {
-        let targetSessions = allSessions.filter { pendingDeletionIDs.contains($0.id) }
+        let targetSessions = libraryVM.allSessions.filter { pendingDeletionIDs.contains($0.id) }
         let screenshotCount = targetSessions.reduce(0) { partialResult, session in
             partialResult + session.screenshotCount
         }
@@ -525,43 +212,8 @@ struct TranscriptView: View {
         return "This permanently removes the selected session from BugNarrator."
     }
 
-    private func count(for filter: SessionLibraryDateFilter) -> Int {
-        librarySnapshot.counts[filter] ?? 0
-    }
 
-    private func resolveInitialFilterIfNeeded() {
-        guard !hasResolvedInitialFilter else {
-            return
-        }
 
-        hasResolvedInitialFilter = true
-        if count(for: .today) == 0, count(for: .retryNeeded) > 0 {
-            selectedFilter = .retryNeeded
-        } else if count(for: .today) == 0, !allSessionEntries.isEmpty {
-            selectedFilter = .allSessions
-        }
-    }
-
-    private func syncSelection() {
-        guard !filteredEntries.isEmpty else {
-            appState.selectedTranscriptID = nil
-            return
-        }
-
-        if let selectedTranscriptID = appState.selectedTranscriptID,
-           filteredEntries.contains(where: { $0.id == selectedTranscriptID }) {
-            return
-        }
-
-        appState.selectedTranscriptID = filteredEntries.first?.id
-    }
-
-    private func openLatestPendingTranscriptionSession() {
-        selectedFilter = .retryNeeded
-        searchText = ""
-        appState.selectedTranscriptID = transcriptStore.latestPendingTranscriptionSession?.id
-        syncSelection()
-    }
 
     private func requestDeletion(for ids: Set<UUID>) {
         guard !ids.isEmpty else {


### PR DESCRIPTION
Final slice of #401. Introduces SessionLibraryViewModel (A1 pattern from Round 88 design sketch) and SessionListSidebar view struct.

## Line-count delta

| File | Before | After | Δ |
|---|---|---|---|
| TranscriptView.swift | 1643 | 1291 | **-352** |
| SessionLibraryViewModel.swift (new) | — | 170 | +170 |
| SessionListSidebar.swift (new) | — | 283 | +283 |

## Test plan

- [x] xcodebuild build succeeds
- [x] All unit tests pass
- [ ] Manual smoke: sidebar filter chips, search field, sort menu, custom date range, delete flows

Closes #631.
Closes #401.