### PR TITLE
refactor: extract SettingsStore+AIProviderReadiness (#901, #636 slice H)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		69F0F76E67B312F356DE7354 /* AppState+PermissionRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CFBCD444BCD3791FE18E77 /* AppState+PermissionRecovery.swift */; };
 		6AC08ACF1118EF6BDAD2E6BA /* DiagnosticsRedactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A78A37219AC79F3307E725 /* DiagnosticsRedactor.swift */; };
 		6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */; };
+		F6B01190AA49977C439FC822 /* SettingsStore+AIProviderReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D05C89386A230A631F0630 /* SettingsStore+AIProviderReadiness.swift */; };
 		6B52833F68E7F99EE7D2FE07 /* AppState+IssueExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AF40FCECF7DCEDABD21EC8 /* AppState+IssueExtraction.swift */; };
 		6BFC55DEB2DE0973549D42C9 /* TranscriptRecoveryAndHistoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F08F18E004924B592F24DC /* TranscriptRecoveryAndHistoryViews.swift */; };
 		6D4BF7BD49B33FC81FB5B4D5 /* SessionArtifactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5530F00F9B6ABE2F8E52B8 /* SessionArtifactsService.swift */; };
@@ -557,6 +558,7 @@
 		8CC43602AE7048F7313E7DF6 /* PendingTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTranscription.swift; sourceTree = "<group>"; };
 		8D4748B8137EC364C1FD89B9 /* SettingsViewComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewComponents.swift; sourceTree = "<group>"; };
 		8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+Tokens.swift"; sourceTree = "<group>"; };
+		71D05C89386A230A631F0630 /* SettingsStore+AIProviderReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+AIProviderReadiness.swift"; sourceTree = "<group>"; };
 		8DBC77AC70873AF0E20A29D8 /* IssueExtractionRequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExtractionRequestBuilderTests.swift; sourceTree = "<group>"; };
 		8E2A6DBFC267AEED543EC2DB /* TranscriptQualityInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptQualityInspectorTests.swift; sourceTree = "<group>"; };
 		8FB75074747EE722764CC071 /* IssueExportPresenters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportPresenters.swift; sourceTree = "<group>"; };
@@ -1022,6 +1024,7 @@
 				140D8ACAC9A9E1AE17181482 /* SettingsStore+Normalization.swift */,
 				A704652028D5FF7C005F44C4 /* SettingsStore+Placeholders.swift */,
 				8D5B6E9398A95C990BE9550A /* SettingsStore+Tokens.swift */,
+				71D05C89386A230A631F0630 /* SettingsStore+AIProviderReadiness.swift */,
 				0DB98E3B2E52CC5AC4BBBE84 /* SettingsStore+TranscriptionInput.swift */,
 				1EBF2173AAF872E97F8645F4 /* SimilarIssueReviewService.swift */,
 				EECE1E25C090853C38690595 /* SupportDataController.swift */,
@@ -1551,6 +1554,7 @@
 				A6DB23AB06C7D8F3169B3540 /* SettingsStore+Normalization.swift in Sources */,
 				1AE86CB911DF684680A7D85D /* SettingsStore+Placeholders.swift in Sources */,
 				6AF92F813D8A761809AB90C2 /* SettingsStore+Tokens.swift in Sources */,
+				F6B01190AA49977C439FC822 /* SettingsStore+AIProviderReadiness.swift in Sources */,
 				300699DE1A6404DE829D5BAC /* SettingsStore+TranscriptionInput.swift in Sources */,
 				DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */,
 				134C2EC9233BF9A86E58B933 /* SettingsView.swift in Sources */,

--- a/Sources/BugNarrator/Services/SettingsStore+AIProviderReadiness.swift
+++ b/Sources/BugNarrator/Services/SettingsStore+AIProviderReadiness.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension SettingsStore {
+    var hasAPIKey: Bool {
+        credentialIsAvailableForUserAction(
+            value: trimmedAPIKey,
+            persistenceState: apiKeyPersistenceState
+        )
+    }
+
+    var hasUsableAIProviderCredential: Bool {
+        switch aiProvider {
+        case .openAI:
+            return aiProviderCredentialIsAvailableForCurrentProvider(allowsLegacyOpenAICredential: true)
+        case .openAICompatible:
+            return aiProviderCredentialIsAvailableForCurrentProvider(allowsLegacyOpenAICredential: false)
+        case .localCompatible, .parakeetLocal:
+            return true
+        }
+    }
+
+    var aiProviderConfigurationIsReady: Bool {
+        aiProviderCompatibilityIssue == nil && hasUsableAIProviderCredential
+    }
+
+    var aiProviderCompatibilityIssue: String? {
+        switch aiProvider {
+        case .openAI:
+            return nil
+        case .openAICompatible:
+            let trimmedBaseURL = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedBaseURL.isEmpty {
+                return "Choose a non-default API base URL for the OpenAI-Compatible provider."
+            }
+            return nil
+        case .localCompatible:
+            if preferredModelValue == "whisper-1" {
+                return "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider."
+            }
+            if issueExtractionModelValue == "gpt-4.1-mini" {
+                return "Choose a local issue extraction model instead of gpt-4.1-mini for the Local-Compatible provider."
+            }
+            return nil
+        case .parakeetLocal:
+            if autoExtractIssues {
+                return "Turn off automatic issue extraction or choose a provider with a chat completion model."
+            }
+            return nil
+        }
+    }
+}

