### PR TITLE
docs: stop telling users to bypass Gatekeeper on a notarized build (#909)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Important:
 7. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
 8. If you try to launch BugNarrator a second time, macOS should bring the existing BugNarrator instance forward instead of opening another menu bar copy.
 
-Released BugNarrator builds are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS opens them without a Gatekeeper prompt.
+BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS should open them without a Gatekeeper prompt. If macOS does warn about a download, do not bypass the warning — verify the DMG against the published `.sha256` checksum and [report it](https://github.com/ABD-Enterprises/bug-narrator/issues/new).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ Important:
 2. Open the DMG. It should present a drag-to-Applications install window.
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
-5. If Gatekeeper warns about the app, open `Applications`, Control-click `BugNarrator.app`, choose `Open`, then confirm once.
-6. On first run, expect AI provider setup. Microphone permission is requested the first time you try to start recording.
-7. If you use screenshot capture, expect Screen Recording permission on first use.
-8. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
-9. If you try to launch BugNarrator a second time, macOS should bring the existing BugNarrator instance forward instead of opening another menu bar copy.
+5. On first run, expect AI provider setup. Microphone permission is requested the first time you try to start recording.
+6. If you use screenshot capture, expect Screen Recording permission on first use.
+7. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
+8. If you try to launch BugNarrator a second time, macOS should bring the existing BugNarrator instance forward instead of opening another menu bar copy.
+
+Released BugNarrator builds are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS opens them without a Gatekeeper prompt.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Important:
 7. If a permission is denied, use the recovery buttons in the menu bar window to reopen the correct System Settings pane.
 8. If you try to launch BugNarrator a second time, macOS should bring the existing BugNarrator instance forward instead of opening another menu bar copy.
 
-BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS should open them without a Gatekeeper prompt. If macOS does warn about a download, do not bypass the warning — verify the DMG against the published `.sha256` checksum and [report it](https://github.com/ABD-Enterprises/bug-narrator/issues/new).
+BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS will not show the "unidentified developer" warning. A first launch of any downloaded app still shows the standard one-time "downloaded from the Internet" confirmation. If macOS reports an unidentified developer, do not bypass it — verify the DMG against the published `.sha256` checksum and report it.
 
 ## Quick Start
 

--- a/contract/archive/909.json
+++ b/contract/archive/909.json
@@ -1,0 +1,78 @@
+{
+  "schema": "orc.contract-archive.v1",
+  "ticket": "909",
+  "provenance": {
+    "pr": null,
+    "head_sha": null,
+    "done_when_total": 4,
+    "machine_backed": 0,
+    "checks": 0,
+    "satisfied": 0,
+    "class_counts": {
+      "machine_check": 0,
+      "human_evidence": 0,
+      "explicitly_self_attested": 4
+    },
+    "classified_ratio": 0,
+    "clauses": [
+      {
+        "index": 1,
+        "text": "The Control-click/Gatekeeper-bypass step is removed from README.md install instructions and surrounding steps are renumbered.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 2,
+        "text": "A positive trust statement replaces it, naming Developer ID + notarization and Team ID 2R4WAH4R53.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 3,
+        "text": "No other tracked doc instructs a Gatekeeper bypass (grep for 'Control-click' and 'Gatekeeper').",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 4,
+        "text": "No source files are modified - docs-only change.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      }
+    ]
+  },
+  "contract": {
+    "scope": [
+      "README.md",
+      "docs/user/user-manual.md",
+      "QUICKSTART.md"
+    ],
+    "depends_on": [],
+    "done_when": [
+      "The Control-click/Gatekeeper-bypass step is removed from README.md install instructions and surrounding steps are renumbered.",
+      "A positive trust statement replaces it, naming Developer ID + notarization and Team ID 2R4WAH4R53.",
+      "No other tracked doc instructs a Gatekeeper bypass (grep for 'Control-click' and 'Gatekeeper').",
+      "No source files are modified - docs-only change."
+    ],
+    "validation": {
+      "local": [
+        "./scripts/validate.sh origin/main"
+      ]
+    },
+    "references": [
+      "Found by 3-model gap analysis 2026-08-01; notarization verified empirically against the published v1.0.40 DMG."
+    ],
+    "acceptance_criteria": [
+      "A first-time reader is never told to bypass Gatekeeper.",
+      "Docs-only diff."
+    ]
+  }
+}

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -36,7 +36,7 @@ It helps you:
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
 
-Released builds are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS opens them without a Gatekeeper prompt.
+BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS should open them without a Gatekeeper prompt. If macOS does warn about a download, do not bypass the warning — verify the DMG against the published `.sha256` checksum and report it.
 
 ### macOS Requirements
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -35,7 +35,8 @@ It helps you:
 2. Open the downloaded DMG.
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
-5. If macOS shows a Gatekeeper warning, use Finder and choose `Open` for the app you trust.
+
+Released builds are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS opens them without a Gatekeeper prompt.
 
 ### macOS Requirements
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -36,7 +36,7 @@ It helps you:
 3. Drag `BugNarrator.app` into `Applications`.
 4. Launch BugNarrator from `Applications`.
 
-BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS should open them without a Gatekeeper prompt. If macOS does warn about a download, do not bypass the warning — verify the DMG against the published `.sha256` checksum and report it.
+BugNarrator releases are signed with a `Developer ID Application` certificate (Team ID `2R4WAH4R53`), notarized by Apple, and stapled, so macOS will not show the "unidentified developer" warning. A first launch of any downloaded app still shows the standard one-time "downloaded from the Internet" confirmation. If macOS reports an unidentified developer, do not bypass it — verify the DMG against the published `.sha256` checksum and report it.
 
 ### macOS Requirements
 


### PR DESCRIPTION
## Summary

`README.md:85` and `docs/UserGuide.md:38` told new users to Control-click past a Gatekeeper warning. **Released builds do not produce one.**

Verified empirically against the published v1.0.40 asset on 2026-08-01:

```
spctl -a -vv BugNarrator.app
  accepted
  source=Notarized Developer ID
  origin=Developer ID Application: ABD Enterprises, Inc. (2R4WAH4R53)
xcrun stapler validate BugNarrator.app -> The validate action worked!
```

The instruction fired at the point of maximum installer doubt and signalled "unsigned app" while the build is correctly signed, notarized, and stapled. Replaced with a positive trust statement naming the signing team.

## Scope

Docs only. Maintainer-facing Gatekeeper references in `docs/Distribution.md`, `docs/operations/rollback.md`, and `docs/testing/testing.md` are untouched — they describe the signing process itself, not an install workaround.

## Test plan

- [x] `scripts/validate.sh origin/main` — exit 0; semgrep PASS (no scannable changes), swift-parse PASS (230 files)
- [x] `grep` confirms no user-facing bypass instruction remains in README / UserGuide / QUICKSTART
- [x] No source files modified

Found by a three-model gap analysis (Claude + Codex + antigravity, run blind). Closes #909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)