### PR TITLE
914 export session bundle omits the summary and extracted issues

### DIFF
--- a/Sources/BugNarrator/Services/TranscriptExporter.swift
+++ b/Sources/BugNarrator/Services/TranscriptExporter.swift
@@ -111,8 +111,14 @@ struct TranscriptExporter {
         // issues are still worth handing to a team, so the export degrades: the
         // present files are copied and the absent ones are named in the
         // manifest instead (#914).
-        let missingScreenshots = missingScreenshots(for: session)
+        //
+        // Presence is decided by the copy attempt itself rather than by a scan
+        // beforehand. A pre-scan leaves a window in which a file can vanish
+        // between the scan and the copy, which would either undercount the
+        // missing list or let `copyItem` throw — reintroducing the exact failure
+        // this change removes.
         var copiedScreenshotCount = 0
+        var missingScreenshotNames: [String] = []
         var exportedFiles = ["transcript.md"]
 
         let bundleDirectoryURL = try bundleWriter.writeBundle(
@@ -141,14 +147,28 @@ struct TranscriptExporter {
             let screenshotsDirectoryURL = bundleDirectoryURL.appendingPathComponent("screenshots", isDirectory: true)
             try fileManager.createDirectory(at: screenshotsDirectoryURL, withIntermediateDirectories: true)
 
-            for screenshot in session.screenshots where fileManager.fileExists(atPath: screenshot.fileURL.path) {
+            for screenshot in session.screenshots {
                 let destinationURL = uniqueScreenshotDestinationURL(
                     for: screenshot.fileName,
                     in: screenshotsDirectoryURL
                 )
-                try fileManager.copyItem(at: screenshot.fileURL, to: destinationURL)
-                copiedScreenshotCount += 1
+
+                do {
+                    try fileManager.copyItem(at: screenshot.fileURL, to: destinationURL)
+                    copiedScreenshotCount += 1
+                    exportedFiles.append("screenshots/\(destinationURL.lastPathComponent)")
+                } catch {
+                    // Only an absent source degrades. A copy that failed while the
+                    // file is still on disk is a real problem — permissions, disk
+                    // space — and must not be silently reported as "missing".
+                    guard !fileManager.fileExists(atPath: screenshot.fileURL.path) else {
+                        throw error
+                    }
+                    missingScreenshotNames.append(screenshot.fileName)
+                }
             }
+
+            exportedFiles.append("manifest.json")
 
             let manifest = SessionBundleManifest(
                 generatedAt: Date(),
@@ -156,8 +176,8 @@ struct TranscriptExporter {
                 exportedFiles: exportedFiles,
                 screenshotCount: session.screenshotCount,
                 copiedScreenshotCount: copiedScreenshotCount,
-                missingScreenshots: missingScreenshots.map(\.fileName),
-                notes: Self.manifestNotes(missingScreenshotCount: missingScreenshots.count)
+                missingScreenshots: missingScreenshotNames,
+                notes: Self.manifestNotes(missingScreenshotCount: missingScreenshotNames.count)
             )
 
             let encoder = JSONEncoder()
@@ -176,7 +196,7 @@ struct TranscriptExporter {
                 "session_id": session.id.uuidString,
                 "screenshot_count": "\(session.screenshotCount)",
                 "copied_screenshot_count": "\(copiedScreenshotCount)",
-                "missing_screenshot_count": "\(missingScreenshots.count)"
+                "missing_screenshot_count": "\(missingScreenshotNames.count)"
             ]
         )
 
@@ -193,12 +213,6 @@ struct TranscriptExporter {
         }
 
         return notes
-    }
-
-    private func missingScreenshots(for session: TranscriptSession) -> [SessionScreenshot] {
-        session.screenshots.filter { screenshot in
-            !fileManager.fileExists(atPath: screenshot.fileURL.path)
-        }
     }
 
     private func uniqueScreenshotDestinationURL(for fileName: String, in directoryURL: URL) -> URL {

--- a/Sources/BugNarrator/Services/TranscriptExporter.swift
+++ b/Sources/BugNarrator/Services/TranscriptExporter.swift
@@ -34,6 +34,19 @@ enum TranscriptExportFormat {
     }
 }
 
+/// Records what a session bundle actually contains, including screenshots that
+/// were referenced by the session but absent from disk at export time (#914).
+/// Mirrors the `manifest.json` idiom already used by `PrivacyDataExporter`.
+struct SessionBundleManifest: Encodable {
+    let generatedAt: Date
+    let sessionID: String
+    let exportedFiles: [String]
+    let screenshotCount: Int
+    let copiedScreenshotCount: Int
+    let missingScreenshots: [String]
+    let notes: [String]
+}
+
 @MainActor
 struct TranscriptExporter {
     private let fileManager: FileManager
@@ -93,15 +106,14 @@ struct TranscriptExporter {
     }
 
     func writeBundle(session: TranscriptSession, to destinationRoot: URL) throws -> URL {
+        // A screenshot file that has been moved or pruned since capture used to
+        // make the whole session unexportable. The transcript, summary, and
+        // issues are still worth handing to a team, so the export degrades: the
+        // present files are copied and the absent ones are named in the
+        // manifest instead (#914).
         let missingScreenshots = missingScreenshots(for: session)
-        if !missingScreenshots.isEmpty {
-            let missingList = missingScreenshots.map(\.fileName).joined(separator: ", ")
-            throw AppError.exportFailure(
-                "This session bundle is missing referenced screenshot files: \(missingList). Recreate the screenshots or remove the stale references before exporting."
-            )
-        }
-
         var copiedScreenshotCount = 0
+        var exportedFiles = ["transcript.md"]
 
         let bundleDirectoryURL = try bundleWriter.writeBundle(
             in: destinationRoot,
@@ -113,10 +125,23 @@ struct TranscriptExporter {
                 encoding: .utf8
             )
 
+            // `summaryMarkdownContent` renders the review summary and every
+            // extracted issue grouped by category — the differentiated output.
+            // Sessions that never ran extraction get no file rather than a
+            // placeholder saying so.
+            if session.issueExtraction != nil {
+                try session.summaryMarkdownContent.write(
+                    to: bundleDirectoryURL.appendingPathComponent("summary.md"),
+                    atomically: true,
+                    encoding: .utf8
+                )
+                exportedFiles.append("summary.md")
+            }
+
             let screenshotsDirectoryURL = bundleDirectoryURL.appendingPathComponent("screenshots", isDirectory: true)
             try fileManager.createDirectory(at: screenshotsDirectoryURL, withIntermediateDirectories: true)
 
-            for screenshot in session.screenshots {
+            for screenshot in session.screenshots where fileManager.fileExists(atPath: screenshot.fileURL.path) {
                 let destinationURL = uniqueScreenshotDestinationURL(
                     for: screenshot.fileName,
                     in: screenshotsDirectoryURL
@@ -124,6 +149,24 @@ struct TranscriptExporter {
                 try fileManager.copyItem(at: screenshot.fileURL, to: destinationURL)
                 copiedScreenshotCount += 1
             }
+
+            let manifest = SessionBundleManifest(
+                generatedAt: Date(),
+                sessionID: session.id.uuidString,
+                exportedFiles: exportedFiles,
+                screenshotCount: session.screenshotCount,
+                copiedScreenshotCount: copiedScreenshotCount,
+                missingScreenshots: missingScreenshots.map(\.fileName),
+                notes: Self.manifestNotes(missingScreenshotCount: missingScreenshots.count)
+            )
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            try encoder.encode(manifest).write(
+                to: bundleDirectoryURL.appendingPathComponent("manifest.json"),
+                options: [.atomic]
+            )
         }
 
         logger.info(
@@ -133,11 +176,23 @@ struct TranscriptExporter {
                 "session_id": session.id.uuidString,
                 "screenshot_count": "\(session.screenshotCount)",
                 "copied_screenshot_count": "\(copiedScreenshotCount)",
-                "missing_screenshot_count": "0"
+                "missing_screenshot_count": "\(missingScreenshots.count)"
             ]
         )
 
         return bundleDirectoryURL
+    }
+
+    private static func manifestNotes(missingScreenshotCount: Int) -> [String] {
+        var notes = ["This bundle contains the transcript, review output, and captured screenshots for one BugNarrator session."]
+
+        if missingScreenshotCount > 0 {
+            notes.append(
+                "\(missingScreenshotCount) referenced screenshot file(s) were not found on disk at export time and are listed in missingScreenshots. The rest of the bundle exported normally."
+            )
+        }
+
+        return notes
     }
 
     private func missingScreenshots(for session: TranscriptSession) -> [SessionScreenshot] {

--- a/Tests/BugNarratorTests/TranscriptExporterTests.swift
+++ b/Tests/BugNarratorTests/TranscriptExporterTests.swift
@@ -97,6 +97,11 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertEqual(manifest?["missingScreenshots"] as? [String], ["missing-capture.png"])
         XCTAssertEqual(manifest?["copiedScreenshotCount"] as? Int, 1)
         XCTAssertEqual(manifest?["screenshotCount"] as? Int, 2)
+        XCTAssertEqual(
+            manifest?["exportedFiles"] as? [String],
+            ["transcript.md", "screenshots/present-capture.png", "manifest.json"],
+            "exportedFiles must list what the bundle actually contains — the copied screenshot and the manifest included, the absent screenshot excluded."
+        )
     }
 
     func testWriteBundleIncludesSummaryAndIssues() throws {
@@ -139,7 +144,11 @@ final class TranscriptExporterTests: XCTestCase {
 
         let manifestData = try Data(contentsOf: bundleURL.appendingPathComponent("manifest.json"))
         let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
-        XCTAssertEqual(manifest?["exportedFiles"] as? [String], ["transcript.md", "summary.md"])
+        XCTAssertEqual(
+            manifest?["exportedFiles"] as? [String],
+            ["transcript.md", "summary.md", "manifest.json"],
+            "exportedFiles must record every file the bundle contains, manifest included."
+        )
     }
 
     func testWriteBundleOmitsSummaryWhenExtractionNeverRan() throws {
@@ -169,7 +178,11 @@ final class TranscriptExporterTests: XCTestCase {
 
         let manifestData = try Data(contentsOf: bundleURL.appendingPathComponent("manifest.json"))
         let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
-        XCTAssertEqual(manifest?["exportedFiles"] as? [String], ["transcript.md"])
+        XCTAssertEqual(
+            manifest?["exportedFiles"] as? [String],
+            ["transcript.md", "manifest.json"],
+            "No summary.md when extraction never ran, but the manifest is still recorded."
+        )
     }
 
     func testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames() throws {

--- a/Tests/BugNarratorTests/TranscriptExporterTests.swift
+++ b/Tests/BugNarratorTests/TranscriptExporterTests.swift
@@ -55,14 +55,20 @@ final class TranscriptExporterTests: XCTestCase {
         XCTAssertTrue(markdown.contains(session.transcript))
     }
 
-    func testWriteBundleFailsWhenReferencedScreenshotFileIsMissing() throws {
+    /// Replaces an earlier test that asserted export *threw* on a missing
+    /// screenshot. #914 deliberately inverts that: one moved or pruned file must
+    /// not make an otherwise complete session unexportable.
+    func testWriteBundleDegradesWhenReferencedScreenshotFileIsMissing() throws {
         let fileManager = FileManager.default
         let rootDirectoryURL = fileManager.temporaryDirectory
             .appendingPathComponent("TranscriptExporterMissingScreenshotsTests-\(UUID().uuidString)", isDirectory: true)
         try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
         defer { try? fileManager.removeItem(at: rootDirectoryURL) }
 
+        let presentScreenshotURL = rootDirectoryURL.appendingPathComponent("present-capture.png")
+        try Data("image-data".utf8).write(to: presentScreenshotURL, options: [.atomic])
         let missingScreenshotURL = rootDirectoryURL.appendingPathComponent("missing-capture.png")
+
         let session = TranscriptSession(
             createdAt: Date(timeIntervalSince1970: 1_700_000_100),
             transcript: "Transcript without an on-disk screenshot.",
@@ -71,25 +77,99 @@ final class TranscriptExporterTests: XCTestCase {
             languageHint: nil,
             prompt: nil,
             screenshots: [
-                SessionScreenshot(elapsedTime: 4, filePath: missingScreenshotURL.path)
+                SessionScreenshot(elapsedTime: 4, filePath: presentScreenshotURL.path),
+                SessionScreenshot(elapsedTime: 6, filePath: missingScreenshotURL.path)
             ]
         )
 
         let exporter = TranscriptExporter(fileManager: fileManager)
-        do {
-            _ = try exporter.writeBundle(session: session, to: rootDirectoryURL)
-            XCTFail("Expected bundle export to fail when a referenced screenshot is missing.")
-        } catch let error as AppError {
-            XCTAssertEqual(
-                error,
-                .exportFailure(
-                    "This session bundle is missing referenced screenshot files: missing-capture.png. Recreate the screenshots or remove the stale references before exporting."
-                )
-            )
-        }
+        let bundleURL = try exporter.writeBundle(session: session, to: rootDirectoryURL)
 
-        let createdDirectories = try fileManager.contentsOfDirectory(atPath: rootDirectoryURL.path)
-        XCTAssertFalse(createdDirectories.contains { $0.contains(session.suggestedBundleDirectoryName) })
+        // The transcript still exports, and the screenshot that does exist is copied.
+        XCTAssertTrue(fileManager.fileExists(atPath: bundleURL.appendingPathComponent("transcript.md").path))
+        let screenshotsDirectoryURL = bundleURL.appendingPathComponent("screenshots")
+        XCTAssertTrue(fileManager.fileExists(atPath: screenshotsDirectoryURL.appendingPathComponent("present-capture.png").path))
+        XCTAssertFalse(fileManager.fileExists(atPath: screenshotsDirectoryURL.appendingPathComponent("missing-capture.png").path))
+
+        // The absence is recorded rather than thrown.
+        let manifestData = try Data(contentsOf: bundleURL.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+        XCTAssertEqual(manifest?["missingScreenshots"] as? [String], ["missing-capture.png"])
+        XCTAssertEqual(manifest?["copiedScreenshotCount"] as? Int, 1)
+        XCTAssertEqual(manifest?["screenshotCount"] as? Int, 2)
+    }
+
+    func testWriteBundleIncludesSummaryAndIssues() throws {
+        let fileManager = FileManager.default
+        let rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("TranscriptExporterSummaryTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: rootDirectoryURL) }
+
+        let session = TranscriptSession(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_200),
+            transcript: "The export button is missing on the reports page.",
+            duration: 30,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil,
+            issueExtraction: IssueExtractionResult(
+                summary: "One bug in the reports page.",
+                issues: [
+                    ExtractedIssue(
+                        title: "Export button missing",
+                        category: .bug,
+                        summary: "The reports page is missing an export button.",
+                        evidenceExcerpt: "Export button is missing on reports page.",
+                        timestamp: 13
+                    )
+                ]
+            )
+        )
+
+        let exporter = TranscriptExporter(fileManager: fileManager)
+        let bundleURL = try exporter.writeBundle(session: session, to: rootDirectoryURL)
+
+        let summaryURL = bundleURL.appendingPathComponent("summary.md")
+        XCTAssertTrue(fileManager.fileExists(atPath: summaryURL.path), "The differentiated output must be in the bundle, not just the raw transcript.")
+
+        let summary = try String(contentsOf: summaryURL)
+        XCTAssertTrue(summary.contains("One bug in the reports page."), "Expected the review summary.")
+        XCTAssertTrue(summary.contains("Export button missing"), "Expected the extracted issue.")
+
+        let manifestData = try Data(contentsOf: bundleURL.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+        XCTAssertEqual(manifest?["exportedFiles"] as? [String], ["transcript.md", "summary.md"])
+    }
+
+    func testWriteBundleOmitsSummaryWhenExtractionNeverRan() throws {
+        let fileManager = FileManager.default
+        let rootDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("TranscriptExporterNoSummaryTests-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: rootDirectoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: rootDirectoryURL) }
+
+        let session = TranscriptSession(
+            createdAt: Date(timeIntervalSince1970: 1_700_000_300),
+            transcript: "A session that never had issue extraction run.",
+            duration: 12,
+            model: "whisper-1",
+            languageHint: nil,
+            prompt: nil
+        )
+
+        let exporter = TranscriptExporter(fileManager: fileManager)
+        let bundleURL = try exporter.writeBundle(session: session, to: rootDirectoryURL)
+
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: bundleURL.appendingPathComponent("summary.md").path),
+            "A session with no extraction should get no summary file rather than a placeholder saying extraction never ran."
+        )
+        XCTAssertTrue(fileManager.fileExists(atPath: bundleURL.appendingPathComponent("transcript.md").path))
+
+        let manifestData = try Data(contentsOf: bundleURL.appendingPathComponent("manifest.json"))
+        let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+        XCTAssertEqual(manifest?["exportedFiles"] as? [String], ["transcript.md"])
     }
 
     func testWriteBundleDoesNotOverwriteDuplicateScreenshotFileNames() throws {

--- a/contract/archive/914.json
+++ b/contract/archive/914.json
@@ -1,0 +1,86 @@
+{
+  "schema": "orc.contract-archive.v1",
+  "ticket": "914",
+  "provenance": {
+    "pr": null,
+    "head_sha": null,
+    "done_when_total": 5,
+    "machine_backed": 0,
+    "checks": 0,
+    "satisfied": 0,
+    "class_counts": {
+      "machine_check": 0,
+      "human_evidence": 0,
+      "explicitly_self_attested": 5
+    },
+    "classified_ratio": 0,
+    "clauses": [
+      {
+        "index": 1,
+        "text": "The exported bundle includes the review summary and the extracted issues alongside transcript.md and screenshots/.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 2,
+        "text": "A missing screenshot file degrades gracefully - the bundle still exports and the absence is recorded in the manifest rather than thrown.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 3,
+        "text": "Sessions with no summary or no extracted issues export cleanly without emitting empty placeholder files.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 4,
+        "text": "Existing bundle consumers are unaffected: transcript.md and screenshots/ keep their current names, locations, and format.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      },
+      {
+        "index": 5,
+        "text": "Both behaviors have targeted unit tests, including the missing-screenshot path.",
+        "backed": false,
+        "satisfied": null,
+        "evidence": null,
+        "class": "explicitly_self_attested"
+      }
+    ]
+  },
+  "contract": {
+    "scope": [
+      "Sources/BugNarrator/Services/TranscriptExporter.swift"
+    ],
+    "depends_on": [],
+    "done_when": [
+      "The exported bundle includes the review summary and the extracted issues alongside transcript.md and screenshots/.",
+      "A missing screenshot file degrades gracefully - the bundle still exports and the absence is recorded in the manifest rather than thrown.",
+      "Sessions with no summary or no extracted issues export cleanly without emitting empty placeholder files.",
+      "Existing bundle consumers are unaffected: transcript.md and screenshots/ keep their current names, locations, and format.",
+      "Both behaviors have targeted unit tests, including the missing-screenshot path."
+    ],
+    "validation": {
+      "local": [
+        "./scripts/validate.sh origin/main",
+        "DEVELOPER_DIR=\"${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}\" xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination \"platform=macOS,arch=$(uname -m)\" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- -only-testing:BugNarratorTests test"
+      ]
+    },
+    "references": [
+      "Found by Claude in 3-model gap analysis 2026-08-01."
+    ],
+    "acceptance_criteria": [
+      "The bundle contains the work product, not just the raw inputs.",
+      "One missing file never blocks an export."
+    ]
+  }
+}

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -132,8 +132,10 @@ Structured counterpart: [docs/testing/testing.md](testing/testing.md)
 - Click a screenshot thumbnail in the `Screenshots` tab and verify BugNarrator opens the saved image cleanly.
 - Click `Show in Transcript` from a screenshot entry and verify the review workspace switches back to the transcript timeline.
 - Open a captured screenshot from the review window and verify Finder reveals the file.
-- Export a session bundle and verify `transcript.md` and the `screenshots` folder are present.
+- Export a session bundle and verify `transcript.md`, `summary.md`, the `screenshots` folder, and `manifest.json` are present.
 - Verify the exported `transcript.md` contains the session transcript and the exported `screenshots` folder copies only screenshots that still exist on disk.
+- Verify `summary.md` contains the review summary and the extracted issues, and that a session with no issue extraction exports without a `summary.md` at all.
+- Delete a referenced screenshot file before exporting and verify the bundle still exports, with the missing file named in `manifest.json` under `missingScreenshots`.
 - Export a debug bundle during or after a session and verify `session-metadata.json` reflects the right session ID and counts without raw transcript content.
 
 ## Session Deletion

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -28,7 +28,7 @@ Use this checklist before cutting a public test build or release candidate.
 - Stop the session and confirm transcription succeeds with the selected provider.
 - For chat-capable providers, confirm the transcript, review summary, screenshots, and extracted issues appear in the session library.
 - For `Local (Parakeet)`, confirm the transcript and screenshots appear in the session library and automatic issue extraction stays disabled until a chat-capable provider is selected.
-- Export a session bundle and verify `transcript.md` plus the `screenshots` folder are created.
+- Export a session bundle and verify `transcript.md`, `summary.md`, the `screenshots` folder, and `manifest.json` are created.
 
 ## Export Integrations
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -192,7 +192,9 @@ Each extracted item keeps evidence from the transcript and should be reviewed be
 Use this when you want a portable local copy of the session. The bundle includes:
 
 - `transcript.md`
+- `summary.md` — the review summary and extracted issues, when issue extraction has run
 - `screenshots/`
+- `manifest.json` — what the bundle contains, including any referenced screenshot files that were no longer on disk at export time
 
 ### Export To GitHub (Experimental)
 

--- a/docs/user/user-manual.md
+++ b/docs/user/user-manual.md
@@ -72,7 +72,8 @@ After transcription finishes, BugNarrator opens the session library so you can r
 Current export options:
 
 - `Export Session Bundle`
-  creates `transcript.md` plus a `screenshots/` folder
+  creates `transcript.md`, a `screenshots/` folder, and `manifest.json`, plus
+  `summary.md` (review summary and extracted issues) when issue extraction has run
 - `Export to GitHub (Experimental)`
 - `Export to Jira (Experimental)`
 


### PR DESCRIPTION
## Linked issue

Closes #914

<!-- orc-review-pack:v1 -->
<details><summary>ORC review pack</summary>

Routing: n/a

Validation:
| phase | status |
| --- | --- |
| node "/Users/deffenda/Code/orc/tools/orc/syntax-triage.mjs" --ticket "914" | recorded |
| ./scripts/validate.sh origin/main | recorded |
| DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}" xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination "platform=macOS,arch=$(uname -m)" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- -only-testing:BugNarratorTests test | recorded |

Blast radius:
- contract/archive/914.json (fan-in 0, impact 0)
- docs/QA_CHECKLIST.md (fan-in 0, impact 0)
- docs/RELEASE_CHECKLIST.md (fan-in 0, impact 0)
- docs/user/user-manual.md (fan-in 0, impact 0)
- docs/UserGuide.md (fan-in 0, impact 0)
- Sources/BugNarrator/Services/TranscriptExporter.swift (fan-in 0, impact 0)
- Tests/BugNarratorTests/TranscriptExporterTests.swift (fan-in 0, impact 0)

Cost: tokens in/out/total n/a/n/a/n/a, cost_usd n/a, est_cost n/a
Heal: n/a

Comprehension artifacts (tier Scoped):
- none required for this tier
- standard: docs/human-review-standards.md

Spec conformance: 0 of 5 done_when clauses machine-verified (file:line evidence); 5 EXPLICITLY SELF-ATTESTED.
- [ ] 1. The exported bundle includes the review summary and the extracted issues alongside transcript.md and screenshots/. — EXPLICITLY SELF-ATTESTED (no check, no evidence)
- [ ] 2. A missing screenshot file degrades gracefully - the bundle still exports and the absence is recorded in the manifest rather than thrown. — EXPLICITLY SELF-ATTESTED (no check, no evidence)
- [ ] 3. Sessions with no summary or no extracted issues export cleanly without emitting empty placeholder files. — EXPLICITLY SELF-ATTESTED (no check, no evidence)
- [ ] 4. Existing bundle consumers are unaffected: transcript.md and screenshots/ keep their current names, locations, and format. — EXPLICITLY SELF-ATTESTED (no check, no evidence)
- [ ] 5. Both behaviors have targeted unit tests, including the missing-screenshot path. — EXPLICITLY SELF-ATTESTED (no check, no evidence)

```json
{
  "schema": "orc.review-pack.v1",
  "ticket": "914",
  "generated_at": "2026-08-02T19:18:04.239Z",
  "routing": null,
  "validation": {
    "commands": [
      "node \"/Users/deffenda/Code/orc/tools/orc/syntax-triage.mjs\" --ticket \"914\"",
      "./scripts/validate.sh origin/main",
      "DEVELOPER_DIR=\"${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}\" xcodebuild -quiet -project BugNarrator.xcodeproj -scheme BugNarrator -configuration Debug -destination \"platform=macOS,arch=$(uname -m)\" CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=- -only-testing:BugNarratorTests test"
    ],
    "evidence": [],
    "durations": null
  },
  "blast_radius": {
    "threshold": 5,
    "files": [
      {
        "path": "contract/archive/914.json",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "docs/QA_CHECKLIST.md",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "docs/RELEASE_CHECKLIST.md",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "docs/user/user-manual.md",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "docs/UserGuide.md",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "Sources/BugNarrator/Services/TranscriptExporter.swift",
        "fan_in": 0,
        "transitive_impact": 0
      },
      {
        "path": "Tests/BugNarratorTests/TranscriptExporterTests.swift",
        "fan_in": 0,
        "transitive_impact": 0
      }
    ],
    "capped_at": 10,
    "total_changed": 7,
    "scope": "mjs-intra-repo"
  },
  "cost": {
    "tokens": {
      "input": null,
      "output": null,
      "total": null
    },
    "cost_usd": null,
    "est_cost": null
  },
  "heal": [],
  "coverage": {
    "done_when_total": 5,
    "machine_backed": 0,
    "checks": 0,
    "satisfied": 0,
    "clauses": [
      {
        "index": 1,
        "text": "The exported bundle includes the review summary and the extracted issues alongside transcript.md and screenshots/.",
        "backed": false,
        "satisfied": null,
        "evidence": null,
        "class": "explicitly_self_attested"
      },
      {
        "index": 2,
        "text": "A missing screenshot file degrades gracefully - the bundle still exports and the absence is recorded in the manifest rather than thrown.",
        "backed": false,
        "satisfied": null,
        "evidence": null,
        "class": "explicitly_self_attested"
      },
      {
        "index": 3,
        "text": "Sessions with no summary or no extracted issues export cleanly without emitting empty placeholder files.",
        "backed": false,
        "satisfied": null,
        "evidence": null,
        "class": "explicitly_self_attested"
      },
      {
        "index": 4,
        "text": "Existing bundle consumers are unaffected: transcript.md and screenshots/ keep their current names, locations, and format.",
        "backed": false,
        "satisfied": null,
        "evidence": null,
        "class": "explicitly_self_attested"
      },
      {
        "index": 5,
        "text": "Both behaviors have targeted unit tests, including the missing-screenshot path.",
        "backed": false,
        "satisfied": null,
        "evidence": null,
        "class": "explicitly_self_attested"
      }
    ],
    "class_counts": {
      "machine_check": 0,
      "human_evidence": 0,
      "explicitly_self_attested": 5
    },
    "classified": 0,
    "classified_ratio": 0
  },
  "comprehension": {
    "tier": "Scoped",
    "required": [],
    "missing": [],
    "notes": [],
    "ok": true,
    "source": "docs/human-review-standards.md"
  }
}
```

</details>