--- a/Sources/BugNarrator/Services/SettingsStore.swift
+++ b/Sources/BugNarrator/Services/SettingsStore.swift
@@ -512,54 +512,6 @@ final class SettingsStore: ObservableObject {
 
 
 
-    var hasAPIKey: Bool {
-        credentialIsAvailableForUserAction(
-            value: trimmedAPIKey,
-            persistenceState: apiKeyPersistenceState
-        )
-    }
-
-    var hasUsableAIProviderCredential: Bool {
-        switch aiProvider {
-        case .openAI:
-            return aiProviderCredentialIsAvailableForCurrentProvider(allowsLegacyOpenAICredential: true)
-        case .openAICompatible:
-            return aiProviderCredentialIsAvailableForCurrentProvider(allowsLegacyOpenAICredential: false)
-        case .localCompatible, .parakeetLocal:
-            return true
-        }
-    }
-
-    var aiProviderConfigurationIsReady: Bool {
-        aiProviderCompatibilityIssue == nil && hasUsableAIProviderCredential
-    }
-
-    var aiProviderCompatibilityIssue: String? {
-        switch aiProvider {
-        case .openAI:
-            return nil
-        case .openAICompatible:
-            let trimmedBaseURL = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedBaseURL.isEmpty {
-                return "Choose a non-default API base URL for the OpenAI-Compatible provider."
-            }
-            return nil
-        case .localCompatible:
-            if preferredModelValue == "whisper-1" {
-                return "Choose a local transcription model instead of whisper-1 for the Local-Compatible provider."
-            }
-            if issueExtractionModelValue == "gpt-4.1-mini" {
-                return "Choose a local issue extraction model instead of gpt-4.1-mini for the Local-Compatible provider."
-            }
-            return nil
-        case .parakeetLocal:
-            if autoExtractIssues {
-                return "Turn off automatic issue extraction or choose a provider with a chat completion model."
-            }
-            return nil
-        }
-    }
-
     func aiProviderCredentialForUserInitiatedAccess() -> String? {
         switch aiProvider {
         case .openAI:
@@ -1401,7 +1353,7 @@ final class SettingsStore: ObservableObject {
         persistenceState(for: slot) == .pendingSave
     }
 
-    private func credentialIsAvailableForUserAction(
+    func credentialIsAvailableForUserAction(
         value: String,
         persistenceState: APIKeyPersistenceState
     ) -> Bool {
@@ -1425,7 +1377,7 @@ final class SettingsStore: ObservableObject {
         return AIProvider(rawValue: rawValue)
     }
 
-    private func aiProviderCredentialIsAvailableForCurrentProvider(
+    func aiProviderCredentialIsAvailableForCurrentProvider(
         allowsLegacyOpenAICredential: Bool
     ) -> Bool {
         if hasPendingSecretChanges(for: .openAI) {


### PR DESCRIPTION
## Summary

Continue #636 SettingsStore decomposition. Move 4 AIProvider readiness computed properties from `SettingsStore.swift` (1,625 lines) into a new focused extension `SettingsStore+AIProviderReadiness.swift`:

- `hasAPIKey`
- `hasUsableAIProviderCredential`
- `aiProviderConfigurationIsReady`
- `aiProviderCompatibilityIssue`

Byte-preserving property bodies. Base file drops to ~1,580 lines.

## Widening

Two private helpers must widen to internal (unchanged bodies) so the new extension can reach them:

- `credentialIsAvailableForUserAction(value:persistenceState:)` (line 1404 → 1356 after removal)
- `aiProviderCredentialIsAvailableForCurrentProvider(allowsLegacyOpenAICredential:)` (line 1428 → 1380 after removal)

## Test plan

- [x] Local swift-parse-check.sh: PASS (229 files)
- [ ] CI macos-runner build+test

Closes #901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)