### PR TITLE
fix: open Settings on AI Engines when no provider credential exists (#911)

### DIFF
--- a/BugNarrator.xcodeproj/project.pbxproj
+++ b/BugNarrator.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		DABA5D4856C56172E1DFB2FF /* RetryPostTranscriptionResultHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EEE520F730E7A4C0B32FE9 /* RetryPostTranscriptionResultHandlerTests.swift */; };
 		DB44B00A8FFA358E3239DA48 /* RecordingAudioSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A79F0CD44463306F35C431 /* RecordingAudioSourceTests.swift */; };
 		DBED32896E81F9C7422A48BC /* SettingsStoreDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72FED1F76E79D004AD1CF56 /* SettingsStoreDisplayTests.swift */; };
+		2988E45A4C168B754232D272 /* SettingsViewInitialSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECA0C00ADA2B693EC45DC24 /* SettingsViewInitialSectionTests.swift */; };
 		DBFA5905D305404FAD17EC5E /* TrackerExportRetryTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74431871C8CB4E2F62C82213 /* TrackerExportRetryTypes.swift */; };
 		DC0465161F26D6650C80F1CF /* ScreenCapturePermissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811ED2635872DFF93EFE0DA1 /* ScreenCapturePermissionService.swift */; };
 		DFEC8A8B12366B1CC1ECF429 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED768FCA5D58A5E78F24A8D /* SettingsStore.swift */; };
@@ -611,6 +612,7 @@
 		B486B153518EB9E1BBC08F17 /* AppState+SystemActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+SystemActions.swift"; sourceTree = "<group>"; };
 		B6EBD017E98FB65B2CD27ED3 /* ApplicationTerminationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationTerminationControllerTests.swift; sourceTree = "<group>"; };
 		B72FED1F76E79D004AD1CF56 /* SettingsStoreDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsStoreDisplayTests.swift; sourceTree = "<group>"; };
+		0ECA0C00ADA2B693EC45DC24 /* SettingsViewInitialSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewInitialSectionTests.swift; sourceTree = "<group>"; };
 		BA49B2B79731E3A62B083174 /* IssueExportController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueExportController.swift; sourceTree = "<group>"; };
 		BB14D61549CBA990AB3FECA3 /* TranscriptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStoreTests.swift; sourceTree = "<group>"; };
 		BB29D8D293162593D9A0B296 /* TranscriptExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporter.swift; sourceTree = "<group>"; };
@@ -799,6 +801,7 @@
 				AF86B21036E15ECF52300E09 /* SessionScreenshotTests.swift */,
 				72E40C471334C91DCE931AA9 /* SettingsStoreDisplayMaskTests.swift */,
 				B72FED1F76E79D004AD1CF56 /* SettingsStoreDisplayTests.swift */,
+				0ECA0C00ADA2B693EC45DC24 /* SettingsViewInitialSectionTests.swift */,
 				2DCF18FBCE4EAE1F20EE8C38 /* SettingsStoreNormalizationTests.swift */,
 				06C14D0FD45D1AEF489AEB69 /* SettingsStorePlaceholdersTests.swift */,
 				1ACC8A426CF0E64809970F2A /* SettingsStoreTests.swift */,
@@ -1339,6 +1342,7 @@
 				9619964E0CEE6D5A039340F7 /* SessionScreenshotTests.swift in Sources */,
 				435FE280CAB12DF2C2184BCC /* SettingsStoreDisplayMaskTests.swift in Sources */,
 				DBED32896E81F9C7422A48BC /* SettingsStoreDisplayTests.swift in Sources */,
+				2988E45A4C168B754232D272 /* SettingsViewInitialSectionTests.swift in Sources */,
 				465C1973DFA15D7501AEA274 /* SettingsStoreNormalizationTests.swift in Sources */,
 				BB1F6ABF206D70F310CFC20A /* SettingsStorePlaceholdersTests.swift in Sources */,
 				D8C580D925E807323208366D /* SettingsStoreTests.swift in Sources */,

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -18,8 +18,13 @@ struct SettingsView: View {
     }
 
     /// The section Settings opens on. An install with no usable AI provider
-    /// credential lands on `AI Engines` — the pane it has to visit before
-    /// recording is possible — instead of `General` (#911).
+    /// credential lands on `AI Engines` instead of `General` (#911), because the
+    /// recording gate routes exactly that user here.
+    ///
+    /// Note this keys off credential presence, not full provider readiness:
+    /// `hasUsableAIProviderCredential` returns `true` unconditionally for the
+    /// local providers, which can still fail `aiProviderCompatibilityIssue`.
+    /// Those users keep the existing `General` landing.
     ///
     /// This only seeds the initial selection. Once the window is open the user's
     /// own tab choices are never overridden.

--- a/Sources/BugNarrator/Views/SettingsView.swift
+++ b/Sources/BugNarrator/Views/SettingsView.swift
@@ -5,7 +5,27 @@ struct SettingsView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var settingsStore: SettingsStore
     @State private var showDeleteAllLocalDataConfirmation = false
-    @State private var selectedSection: SettingsSection = .general
+    @State private var selectedSection: SettingsSection
+
+    init(appState: AppState, settingsStore: SettingsStore) {
+        self.appState = appState
+        self.settingsStore = settingsStore
+        _selectedSection = State(
+            initialValue: Self.initialSection(
+                hasUsableAIProviderCredential: settingsStore.hasUsableAIProviderCredential
+            )
+        )
+    }
+
+    /// The section Settings opens on. An install with no usable AI provider
+    /// credential lands on `AI Engines` — the pane it has to visit before
+    /// recording is possible — instead of `General` (#911).
+    ///
+    /// This only seeds the initial selection. Once the window is open the user's
+    /// own tab choices are never overridden.
+    static func initialSection(hasUsableAIProviderCredential: Bool) -> SettingsSection {
+        hasUsableAIProviderCredential ? .general : .aiEngines
+    }
 
     /// The tabbed sections of Settings. A segmented `Picker` drives selection —
     /// macOS `TabView` does not expose addressable tab controls in this window,

--- a/Tests/BugNarratorTests/SettingsViewInitialSectionTests.swift
+++ b/Tests/BugNarratorTests/SettingsViewInitialSectionTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import BugNarrator
+
+/// Covers the Settings landing-pane rule from #911: an install with no usable
+/// AI provider credential opens on `AI Engines` rather than `General`.
+@MainActor
+final class SettingsViewInitialSectionTests: XCTestCase {
+    func testUnconfiguredInstallOpensOnAIEngines() {
+        XCTAssertEqual(
+            SettingsView.initialSection(hasUsableAIProviderCredential: false),
+            .aiEngines,
+            "A user with no usable provider credential is sent to Settings by the recording gate; they must land on the pane that resolves it."
+        )
+    }
+
+    func testConfiguredInstallOpensOnGeneral() {
+        XCTAssertEqual(
+            SettingsView.initialSection(hasUsableAIProviderCredential: true),
+            .general,
+            "Once a provider is configured, Settings keeps its established General landing pane."
+        )
+    }
+}

--- a/Tests/BugNarratorTests/SettingsViewInitialSectionTests.swift
+++ b/Tests/BugNarratorTests/SettingsViewInitialSectionTests.swift
@@ -3,8 +3,16 @@ import XCTest
 
 /// Covers the Settings landing-pane rule from #911: an install with no usable
 /// AI provider credential opens on `AI Engines` rather than `General`.
+///
+/// Two layers on purpose. The first pair pins the pure mapping. The second pair
+/// drives a real `SettingsStore` so the *wiring* is covered too — that
+/// `initialSection` is fed `hasUsableAIProviderCredential` and not some other
+/// readiness signal. A review of the original version noted the pure-function
+/// tests alone would still pass if the init were wired to the wrong input.
 @MainActor
 final class SettingsViewInitialSectionTests: XCTestCase {
+    // MARK: - Pure mapping
+
     func testUnconfiguredInstallOpensOnAIEngines() {
         XCTAssertEqual(
             SettingsView.initialSection(hasUsableAIProviderCredential: false),
@@ -18,6 +26,60 @@ final class SettingsViewInitialSectionTests: XCTestCase {
             SettingsView.initialSection(hasUsableAIProviderCredential: true),
             .general,
             "Once a provider is configured, Settings keeps its established General landing pane."
+        )
+    }
+
+    // MARK: - Wiring against a real SettingsStore
+
+    func testStoreWithNoCredentialResolvesToAIEngines() {
+        let harness = AppStateHarness(apiKey: "")
+        harness.settingsStore.aiProvider = .openAI
+
+        XCTAssertFalse(
+            harness.settingsStore.hasUsableAIProviderCredential,
+            "Precondition: an empty OpenAI key means no usable credential."
+        )
+        XCTAssertEqual(
+            SettingsView.initialSection(
+                hasUsableAIProviderCredential: harness.settingsStore.hasUsableAIProviderCredential
+            ),
+            .aiEngines
+        )
+    }
+
+    func testStoreWithCredentialResolvesToGeneral() {
+        let harness = AppStateHarness(apiKey: "sk-test-123")
+        harness.settingsStore.aiProvider = .openAI
+
+        XCTAssertTrue(
+            harness.settingsStore.hasUsableAIProviderCredential,
+            "Precondition: a present OpenAI key means a usable credential."
+        )
+        XCTAssertEqual(
+            SettingsView.initialSection(
+                hasUsableAIProviderCredential: harness.settingsStore.hasUsableAIProviderCredential
+            ),
+            .general
+        )
+    }
+
+    /// Local providers report `true` unconditionally — they need no credential —
+    /// so they keep the General landing even with an empty key. This pins the
+    /// behavior a review flagged as easy to misread as a bug.
+    func testKeylessLocalProviderKeepsGeneralLanding() {
+        let harness = AppStateHarness(apiKey: "")
+        harness.settingsStore.aiProvider = .parakeetLocal
+
+        XCTAssertTrue(
+            harness.settingsStore.hasUsableAIProviderCredential,
+            "Local (Parakeet) requires no API key, so credential readiness is true even with an empty key."
+        )
+        XCTAssertEqual(
+            SettingsView.initialSection(
+                hasUsableAIProviderCredential: harness.settingsStore.hasUsableAIProviderCredential
+            ),
+            .general,
+            "A keyless local provider was never blocked by a missing credential, so it should not be redirected."
         )
     }
 }

--- a/contract/archive/911.json
+++ b/contract/archive/911.json
@@ -1,0 +1,77 @@
+{
+  "schema": "orc.contract-archive.v1",
+  "ticket": "911",
+  "provenance": {
+    "pr": null,
+    "head_sha": null,
+    "done_when_total": 4,
+    "machine_backed": 0,
+    "checks": 0,
+    "satisfied": 0,
+    "class_counts": {
+      "machine_check": 0,
+      "human_evidence": 0,
+      "explicitly_self_attested": 4
+    },
+    "classified_ratio": 0,
+    "clauses": [
+      {
+        "index": 1,
+        "text": "Settings selects the AI Engines pane on open when hasUsableAIProviderCredential is false.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 2,
+        "text": "Settings selects General on open when a usable provider credential exists (today's behavior preserved).",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 3,
+        "text": "Manual tab selection during a session is never overridden.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 4,
+        "text": "Pane-selection logic is a pure helper with targeted unit tests for both states.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      }
+    ]
+  },
+  "contract": {
+    "scope": [
+      "Sources/BugNarrator/Views/SettingsView.swift"
+    ],
+    "depends_on": [],
+    "done_when": [
+      "Settings selects the AI Engines pane on open when hasUsableAIProviderCredential is false.",
+      "Settings selects General on open when a usable provider credential exists (today's behavior preserved).",
+      "Manual tab selection during a session is never overridden.",
+      "Pane-selection logic is a pure helper with targeted unit tests for both states."
+    ],
+    "validation": {
+      "local": [
+        "./scripts/validate.sh origin/main",
+        "DEVELOPER_DIR=\"${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}\" xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination \"platform=macOS,arch=$(uname -m)\" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- -only-testing:BugNarratorTests test"
+      ]
+    },
+    "references": [
+      "Found by Codex in 3-model gap analysis 2026-08-01."
+    ],
+    "acceptance_criteria": [
+      "Unconfigured user lands where the work is.",
+      "Configured user sees no change."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

The recording gate (`AppState.swift:587`) bounces an unconfigured user into Settings — which opens on **General**. The one pane they must visit to proceed is a tab away and unmarked.

Now: no usable provider credential → Settings opens on **AI Engines**. Configured → **General**, exactly as today.

## Design note

The selection is seeded through a pure static helper called from `init`. Because `@State` initializes once at view construction, this affects only the *landing* pane — a tab the user picks while the window is open is never overridden. That was an explicit `done_when` on the ticket and it falls out of the mechanism rather than needing guard logic.

```swift
static func initialSection(hasUsableAIProviderCredential: Bool) -> SettingsSection {
    hasUsableAIProviderCredential ? .general : .aiEngines
}
```

## Test plan

- [x] New `SettingsViewInitialSectionTests` — both states, **2/2 passed**
- [x] Full unit suite: **723 tests, 0 failures**
- [x] `scripts/validate.sh origin/main` — exit 0
- [x] Test registered in `project.pbxproj` (build + file ref + group + sources phase)

Found by Codex in a three-model gap analysis. Closes #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)